### PR TITLE
Fix: Support variable getter/setter node creation via payload in MCP …

### DIFF
--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPBlueprintNodeCommands.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPBlueprintNodeCommands.cpp
@@ -1665,6 +1665,19 @@ TSharedPtr<FJsonObject> FUnrealMCPBlueprintNodeCommands::HandleFindBlueprintNode
             }
         }
     }
+    else if (NodeType.Equals(TEXT("BreakStruct"), ESearchCase::IgnoreCase) || NodeType.Equals(TEXT("UK2Node_BreakStruct"), ESearchCase::IgnoreCase))
+    {
+        // Explicitly find all Break Struct nodes
+        for (UEdGraphNode* Node : EventGraph->Nodes)
+        {
+            UK2Node_BreakStruct* BreakStructNode = Cast<UK2Node_BreakStruct>(Node);
+            if (BreakStructNode)
+            {
+                UE_LOG(LogTemp, Display, TEXT("Found BreakStruct node: %s"), *BreakStructNode->NodeGuid.ToString());
+                NodesArray.Add(MakeShared<FJsonValueObject>(CreateNodeInfo(BreakStructNode)));
+            }
+        }
+    }
     else
     {
         UE_LOG(LogTemp, Warning, TEXT("Unsupported node type: %s"), *NodeType);

--- a/Python/utils/blueprint_actions/blueprint_action_operations.py
+++ b/Python/utils/blueprint_actions/blueprint_action_operations.py
@@ -96,6 +96,11 @@ def create_node_by_action_name(
     **kwargs
 ) -> Dict[str, Any]:
     """Implementation for creating a blueprint node by discovered action/function name."""
+    # --- PATCH START ---
+    if function_name in ("Get", "Set") and "variable_name" in kwargs:
+        function_name = f"{function_name} {kwargs['variable_name']}"
+        kwargs.pop("variable_name")
+    # --- PATCH END ---
     params = {
         "blueprint_name": blueprint_name,
         "function_name": function_name


### PR DESCRIPTION
…(Get/Set with variable_name)

- Moves function name rewrite logic to before node type handling
- Ensures both string and payload styles work for variable getter/setter nodes
- Adds diagnostic logging for easier debugging