### PR TITLE
Add cleanup_blueprint_graph tool and duplicate_asset command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,6 +157,70 @@ When implementing complex functionality (inventory systems, dialogue systems, ga
 
 **Rationale:** MCP-created Blueprint logic is difficult to debug after the fact. Each step builds on previous steps. One incorrect node connection early on cascades into complex debugging later. Verify early, verify often.
 
+### Test-First Phase Planning (CRITICAL)
+
+**⚠️ Phases MUST be structured for earliest possible testing, NOT by architectural layer.**
+
+**The Problem:**
+Traditional layered approach (Data → Blueprint Logic → Widgets) delays testing until ALL layers are complete. When bugs appear, you have a massive interconnected system to debug with no working baseline.
+
+**The Solution: UI-First, Data-Second, Logic-Last**
+
+```
+WRONG ORDER (delays testing):          RIGHT ORDER (early testing):
+1. Create data structures               1. Create widget visuals (hardcoded data)
+2. Create Blueprint logic               2. Test widget layout/interactions manually
+3. Create widgets                       3. Create data structures
+4. NOW you can finally test             4. Connect data to widgets, test with real data
+   → Debugging nightmare                5. Create Blueprint logic incrementally
+                                        6. Test each function as it's added
+                                           → Bugs caught immediately
+```
+
+**Phase Planning Rules:**
+
+1. **Widgets First**: Create UI widgets with hardcoded/mock data
+   - User can visually verify layout, colors, sizing
+   - Test click handlers, hover states, animations
+   - No dependencies on data layer yet
+
+2. **Data Layer Second**: Create structs, DataTables, managers
+   - Connect to existing widgets
+   - Test that real data displays correctly
+   - Widget bugs are already fixed at this point
+
+3. **Blueprint Logic Last (or in parallel)**: Complex game logic
+   - Each function tested immediately after creation
+   - Widget + data layer already verified working
+   - Logic bugs are isolated, not cascading
+
+4. **Parallel Work When Possible**:
+   - Widget visual work can happen alongside data structure creation
+   - Simple BP functions (getters, setters) can be added early
+   - Complex logic waits until UI is verified
+
+**Example - Inventory System (Correct Order):**
+```
+Phase 1: Widget Skeleton
+- Create WBP_InventorySlot with hardcoded icon
+- Create WBP_InventoryGrid with hardcoded slots
+- USER TEST: "Does the grid look right? Can I click slots?"
+
+Phase 2: Data + Widget Connection
+- Create S_InventorySlot struct
+- Create DT_Items DataTable
+- Connect DataTable to widgets
+- USER TEST: "Do real items show with correct icons?"
+
+Phase 3: Manager Logic
+- Create BP_InventoryManager
+- Implement AddItem function → TEST
+- Implement RemoveItem function → TEST
+- Each function tested in isolation
+```
+
+**Key Principle:** After each phase, the user should be able to launch Unreal, interact with something, and verify it works. If a phase doesn't end with a testable deliverable, the phase is too large - split it.
+
 ### Adding New Functionality
 
 1. **Plan cross-component**: Design Python API signature and C++ implementation together

--- a/Docs/loot-plan/00_Overview.md
+++ b/Docs/loot-plan/00_Overview.md
@@ -1,0 +1,183 @@
+# Looting System - Overview
+
+> **STATUS: 📋 PLANNED**
+
+> **REMINDER**: ALL functionality in this looting system MUST be implemented using MCP tools.
+> NO manual Unreal Editor work is permitted. This serves as a comprehensive test of AI-driven Blueprint development.
+
+## ⚠️ TEST-FIRST PHASE STRUCTURE
+
+This plan follows the **UI-First, Data-Second, Logic-Last** methodology (see CLAUDE.md).
+
+**Each phase ends with a USER TEST checkpoint** - something the user can launch Unreal and verify works before proceeding.
+
+---
+
+## Implementation Status
+
+| Phase | Status | Testable Deliverable |
+|-------|--------|---------------------|
+| Phase 1: Loot Window Skeleton | 📋 PLANNED | Visual loot window with hardcoded slots |
+| Phase 2: Drag Widget | 📋 PLANNED | Drag widget follows cursor |
+| Phase 3: Inventory Drag Support | 📋 PLANNED | Drag from inventory shows overlay |
+| Phase 4: Lootable Actor + Data | 📋 PLANNED | Loot window shows real items from chest |
+| Phase 5: E-Key Integration | 📋 PLANNED | E key opens loot or dialogue contextually |
+
+---
+
+## User Requirements
+
+- **E key interaction** - Same key as dialogue, context-aware (NPC = dialogue, Loot = loot window)
+- **Side-by-side layout** - Inventory on right, loot on left
+- **Auto-find slot on drop** - Drop anywhere on container, item goes to first available slot
+- **Grey overlay** - Dragged slot shows grey overlay (overlay on top, not modify original)
+- **Full stack transfer** - For now, transfer entire stack on drag-drop
+- **Class inheritance** - Base classes for shared slot/container functionality
+
+---
+
+## Architecture
+
+```
+INTERFACE
+BPI_Interactable - Shared by NPCs and lootables
+├── CanInteract(Interactor) → bool
+├── GetInteractionPrompt() → String
+└── OnInteract(Interactor) → void
+
+BASE WIDGET CLASSES (created in Phase 1)
+WBP_ItemSlotBase (common slot)
+├── SlotBackground, ItemIcon, StackCountText, DragOverlay
+├── SetSlotData(), SetDragOverlay(), GetSlotData()
+└── OnSlotClicked (virtual), OnSlotDragStart (virtual)
+
+WBP_ItemContainerBase (common container)
+├── ContainerBackground, TitleText, SlotsContainer
+├── InitializeContainer(), RefreshAllSlots()
+└── HandleItemDrop(), FindEmptySlot()
+
+LOOT (new)
+WBP_LootSlot extends WBP_ItemSlotBase
+WBP_LootWindow extends WBP_ItemContainerBase
+BP_LootableBase (Actor, implements BPI_Interactable)
+
+INVENTORY (modified)
+WBP_InventorySlot - Add drag support
+WBP_InventoryGrid - Add drop handling
+
+DRAG SYSTEM
+WBP_DraggedItem (follows cursor, shows item being dragged)
+```
+
+---
+
+## Development Phases (TEST-FIRST ORDER)
+
+### Phase 1: Loot Window Skeleton
+**Goal:** User sees a loot window with hardcoded items, can visually verify layout.
+
+- Create base widget classes (WBP_ItemSlotBase, WBP_ItemContainerBase)
+- Create WBP_LootSlot with hardcoded item display
+- Create WBP_LootWindow with grid of slots, close button
+- **USER TEST:** Add loot window to viewport, verify it looks correct, close button works
+
+### Phase 2: Drag Widget
+**Goal:** User can see a widget follow their cursor.
+
+- Create WBP_DraggedItem widget
+- Test by spawning and having it follow mouse
+- **USER TEST:** Drag widget follows cursor smoothly
+
+### Phase 3: Inventory Drag Support
+**Goal:** User can drag from existing inventory, see grey overlay.
+
+- Add DragOverlay to WBP_InventorySlot
+- Add StartDrag/CancelDrag to WBP_InventoryGrid
+- Connect left-click to start drag
+- **USER TEST:** Click inventory slot → grey overlay appears, drag widget follows cursor
+
+### Phase 4: Lootable Actor + Data Connection
+**Goal:** Real loot containers with actual item data.
+
+- Create BPI_Interactable interface
+- Create BP_LootableBase actor with LootSlots array
+- Connect loot window to lootable data
+- Implement item transfer (loot → inventory)
+- **USER TEST:** Place chest in level, open loot window, drag item to inventory
+
+### Phase 5: E-Key Integration
+**Goal:** Complete flow - E key works for both NPCs and loot.
+
+- Modify BP_ThirdPersonCharacter E-key handler
+- Add BPI_Interactable to BP_DialogueNPC
+- Add OpenLootWindow/CloseLootWindow to player
+- Side-by-side positioning
+- **USER TEST:** E near NPC = dialogue, E near chest = loot window
+
+---
+
+## Phase Documents
+
+| Phase | Document | Focus |
+|-------|----------|-------|
+| 1 | [Phase1_LootWindowSkeleton.md](Phase1_LootWindowSkeleton.md) | Visual widgets with hardcoded data |
+| 2 | [Phase2_DragWidget.md](Phase2_DragWidget.md) | Cursor-following drag visual |
+| 3 | [Phase3_InventoryDragSupport.md](Phase3_InventoryDragSupport.md) | Drag overlay, start/cancel drag |
+| 4 | [Phase4_LootableActorAndData.md](Phase4_LootableActorAndData.md) | Actor, interface, real data |
+| 5 | [Phase5_EKeyIntegration.md](Phase5_EKeyIntegration.md) | E-key handler, final integration |
+
+---
+
+## Asset Structure
+
+```
+/Game/Blueprints/
+└── Interfaces/
+    └── BPI_Interactable.uasset         (Blueprint Interface)
+
+/Game/Inventory/
+├── Data/                               (existing - shared with loot)
+│   ├── E_ItemType.uasset
+│   ├── S_ItemDefinition.uasset
+│   ├── S_InventorySlot.uasset
+│   └── DT_Items.uasset
+├── Blueprints/
+│   └── BP_InventoryManager.uasset      (existing)
+└── UI/
+    ├── Base/                           (NEW)
+    │   ├── WBP_ItemSlotBase.uasset
+    │   └── WBP_ItemContainerBase.uasset
+    ├── WBP_InventoryGrid.uasset        (modified for drag)
+    ├── WBP_InventorySlot.uasset        (modified for drag)
+    ├── WBP_ItemContextMenu.uasset      (existing)
+    ├── WBP_ItemTooltip.uasset          (existing)
+    └── WBP_DraggedItem.uasset          (NEW)
+
+/Game/Loot/                             (NEW)
+├── Blueprints/
+│   └── BP_LootableBase.uasset          (Actor, implements BPI_Interactable)
+└── UI/
+    ├── WBP_LootSlot.uasset             (extends WBP_ItemSlotBase)
+    └── WBP_LootWindow.uasset           (extends WBP_ItemContainerBase)
+```
+
+---
+
+## Success Criteria
+
+- [ ] E key opens dialogue for NPCs, loot window for lootables
+- [ ] Inventory and loot windows appear side-by-side
+- [ ] Left-click and drag from loot slot shows grey overlay
+- [ ] Dragged item visual follows cursor
+- [ ] Drop on inventory transfers full stack
+- [ ] Source slot clears, target slot shows item
+- [ ] Both containers refresh after transfer
+- [ ] Close button on loot window works
+- [ ] Empty loot containers can optionally auto-close
+
+---
+
+## Related Systems
+
+- [Inventory System](../inventory-plan/00_Overview.md) - Core inventory functionality
+- Dialogue System - Shares E-key interaction via BPI_Interactable

--- a/Docs/loot-plan/Phase1_LootWindowSkeleton.md
+++ b/Docs/loot-plan/Phase1_LootWindowSkeleton.md
@@ -1,0 +1,483 @@
+# Phase 1: Loot Window Skeleton
+
+> **STATUS: 📋 PLANNED**
+
+> **REMINDER**: ALL functionality MUST be implemented using MCP tools.
+> NO manual Unreal Editor work is permitted.
+
+## Objective
+
+Create visual loot widgets with **hardcoded test data** so user can verify layout before connecting real data.
+
+**USER TEST at end of phase:** Add loot window to viewport via BeginPlay, verify:
+- Window appears with correct styling
+- Slots display hardcoded item icons
+- Close button exists (click handler in Phase 4)
+
+## Dependencies
+
+- Existing S_InventorySlot struct (reuse for loot slots)
+- Existing S_ItemDefinition struct (reuse for item data)
+
+---
+
+## Step 1.1: Create Base Folder
+
+### MCP TOOL CALLS
+
+```python
+create_folder(folder_path="Content/Inventory/UI/Base")
+create_folder(folder_path="Content/Loot")
+create_folder(folder_path="Content/Loot/UI")
+create_folder(folder_path="Content/Loot/Blueprints")
+```
+
+### VERIFICATION
+- [ ] Folders created in Content Browser
+- [ ] No errors
+
+---
+
+## Step 1.2: Create WBP_ItemSlotBase
+
+### AIM
+Base widget class for item slots. Both inventory and loot slots will extend this.
+
+### COMPONENTS
+
+| Component | Type | Size | Properties |
+|-----------|------|------|------------|
+| CanvasPanel | Canvas Panel | - | Root |
+| SlotBackground | Border | 64x64 | Dark grey (0.1, 0.1, 0.1, 1.0) |
+| ItemIcon | Image | 56x56 | Centered, displays item texture |
+| StackCountText | TextBlock | - | Bottom-right, font size 12 |
+| DragOverlay | Border | 64x64 | Grey (0.3, 0.3, 0.3, 0.6), **Hidden by default** |
+
+### VARIABLES
+
+| Variable | Type | Default | Purpose |
+|----------|------|---------|---------|
+| SlotIndex | Integer | 0 | Position in container |
+| CachedSlotData | S_InventorySlot | - | Cached slot data |
+| ParentContainer | UserWidget | None | Reference to parent |
+| IsDragSource | Boolean | false | True when being dragged |
+
+### FUNCTIONS
+
+| Function | Inputs | Outputs | Purpose |
+|----------|--------|---------|---------|
+| SetSlotData | SlotData, ItemDef | - | Update display |
+| SetDragOverlay | bVisible | - | Show/hide overlay |
+| GetSlotData | - | SlotData | Return cached data |
+
+### MCP TOOL CALLS
+
+```python
+# Create widget
+create_umg_widget_blueprint(
+    widget_name="WBP_ItemSlotBase",
+    parent_class="UserWidget",
+    path="/Game/Inventory/UI/Base"
+)
+
+# Add SlotBackground
+add_widget_component_to_widget(
+    widget_name="WBP_ItemSlotBase",
+    component_name="SlotBackground",
+    component_type="Border",
+    position=[0, 0],
+    size=[64, 64],
+    kwargs={"background_color": [0.1, 0.1, 0.1, 1.0]}
+)
+
+# Add ItemIcon (inside SlotBackground, or on top)
+add_widget_component_to_widget(
+    widget_name="WBP_ItemSlotBase",
+    component_name="ItemIcon",
+    component_type="Image",
+    position=[4, 4],
+    size=[56, 56],
+    kwargs={}
+)
+
+# Add StackCountText
+add_widget_component_to_widget(
+    widget_name="WBP_ItemSlotBase",
+    component_name="StackCountText",
+    component_type="TextBlock",
+    position=[40, 46],
+    size=[20, 16],
+    kwargs={"text": "", "font_size": 12}
+)
+
+# Add DragOverlay (initially Hidden)
+add_widget_component_to_widget(
+    widget_name="WBP_ItemSlotBase",
+    component_name="DragOverlay",
+    component_type="Border",
+    position=[0, 0],
+    size=[64, 64],
+    kwargs={"background_color": [0.3, 0.3, 0.3, 0.6]}
+)
+
+set_widget_component_property(
+    widget_name="WBP_ItemSlotBase",
+    component_name="DragOverlay",
+    kwargs={"Visibility": "Hidden"}
+)
+
+# Add variables
+add_blueprint_variable(
+    blueprint_name="WBP_ItemSlotBase",
+    variable_name="SlotIndex",
+    variable_type="Integer",
+    is_exposed=False
+)
+
+add_blueprint_variable(
+    blueprint_name="WBP_ItemSlotBase",
+    variable_name="CachedSlotData",
+    variable_type="/Game/Inventory/Data/S_InventorySlot",
+    is_exposed=False
+)
+
+add_blueprint_variable(
+    blueprint_name="WBP_ItemSlotBase",
+    variable_name="ParentContainer",
+    variable_type="UserWidget",
+    is_exposed=False
+)
+
+add_blueprint_variable(
+    blueprint_name="WBP_ItemSlotBase",
+    variable_name="IsDragSource",
+    variable_type="Boolean",
+    is_exposed=False
+)
+
+# Create functions
+create_custom_blueprint_function(
+    blueprint_name="WBP_ItemSlotBase",
+    function_name="SetSlotData",
+    inputs=[
+        {"name": "SlotData", "type": "S_InventorySlot"},
+        {"name": "ItemDef", "type": "S_ItemDefinition"}
+    ],
+    outputs=[],
+    is_pure=False,
+    category="Slot"
+)
+
+create_custom_blueprint_function(
+    blueprint_name="WBP_ItemSlotBase",
+    function_name="SetDragOverlay",
+    inputs=[{"name": "bVisible", "type": "Boolean"}],
+    outputs=[],
+    is_pure=False,
+    category="Slot"
+)
+
+create_custom_blueprint_function(
+    blueprint_name="WBP_ItemSlotBase",
+    function_name="GetSlotData",
+    inputs=[],
+    outputs=[{"name": "SlotData", "type": "S_InventorySlot"}],
+    is_pure=True,
+    category="Slot"
+)
+
+compile_blueprint(blueprint_name="WBP_ItemSlotBase")
+```
+
+### FUNCTION IMPLEMENTATIONS
+
+#### SetSlotData
+```
+1. Set CachedSlotData = SlotData
+2. If SlotData.ItemRowName is not empty:
+   - Set ItemIcon texture = ItemDef.Icon
+   - If SlotData.StackCount > 1:
+     - Set StackCountText = StackCount (as string)
+     - Set StackCountText visibility = Visible
+   - Else:
+     - Set StackCountText visibility = Hidden
+   - Set ItemIcon visibility = Visible
+3. Else (empty slot):
+   - Set ItemIcon visibility = Hidden
+   - Set StackCountText visibility = Hidden
+```
+
+#### SetDragOverlay
+```
+1. If bVisible:
+   - Set DragOverlay visibility = Visible
+2. Else:
+   - Set DragOverlay visibility = Hidden
+3. Set IsDragSource = bVisible
+```
+
+#### GetSlotData
+```
+1. Return CachedSlotData
+```
+
+### VERIFICATION
+- [ ] WBP_ItemSlotBase created at /Game/Inventory/UI/Base/
+- [ ] All 5 components added
+- [ ] DragOverlay initially Hidden
+- [ ] 4 variables added
+- [ ] 3 functions created
+- [ ] Blueprint compiles
+
+---
+
+## Step 1.3: Create WBP_LootSlot
+
+### AIM
+Loot-specific slot widget extending base. For now, simple implementation.
+
+### MCP TOOL CALLS
+
+```python
+create_umg_widget_blueprint(
+    widget_name="WBP_LootSlot",
+    parent_class="WBP_ItemSlotBase",  # Extend base
+    path="/Game/Loot/UI"
+)
+
+# Add LootableRef variable
+add_blueprint_variable(
+    blueprint_name="WBP_LootSlot",
+    variable_name="LootableRef",
+    variable_type="Actor",  # Will be BP_LootableBase later
+    is_exposed=False
+)
+
+compile_blueprint(blueprint_name="WBP_LootSlot")
+```
+
+### VERIFICATION
+- [ ] WBP_LootSlot created at /Game/Loot/UI/
+- [ ] Inherits from WBP_ItemSlotBase
+- [ ] LootableRef variable added
+- [ ] Blueprint compiles
+
+---
+
+## Step 1.4: Create WBP_LootWindow
+
+### AIM
+Container for loot slots with title and close button.
+
+### COMPONENTS
+
+| Component | Type | Size | Properties |
+|-----------|------|------|------------|
+| CanvasPanel | Canvas Panel | - | Root |
+| WindowBackground | Border | 300x350 | Dark (0.05, 0.05, 0.05, 0.95) |
+| HeaderBackground | Border | 280x35 | Slightly lighter (0.1, 0.1, 0.15, 1.0) |
+| TitleText | TextBlock | - | "Loot", font size 16 |
+| CloseButton | Button | 24x24 | Top-right corner |
+| CloseButtonText | TextBlock | - | "X" |
+| SlotsGrid | UniformGridPanel | 280x280 | 4 columns |
+
+### VARIABLES
+
+| Variable | Type | Default | Purpose |
+|----------|------|---------|---------|
+| SlotWidgets | WBP_LootSlot[] | [] | Array of slot widgets |
+| LootableRef | Actor | None | Reference to lootable |
+| InventoryGridRef | UserWidget | None | Reference to inventory |
+| GridColumns | Integer | 4 | Slots per row |
+| MaxSlots | Integer | 8 | Maximum loot slots |
+
+### MCP TOOL CALLS
+
+```python
+create_umg_widget_blueprint(
+    widget_name="WBP_LootWindow",
+    parent_class="UserWidget",
+    path="/Game/Loot/UI"
+)
+
+# Add WindowBackground
+add_widget_component_to_widget(
+    widget_name="WBP_LootWindow",
+    component_name="WindowBackground",
+    component_type="Border",
+    position=[0, 0],
+    size=[300, 350],
+    kwargs={"background_color": [0.05, 0.05, 0.05, 0.95]}
+)
+
+# Add HeaderBackground
+add_widget_component_to_widget(
+    widget_name="WBP_LootWindow",
+    component_name="HeaderBackground",
+    component_type="Border",
+    position=[10, 10],
+    size=[280, 35],
+    kwargs={"background_color": [0.1, 0.1, 0.15, 1.0]}
+)
+
+# Add TitleText
+add_widget_component_to_widget(
+    widget_name="WBP_LootWindow",
+    component_name="TitleText",
+    component_type="TextBlock",
+    position=[20, 15],
+    size=[200, 25],
+    kwargs={"text": "Loot", "font_size": 16}
+)
+
+# Add CloseButton
+add_widget_component_to_widget(
+    widget_name="WBP_LootWindow",
+    component_name="CloseButton",
+    component_type="Button",
+    position=[262, 15],
+    size=[24, 24],
+    kwargs={"text": "X"}
+)
+
+# Add SlotsGrid
+add_widget_component_to_widget(
+    widget_name="WBP_LootWindow",
+    component_name="SlotsGrid",
+    component_type="UniformGridPanel",
+    position=[10, 55],
+    size=[280, 280],
+    kwargs={}
+)
+
+# Add variables
+add_blueprint_variable(
+    blueprint_name="WBP_LootWindow",
+    variable_name="SlotWidgets",
+    variable_type="WBP_LootSlot[]",
+    is_exposed=False
+)
+
+add_blueprint_variable(
+    blueprint_name="WBP_LootWindow",
+    variable_name="LootableRef",
+    variable_type="Actor",
+    is_exposed=False
+)
+
+add_blueprint_variable(
+    blueprint_name="WBP_LootWindow",
+    variable_name="InventoryGridRef",
+    variable_type="UserWidget",
+    is_exposed=False
+)
+
+add_blueprint_variable(
+    blueprint_name="WBP_LootWindow",
+    variable_name="GridColumns",
+    variable_type="Integer",
+    is_exposed=False
+)
+
+set_blueprint_variable_value(
+    blueprint_name="WBP_LootWindow",
+    variable_name="GridColumns",
+    value=4
+)
+
+add_blueprint_variable(
+    blueprint_name="WBP_LootWindow",
+    variable_name="MaxSlots",
+    variable_type="Integer",
+    is_exposed=False
+)
+
+set_blueprint_variable_value(
+    blueprint_name="WBP_LootWindow",
+    variable_name="MaxSlots",
+    value=8
+)
+
+# Create functions (implementations in Phase 4)
+create_custom_blueprint_function(
+    blueprint_name="WBP_LootWindow",
+    function_name="InitializeSlots",
+    inputs=[],
+    outputs=[],
+    is_pure=False,
+    category="Loot"
+)
+
+create_custom_blueprint_function(
+    blueprint_name="WBP_LootWindow",
+    function_name="RefreshAllSlots",
+    inputs=[],
+    outputs=[],
+    is_pure=False,
+    category="Loot"
+)
+
+compile_blueprint(blueprint_name="WBP_LootWindow")
+```
+
+### VERIFICATION
+- [ ] WBP_LootWindow created at /Game/Loot/UI/
+- [ ] All components visible
+- [ ] Variables added with defaults
+- [ ] Blueprint compiles
+
+---
+
+## Step 1.5: Test Widget Display
+
+### AIM
+Temporarily add loot window to viewport to verify visual appearance.
+
+### APPROACH
+Add to player's BeginPlay temporarily (or create test Blueprint).
+
+```python
+# Get existing BP_ThirdPersonCharacter
+# In BeginPlay, add nodes to:
+# 1. Create WBP_LootWindow widget
+# 2. Add to viewport
+# This is TEMPORARY for visual testing only
+```
+
+Alternatively, open widget in UMG Editor and use preview.
+
+### USER TEST
+1. Launch Unreal Editor
+2. Open WBP_LootWindow in UMG Designer
+3. Verify:
+   - [ ] Window background appears (dark)
+   - [ ] Header bar visible
+   - [ ] "Loot" title text shows
+   - [ ] Close button (X) in top-right
+   - [ ] Grid area visible
+
+---
+
+## Phase 1 Completion Checklist
+
+### Assets Created
+- [ ] WBP_ItemSlotBase with components and functions
+- [ ] WBP_LootSlot extending base
+- [ ] WBP_LootWindow with all components
+
+### Visual Verification (USER TEST)
+- [ ] Loot window displays correctly in designer
+- [ ] Slot base displays with dark background
+- [ ] DragOverlay is hidden by default
+- [ ] All widgets compile without errors
+
+### Ready for Phase 2
+- [ ] All widgets compile
+- [ ] User has verified visual appearance
+- [ ] Proceed to Phase 2: Drag Widget
+
+---
+
+## Next Phase
+
+Continue to [Phase2_DragWidget.md](Phase2_DragWidget.md) to create the cursor-following drag visual.

--- a/Docs/loot-plan/Phase2_DragWidget.md
+++ b/Docs/loot-plan/Phase2_DragWidget.md
@@ -1,0 +1,288 @@
+# Phase 2: Drag Widget
+
+> **STATUS: 📋 PLANNED**
+
+> **REMINDER**: ALL functionality MUST be implemented using MCP tools.
+> NO manual Unreal Editor work is permitted.
+
+## Objective
+
+Create WBP_DraggedItem widget that follows the mouse cursor.
+
+**USER TEST at end of phase:** Spawn drag widget and verify it follows cursor smoothly.
+
+## Dependencies
+
+- Phase 1 completed (base widgets exist)
+
+---
+
+## Step 2.1: Create WBP_DraggedItem Widget
+
+### AIM
+Widget that displays dragged item and follows cursor.
+
+### COMPONENTS
+
+| Component | Type | Size | Properties |
+|-----------|------|------|------------|
+| CanvasPanel | Canvas Panel | 64x64 | Root, slight transparency |
+| ItemIcon | Image | 56x56 | Centered item texture |
+| StackCountText | TextBlock | - | Bottom-right stack count, font size 12 |
+
+### VARIABLES
+
+| Variable | Type | Purpose |
+|----------|------|---------|
+| DraggedSlotData | S_InventorySlot | Data being dragged |
+| SourceContainer | UserWidget | Container item came from |
+| SourceSlotIndex | Integer | Original slot index |
+| ItemDefRef | S_ItemDefinition | Cached item definition |
+
+### FUNCTIONS
+
+| Function | Inputs | Outputs | Purpose |
+|----------|--------|---------|---------|
+| SetDragData | SlotData, Container, SlotIndex, ItemDef | - | Initialize with data |
+| UpdatePosition | - | - | Move to mouse position |
+
+### MCP TOOL CALLS
+
+```python
+create_umg_widget_blueprint(
+    widget_name="WBP_DraggedItem",
+    parent_class="UserWidget",
+    path="/Game/Inventory/UI"
+)
+
+# Add ItemIcon
+add_widget_component_to_widget(
+    widget_name="WBP_DraggedItem",
+    component_name="ItemIcon",
+    component_type="Image",
+    position=[4, 4],
+    size=[56, 56],
+    kwargs={}
+)
+
+# Add StackCountText
+add_widget_component_to_widget(
+    widget_name="WBP_DraggedItem",
+    component_name="StackCountText",
+    component_type="TextBlock",
+    position=[40, 46],
+    size=[20, 16],
+    kwargs={"text": "", "font_size": 12}
+)
+
+# Add variables
+add_blueprint_variable(
+    blueprint_name="WBP_DraggedItem",
+    variable_name="DraggedSlotData",
+    variable_type="/Game/Inventory/Data/S_InventorySlot",
+    is_exposed=False
+)
+
+add_blueprint_variable(
+    blueprint_name="WBP_DraggedItem",
+    variable_name="SourceContainer",
+    variable_type="UserWidget",
+    is_exposed=False
+)
+
+add_blueprint_variable(
+    blueprint_name="WBP_DraggedItem",
+    variable_name="SourceSlotIndex",
+    variable_type="Integer",
+    is_exposed=False
+)
+
+add_blueprint_variable(
+    blueprint_name="WBP_DraggedItem",
+    variable_name="ItemDefRef",
+    variable_type="/Game/Inventory/Data/S_ItemDefinition",
+    is_exposed=False
+)
+
+# Create SetDragData function
+create_custom_blueprint_function(
+    blueprint_name="WBP_DraggedItem",
+    function_name="SetDragData",
+    inputs=[
+        {"name": "SlotData", "type": "S_InventorySlot"},
+        {"name": "Container", "type": "UserWidget"},
+        {"name": "SlotIndex", "type": "Integer"},
+        {"name": "ItemDef", "type": "S_ItemDefinition"}
+    ],
+    outputs=[],
+    is_pure=False,
+    category="Drag"
+)
+
+# Create UpdatePosition function
+create_custom_blueprint_function(
+    blueprint_name="WBP_DraggedItem",
+    function_name="UpdatePosition",
+    inputs=[],
+    outputs=[],
+    is_pure=False,
+    category="Drag"
+)
+
+compile_blueprint(blueprint_name="WBP_DraggedItem")
+```
+
+### VERIFICATION
+- [ ] WBP_DraggedItem created at /Game/Inventory/UI/
+- [ ] Components added
+- [ ] Variables added
+- [ ] Functions created
+- [ ] Blueprint compiles
+
+---
+
+## Step 2.2: Implement SetDragData Function
+
+### AIM
+Initialize the drag widget with item data.
+
+### LOGIC
+```
+Input: SlotData, Container, SlotIndex, ItemDef
+
+1. Set DraggedSlotData = SlotData
+2. Set SourceContainer = Container
+3. Set SourceSlotIndex = SlotIndex
+4. Set ItemDefRef = ItemDef
+5. Set ItemIcon texture = ItemDef.Icon
+6. If SlotData.StackCount > 1:
+   - Set StackCountText = SlotData.StackCount (as string)
+   - Set StackCountText visibility = Visible
+7. Else:
+   - Set StackCountText visibility = Hidden
+```
+
+### MCP TOOL CALLS
+
+```python
+# Implement SetDragData function graph
+# Node sequence:
+# FunctionEntry → Set DraggedSlotData → Set SourceContainer → Set SourceSlotIndex
+# → Set ItemDefRef → Break ItemDef → Set ItemIcon Brush → Branch (StackCount > 1)
+# → True: Set StackCountText, Set Visibility Visible
+# → False: Set Visibility Hidden
+# → Return
+```
+
+### VERIFICATION
+- [ ] SetDragData function implemented
+- [ ] Icon displays correctly
+- [ ] Stack count shows when > 1
+- [ ] Stack count hidden when = 1
+- [ ] Blueprint compiles
+
+---
+
+## Step 2.3: Implement UpdatePosition Function
+
+### AIM
+Move widget to follow mouse cursor.
+
+### LOGIC
+```
+1. Get Player Controller → Get Mouse Position
+2. Get widget slot (if using Canvas Panel slot)
+3. Set position = Mouse Position - (32, 32)  // Center on cursor
+```
+
+### MCP TOOL CALLS
+
+```python
+# Implement UpdatePosition function graph
+# Node sequence:
+# FunctionEntry → Get Player Controller (0) → Get Mouse Position
+# → Subtract Vector2D (32, 32) → Set Position in Viewport
+```
+
+### VERIFICATION
+- [ ] UpdatePosition implemented
+- [ ] Widget moves to mouse position
+- [ ] Blueprint compiles
+
+---
+
+## Step 2.4: Add Tick Event
+
+### AIM
+Call UpdatePosition every frame.
+
+### LOGIC
+```
+Event Tick → Call UpdatePosition()
+```
+
+### MCP TOOL CALLS
+
+```python
+# In EventGraph:
+# Event Tick → UpdatePosition call
+```
+
+### VERIFICATION
+- [ ] Tick event connected to UpdatePosition
+- [ ] Blueprint compiles
+
+---
+
+## Step 2.5: Test Cursor Following
+
+### AIM
+Verify drag widget follows cursor smoothly.
+
+### TEST APPROACH
+Temporarily add test logic to player BeginPlay:
+
+```python
+# Temporary test code (remove after verification):
+# BeginPlay → Create WBP_DraggedItem → Add to Viewport (Z-Order 1000)
+```
+
+### USER TEST
+1. Launch Unreal Editor
+2. Play in Editor
+3. Verify:
+   - [ ] Drag widget appears on screen
+   - [ ] Widget follows mouse cursor smoothly
+   - [ ] No visual lag or jitter
+   - [ ] Widget stays centered on cursor
+
+### CLEANUP
+After verification, remove test code from player BeginPlay.
+
+---
+
+## Phase 2 Completion Checklist
+
+### Assets Created
+- [ ] WBP_DraggedItem with icon and stack count
+
+### Functions Implemented
+- [ ] SetDragData populates display
+- [ ] UpdatePosition follows mouse
+- [ ] Tick calls UpdatePosition
+
+### Visual Verification (USER TEST)
+- [ ] Drag widget follows cursor smoothly
+- [ ] Icon displays correctly
+- [ ] Stack count displays when applicable
+
+### Ready for Phase 3
+- [ ] Widget compiles
+- [ ] Cursor following verified
+- [ ] Proceed to Phase 3: Inventory Drag Support
+
+---
+
+## Next Phase
+
+Continue to [Phase3_InventoryDragSupport.md](Phase3_InventoryDragSupport.md) to add drag functionality to existing inventory.

--- a/Docs/loot-plan/Phase3_InventoryDragSupport.md
+++ b/Docs/loot-plan/Phase3_InventoryDragSupport.md
@@ -1,0 +1,324 @@
+# Phase 3: Inventory Drag Support
+
+> **STATUS: 📋 PLANNED**
+
+> **REMINDER**: ALL functionality MUST be implemented using MCP tools.
+> NO manual Unreal Editor work is permitted.
+
+## Objective
+
+Add drag functionality to existing inventory widgets:
+- Grey overlay on source slot
+- Left-click starts drag
+- Drag widget spawns and follows cursor
+
+**USER TEST at end of phase:** Click inventory slot → grey overlay appears, drag widget follows cursor.
+
+## Dependencies
+
+- Phase 2 completed (WBP_DraggedItem exists)
+- Existing WBP_InventorySlot, WBP_InventoryGrid
+
+---
+
+## Step 3.1: Add DragOverlay to WBP_InventorySlot
+
+### AIM
+Add grey overlay component that shows during drag.
+
+### MCP TOOL CALLS
+
+```python
+# Add DragOverlay component
+add_widget_component_to_widget(
+    widget_name="WBP_InventorySlot",
+    component_name="DragOverlay",
+    component_type="Border",
+    position=[0, 0],
+    size=[64, 64],
+    kwargs={"background_color": [0.3, 0.3, 0.3, 0.6]}
+)
+
+# Set DragOverlay to Hidden by default
+set_widget_component_property(
+    widget_name="WBP_InventorySlot",
+    component_name="DragOverlay",
+    kwargs={"Visibility": "Hidden"}
+)
+
+# Add IsDragSource variable
+add_blueprint_variable(
+    blueprint_name="WBP_InventorySlot",
+    variable_name="IsDragSource",
+    variable_type="Boolean",
+    is_exposed=False
+)
+
+compile_blueprint(blueprint_name="WBP_InventorySlot")
+```
+
+### VERIFICATION
+- [ ] DragOverlay added to slot
+- [ ] Overlay initially Hidden
+- [ ] IsDragSource variable added
+- [ ] Blueprint compiles
+
+---
+
+## Step 3.2: Create SetDragOverlay Function in WBP_InventorySlot
+
+### AIM
+Function to show/hide the drag overlay.
+
+### MCP TOOL CALLS
+
+```python
+create_custom_blueprint_function(
+    blueprint_name="WBP_InventorySlot",
+    function_name="SetDragOverlay",
+    inputs=[{"name": "bVisible", "type": "Boolean"}],
+    outputs=[],
+    is_pure=False,
+    category="Slot"
+)
+```
+
+### LOGIC
+```
+Input: bVisible (bool)
+
+1. If bVisible:
+   - Set DragOverlay visibility = Visible
+2. Else:
+   - Set DragOverlay visibility = Hidden
+3. Set IsDragSource = bVisible
+```
+
+### VERIFICATION
+- [ ] SetDragOverlay function created
+- [ ] Logic implemented
+- [ ] Blueprint compiles
+
+---
+
+## Step 3.3: Add Drag Variables to WBP_InventoryGrid
+
+### AIM
+Add state tracking for active drag operations.
+
+### MCP TOOL CALLS
+
+```python
+# Add drag state variables
+add_blueprint_variable(
+    blueprint_name="WBP_InventoryGrid",
+    variable_name="ActiveDragWidget",
+    variable_type="UserWidget",
+    is_exposed=False
+)
+
+add_blueprint_variable(
+    blueprint_name="WBP_InventoryGrid",
+    variable_name="DragSourceSlotIndex",
+    variable_type="Integer",
+    is_exposed=False
+)
+
+set_blueprint_variable_value(
+    blueprint_name="WBP_InventoryGrid",
+    variable_name="DragSourceSlotIndex",
+    value=-1
+)
+
+add_blueprint_variable(
+    blueprint_name="WBP_InventoryGrid",
+    variable_name="DragSourceContainer",
+    variable_type="UserWidget",
+    is_exposed=False
+)
+
+compile_blueprint(blueprint_name="WBP_InventoryGrid")
+```
+
+### VERIFICATION
+- [ ] Variables added
+- [ ] DragSourceSlotIndex defaults to -1
+- [ ] Blueprint compiles
+
+---
+
+## Step 3.4: Create StartDrag Function in WBP_InventoryGrid
+
+### AIM
+Begin drag operation: show overlay, create drag widget.
+
+### MCP TOOL CALLS
+
+```python
+create_custom_blueprint_function(
+    blueprint_name="WBP_InventoryGrid",
+    function_name="StartDrag",
+    inputs=[{"name": "SlotIndex", "type": "Integer"}],
+    outputs=[],
+    is_pure=False,
+    category="DragDrop"
+)
+```
+
+### LOGIC
+```
+Input: SlotIndex (int)
+
+1. Set DragSourceSlotIndex = SlotIndex
+2. Set DragSourceContainer = Self
+3. Get slot widget at SlotIndex from SlotWidgets array
+4. Call SetDragOverlay(true) on slot widget
+5. Get slot data (CachedSlotData) from slot widget
+6. Look up ItemDef from DataTable using ItemRowName
+7. Create WBP_DraggedItem widget
+8. Call SetDragData on drag widget with slot data, self, index, itemdef
+9. Set ActiveDragWidget = created widget
+10. Add drag widget to viewport (Z-Order: 1000)
+```
+
+### VERIFICATION
+- [ ] StartDrag function created
+- [ ] Overlay shows on source slot
+- [ ] Drag widget created and added to viewport
+- [ ] Blueprint compiles
+
+---
+
+## Step 3.5: Create CancelDrag Function in WBP_InventoryGrid
+
+### AIM
+Cancel drag operation: hide overlay, remove drag widget.
+
+### MCP TOOL CALLS
+
+```python
+create_custom_blueprint_function(
+    blueprint_name="WBP_InventoryGrid",
+    function_name="CancelDrag",
+    inputs=[],
+    outputs=[],
+    is_pure=False,
+    category="DragDrop"
+)
+```
+
+### LOGIC
+```
+1. If DragSourceSlotIndex >= 0:
+   - Get slot widget at DragSourceSlotIndex
+   - Call SetDragOverlay(false) on slot widget
+2. If ActiveDragWidget is valid:
+   - Remove ActiveDragWidget from parent
+3. Set ActiveDragWidget = None
+4. Set DragSourceSlotIndex = -1
+5. Set DragSourceContainer = None
+```
+
+### VERIFICATION
+- [ ] CancelDrag function created
+- [ ] Overlay hides on cancel
+- [ ] Drag widget removed
+- [ ] State variables reset
+- [ ] Blueprint compiles
+
+---
+
+## Step 3.6: Modify WBP_InventorySlot Left-Click Handler
+
+### AIM
+Left-click on slot with item starts drag.
+
+### CURRENT BEHAVIOR
+HandleMouseDown handles right-click for context menu.
+
+### NEW BEHAVIOR
+```
+OnMouseButtonDown:
+1. Get mouse button from event
+2. If LEFT CLICK:
+   a. Get CachedSlotData
+   b. If ItemRowName is NOT empty (has item):
+      - Call ParentGrid.StartDrag(SlotIndex)
+      - Return Handled
+   c. Else:
+      - Hide context menu if open
+      - Return Handled
+3. If RIGHT CLICK:
+   a. (Existing context menu logic)
+4. Return Unhandled
+```
+
+### MCP TOOL CALLS
+
+```python
+# Modify existing HandleMouseDown or create OnMouseButtonDown override
+create_widget_input_handler(
+    widget_name="WBP_InventorySlot",
+    input_type="MouseButton",
+    input_event="LeftMouseButton",
+    trigger="Pressed",
+    handler_name="OnSlotLeftClick"
+)
+```
+
+### VERIFICATION
+- [ ] Left-click starts drag
+- [ ] Only works on slots with items
+- [ ] Right-click still shows context menu
+- [ ] Blueprint compiles
+
+---
+
+## Step 3.7: Test Drag from Inventory
+
+### USER TEST
+1. Launch Unreal Editor
+2. Play in Editor
+3. Open inventory (I key or existing method)
+4. Left-click on slot with item:
+   - [ ] Grey overlay appears on clicked slot
+   - [ ] Drag widget appears at cursor
+   - [ ] Drag widget follows cursor
+5. Press Escape or click empty area:
+   - [ ] Drag widget disappears
+   - [ ] Grey overlay disappears
+   - [ ] Item stays in original slot
+6. Right-click on slot:
+   - [ ] Context menu still works
+
+---
+
+## Phase 3 Completion Checklist
+
+### WBP_InventorySlot Updates
+- [ ] DragOverlay component added
+- [ ] IsDragSource variable added
+- [ ] SetDragOverlay function implemented
+- [ ] Left-click starts drag
+
+### WBP_InventoryGrid Updates
+- [ ] Drag state variables added
+- [ ] StartDrag function implemented
+- [ ] CancelDrag function implemented
+
+### Functionality Verified (USER TEST)
+- [ ] Left-click on item shows grey overlay
+- [ ] Drag widget follows cursor
+- [ ] Cancel restores original state
+- [ ] Right-click context menu still works
+
+### Ready for Phase 4
+- [ ] All blueprints compile
+- [ ] Drag start/cancel working
+- [ ] Proceed to Phase 4: Lootable Actor + Data
+
+---
+
+## Next Phase
+
+Continue to [Phase4_LootableActorAndData.md](Phase4_LootableActorAndData.md) to create the lootable actor and connect real data.

--- a/Docs/loot-plan/Phase4_LootableActorAndData.md
+++ b/Docs/loot-plan/Phase4_LootableActorAndData.md
@@ -1,0 +1,575 @@
+# Phase 4: Lootable Actor and Data Connection
+
+> **STATUS: 📋 PLANNED**
+
+> **REMINDER**: ALL functionality MUST be implemented using MCP tools.
+> NO manual Unreal Editor work is permitted.
+
+## Objective
+
+Create lootable actor with real item data and connect to loot window:
+1. Create BPI_Interactable interface
+2. Create BP_LootableBase actor with loot slot array
+3. Connect loot window to real data
+4. Implement item transfer (loot → inventory)
+
+**USER TEST at end of phase:** Place chest in level, open loot window, drag item to inventory.
+
+## Dependencies
+
+- Phase 3 completed (inventory drag working)
+- Existing S_InventorySlot, S_ItemDefinition, DT_Items
+
+---
+
+## Step 4.1: Create BPI_Interactable Interface
+
+### AIM
+Create interface for shared E-key interaction (used by NPCs and lootables).
+
+### INTERFACE FUNCTIONS
+
+| Function | Inputs | Outputs | Purpose |
+|----------|--------|---------|---------|
+| CanInteract | Interactor (Actor) | CanInteract (bool) | Check if interaction possible |
+| GetInteractionPrompt | - | Prompt (String) | Get display text |
+| OnInteract | Interactor (Actor) | - | Execute interaction |
+
+### MCP TOOL CALLS
+
+```python
+# Create folder for interfaces
+create_folder(folder_path="Content/Blueprints/Interfaces")
+
+# Create the interface
+create_blueprint_interface(
+    name="BPI_Interactable",
+    folder_path="/Game/Blueprints/Interfaces"
+)
+
+# Note: Interface functions are typically added via UE Editor
+# MCP may need add_interface_function tool or similar
+```
+
+### VERIFICATION
+- [ ] BPI_Interactable created
+- [ ] CanInteract function exists (Actor input, bool output)
+- [ ] GetInteractionPrompt function exists (String output)
+- [ ] OnInteract function exists (Actor input)
+
+---
+
+## Step 4.2: Create BP_LootableBase Actor
+
+### AIM
+Base actor for lootable objects (chests, crates, etc.).
+
+### COMPONENTS
+
+| Component | Type | Properties |
+|-----------|------|------------|
+| DefaultSceneRoot | Scene | Root |
+| StaticMesh | StaticMesh | Visual mesh |
+| InteractionSphere | SphereCollision | Radius 200cm |
+| InteractionPrompt | WidgetComponent | "Press E to Loot" |
+
+### VARIABLES
+
+| Variable | Type | Default | Purpose |
+|----------|------|---------|---------|
+| LootSlots | S_InventorySlot[] | [] | Items in container |
+| ItemsDataTable | DataTable | DT_Items | Reference to item defs |
+| MaxSlots | Integer | 8 | Maximum capacity |
+| bIsLooted | Boolean | false | Already emptied |
+
+### FUNCTIONS
+
+| Function | Inputs | Outputs | Purpose |
+|----------|--------|---------|---------|
+| InitializeLoot | ItemNames[], Quantities[] | Success | Set initial items |
+| GetLootSlotData | SlotIndex | SlotData, ItemDef, IsEmpty | Get slot info |
+| RemoveLootItem | SlotIndex | Removed, Success | Remove item |
+| HasLoot | - | HasItems (bool) | Check if has items |
+
+### MCP TOOL CALLS
+
+```python
+# Create actor blueprint
+create_blueprint(
+    name="BP_LootableBase",
+    parent_class="Actor",
+    folder_path="/Game/Loot/Blueprints"
+)
+
+# Add interface
+add_interface_to_blueprint(
+    blueprint_name="BP_LootableBase",
+    interface_name="/Game/Blueprints/Interfaces/BPI_Interactable"
+)
+
+# Add components
+add_component_to_blueprint(
+    blueprint_name="BP_LootableBase",
+    component_type="StaticMeshComponent",
+    component_name="LootMesh"
+)
+
+add_component_to_blueprint(
+    blueprint_name="BP_LootableBase",
+    component_type="SphereComponent",
+    component_name="InteractionSphere"
+)
+
+# Configure InteractionSphere radius (200cm)
+
+add_component_to_blueprint(
+    blueprint_name="BP_LootableBase",
+    component_type="WidgetComponent",
+    component_name="InteractionPrompt"
+)
+
+# Add variables
+add_blueprint_variable(
+    blueprint_name="BP_LootableBase",
+    variable_name="LootSlots",
+    variable_type="/Game/Inventory/Data/S_InventorySlot[]",
+    is_exposed=False
+)
+
+add_blueprint_variable(
+    blueprint_name="BP_LootableBase",
+    variable_name="ItemsDataTable",
+    variable_type="DataTable",
+    is_exposed=True
+)
+
+add_blueprint_variable(
+    blueprint_name="BP_LootableBase",
+    variable_name="MaxSlots",
+    variable_type="Integer",
+    is_exposed=True
+)
+
+set_blueprint_variable_value(
+    blueprint_name="BP_LootableBase",
+    variable_name="MaxSlots",
+    value=8
+)
+
+add_blueprint_variable(
+    blueprint_name="BP_LootableBase",
+    variable_name="bIsLooted",
+    variable_type="Boolean",
+    is_exposed=False
+)
+
+# Create functions
+create_custom_blueprint_function(
+    blueprint_name="BP_LootableBase",
+    function_name="InitializeLoot",
+    inputs=[
+        {"name": "ItemNames", "type": "Name[]"},
+        {"name": "Quantities", "type": "Integer[]"}
+    ],
+    outputs=[{"name": "Success", "type": "Boolean"}],
+    is_pure=False,
+    category="Loot"
+)
+
+create_custom_blueprint_function(
+    blueprint_name="BP_LootableBase",
+    function_name="GetLootSlotData",
+    inputs=[{"name": "SlotIndex", "type": "Integer"}],
+    outputs=[
+        {"name": "SlotData", "type": "S_InventorySlot"},
+        {"name": "ItemDef", "type": "S_ItemDefinition"},
+        {"name": "IsEmpty", "type": "Boolean"}
+    ],
+    is_pure=True,
+    category="Loot"
+)
+
+create_custom_blueprint_function(
+    blueprint_name="BP_LootableBase",
+    function_name="RemoveLootItem",
+    inputs=[{"name": "SlotIndex", "type": "Integer"}],
+    outputs=[
+        {"name": "Removed", "type": "Boolean"},
+        {"name": "Success", "type": "Boolean"}
+    ],
+    is_pure=False,
+    category="Loot"
+)
+
+create_custom_blueprint_function(
+    blueprint_name="BP_LootableBase",
+    function_name="HasLoot",
+    inputs=[],
+    outputs=[{"name": "HasItems", "type": "Boolean"}],
+    is_pure=True,
+    category="Loot"
+)
+
+compile_blueprint(blueprint_name="BP_LootableBase")
+```
+
+### INTERFACE IMPLEMENTATIONS
+
+#### CanInteract
+```
+Input: Interactor (Actor)
+Output: CanInteract (bool)
+
+1. Return HasLoot() AND NOT bIsLooted
+```
+
+#### GetInteractionPrompt
+```
+Output: Prompt (String)
+
+1. Return "Press E to Loot"
+```
+
+#### OnInteract
+```
+Input: Interactor (Actor)
+
+1. Cast Interactor to BP_ThirdPersonCharacter
+2. Call OpenLootWindow(Self) on character
+```
+
+### VERIFICATION
+- [ ] BP_LootableBase created
+- [ ] Implements BPI_Interactable
+- [ ] Components added
+- [ ] Variables and functions created
+- [ ] Interface functions implemented
+- [ ] Blueprint compiles
+
+---
+
+## Step 4.3: Implement Loot Functions
+
+### InitializeLoot
+```
+Input: ItemNames (Name[]), Quantities (int[])
+Output: Success (bool)
+
+1. Clear LootSlots array
+2. For i = 0 to min(ItemNames.Length, MaxSlots):
+   a. Create S_InventorySlot struct
+   b. Set ItemRowName = ItemNames[i]
+   c. Set StackCount = Quantities[i]
+   d. Add to LootSlots
+3. Return true
+```
+
+### GetLootSlotData
+```
+Input: SlotIndex (int)
+Output: SlotData, ItemDef, IsEmpty
+
+1. If SlotIndex < 0 OR SlotIndex >= LootSlots.Length:
+   - Return empty, empty, true
+2. Get slot from LootSlots[SlotIndex]
+3. If slot.ItemRowName is empty:
+   - Return slot, empty, true
+4. Look up ItemDef from ItemsDataTable
+5. Return slot, ItemDef, false
+```
+
+### RemoveLootItem
+```
+Input: SlotIndex (int)
+Output: Removed, Success
+
+1. If SlotIndex < 0 OR SlotIndex >= LootSlots.Length:
+   - Return false, false
+2. Get slot from LootSlots[SlotIndex]
+3. If slot.ItemRowName is empty:
+   - Return false, false
+4. Clear slot (set ItemRowName = None, StackCount = 0)
+5. Set LootSlots[SlotIndex] = cleared slot
+6. Return true, true
+```
+
+### HasLoot
+```
+Output: HasItems (bool)
+
+1. For each slot in LootSlots:
+   - If slot.ItemRowName is NOT empty:
+     - Return true
+2. Return false
+```
+
+### VERIFICATION
+- [ ] All functions implemented
+- [ ] InitializeLoot populates array
+- [ ] GetLootSlotData retrieves correct data
+- [ ] RemoveLootItem clears slot
+- [ ] HasLoot detects items
+- [ ] Blueprint compiles
+
+---
+
+## Step 4.4: Connect WBP_LootWindow to Real Data
+
+### AIM
+Update loot window to display items from BP_LootableBase.
+
+### NEW FUNCTION: OpenLoot
+
+```python
+create_custom_blueprint_function(
+    blueprint_name="WBP_LootWindow",
+    function_name="OpenLoot",
+    inputs=[
+        {"name": "Lootable", "type": "BP_LootableBase"},
+        {"name": "InventoryGrid", "type": "UserWidget"}
+    ],
+    outputs=[],
+    is_pure=False,
+    category="Loot"
+)
+```
+
+### LOGIC: OpenLoot
+```
+Input: Lootable, InventoryGrid
+
+1. Set LootableRef = Lootable
+2. Set InventoryGridRef = InventoryGrid
+3. Call InitializeSlots()
+4. Call RefreshAllSlots()
+```
+
+### UPDATE: InitializeSlots
+```
+1. Clear SlotWidgets array
+2. For i = 0 to MaxSlots:
+   a. Create WBP_LootSlot widget
+   b. Set SlotIndex = i
+   c. Set ParentContainer = Self
+   d. Set LootableRef = LootableRef
+   e. Add to SlotsGrid at row i/4, column i%4
+   f. Add to SlotWidgets array
+```
+
+### UPDATE: RefreshAllSlots
+```
+1. For each slot in SlotWidgets:
+   a. Get SlotIndex
+   b. Call LootableRef.GetLootSlotData(SlotIndex)
+   c. Call slot.SetSlotData(SlotData, ItemDef)
+```
+
+### VERIFICATION
+- [ ] OpenLoot function created
+- [ ] InitializeSlots creates slot widgets
+- [ ] RefreshAllSlots displays items
+- [ ] Blueprint compiles
+
+---
+
+## Step 4.5: Implement EndDrag for Item Transfer
+
+### AIM
+Complete drag by transferring item from loot to inventory.
+
+### ADD TO WBP_InventoryGrid: EndDrag Function
+
+```python
+create_custom_blueprint_function(
+    blueprint_name="WBP_InventoryGrid",
+    function_name="EndDrag",
+    inputs=[{"name": "TargetContainer", "type": "UserWidget"}],
+    outputs=[],
+    is_pure=False,
+    category="DragDrop"
+)
+```
+
+### LOGIC: EndDrag
+```
+Input: TargetContainer (UserWidget)
+
+1. If DragSourceSlotIndex < 0:
+   - Return (no active drag)
+
+2. Get slot widget at DragSourceSlotIndex
+3. Call SetDragOverlay(false) on slot widget
+
+4. If TargetContainer is valid AND TargetContainer != DragSourceContainer:
+   a. Get ActiveDragWidget's DraggedSlotData
+   b. Call HandleItemDrop on TargetContainer with slot data
+   c. If HandleItemDrop returns true:
+      - Remove item from source container
+      - Refresh source container
+
+5. If ActiveDragWidget is valid:
+   - Remove ActiveDragWidget from parent
+
+6. Set ActiveDragWidget = None
+7. Set DragSourceSlotIndex = -1
+8. Set DragSourceContainer = None
+```
+
+### ADD: HandleItemDrop Function
+
+```python
+create_custom_blueprint_function(
+    blueprint_name="WBP_InventoryGrid",
+    function_name="HandleItemDrop",
+    inputs=[{"name": "DroppedSlotData", "type": "S_InventorySlot"}],
+    outputs=[{"name": "Success", "type": "Boolean"}],
+    is_pure=False,
+    category="DragDrop"
+)
+```
+
+### LOGIC: HandleItemDrop
+```
+Input: DroppedSlotData (S_InventorySlot)
+Output: Success (bool)
+
+1. Get ItemRowName from DroppedSlotData
+2. Get StackCount from DroppedSlotData
+3. Call InventoryManager.AddItem(ItemRowName, StackCount)
+4. If AmountAdded > 0:
+   - Call RefreshAllSlots()
+   - Return true
+5. Return false
+```
+
+### VERIFICATION
+- [ ] EndDrag function created
+- [ ] HandleItemDrop function created
+- [ ] Item transfers on drop
+- [ ] Source slot clears
+- [ ] Both containers refresh
+- [ ] Blueprint compiles
+
+---
+
+## Step 4.6: Add StartDrag to WBP_LootWindow
+
+### AIM
+Enable dragging from loot slots.
+
+```python
+create_custom_blueprint_function(
+    blueprint_name="WBP_LootWindow",
+    function_name="StartDrag",
+    inputs=[{"name": "SlotIndex", "type": "Integer"}],
+    outputs=[],
+    is_pure=False,
+    category="DragDrop"
+)
+```
+
+### LOGIC: (Same as WBP_InventoryGrid.StartDrag)
+
+### ADD: Left-click handler to WBP_LootSlot
+
+```python
+create_widget_input_handler(
+    widget_name="WBP_LootSlot",
+    input_type="MouseButton",
+    input_event="LeftMouseButton",
+    trigger="Pressed",
+    handler_name="OnSlotLeftClick"
+)
+```
+
+### VERIFICATION
+- [ ] StartDrag function on WBP_LootWindow
+- [ ] Left-click on loot slot starts drag
+- [ ] Blueprint compiles
+
+---
+
+## Step 4.7: Create Test Lootable
+
+### AIM
+Place a test chest in level with items.
+
+### MCP TOOL CALLS
+
+```python
+# Place test lootable in level
+spawn_blueprint_actor(
+    blueprint_name="/Game/Loot/Blueprints/BP_LootableBase",
+    actor_name="TestLootChest",
+    location=[500, 0, 100]
+)
+```
+
+### INITIALIZE TEST DATA
+In BP_LootableBase BeginPlay:
+```
+1. Call InitializeLoot with:
+   - ItemNames: ["HealthPotion", "IronOre", "IronSword"]
+   - Quantities: [5, 10, 1]
+```
+
+### VERIFICATION
+- [ ] Test chest placed in level
+- [ ] BeginPlay initializes items
+- [ ] Blueprint compiles
+
+---
+
+## Step 4.8: Test Full Drag-Drop Flow
+
+### USER TEST
+1. Launch Unreal Editor
+2. Play in Editor
+3. Walk to test chest
+4. Open loot window (manual test - E-key in Phase 5)
+5. Verify:
+   - [ ] Loot window shows items
+   - [ ] Left-click loot slot shows grey overlay
+   - [ ] Drag widget follows cursor
+   - [ ] Drop on inventory transfers item
+   - [ ] Item disappears from loot
+   - [ ] Item appears in inventory
+6. Test cancel:
+   - [ ] Drag item but release elsewhere
+   - [ ] Item stays in loot
+   - [ ] Grey overlay disappears
+
+---
+
+## Phase 4 Completion Checklist
+
+### Assets Created
+- [ ] BPI_Interactable interface
+- [ ] BP_LootableBase actor with loot storage
+
+### Data Flow
+- [ ] Loot window reads from actor
+- [ ] Item transfer updates both containers
+- [ ] DataTable lookup works
+
+### Drag-Drop Complete
+- [ ] Drag from loot shows overlay
+- [ ] Drop on inventory transfers
+- [ ] Cancel restores state
+- [ ] Both directions work (if enabled)
+
+### USER TEST Passed
+- [ ] Full drag-drop flow working
+- [ ] Items visually update
+- [ ] No errors
+
+### Ready for Phase 5
+- [ ] All blueprints compile
+- [ ] Data connection verified
+- [ ] Proceed to Phase 5: E-Key Integration
+
+---
+
+## Next Phase
+
+Continue to [Phase5_EKeyIntegration.md](Phase5_EKeyIntegration.md) to integrate with E-key and complete the system.

--- a/Docs/loot-plan/Phase5_EKeyIntegration.md
+++ b/Docs/loot-plan/Phase5_EKeyIntegration.md
@@ -1,0 +1,423 @@
+# Phase 5: E-Key Integration
+
+> **STATUS: 📋 PLANNED**
+
+> **REMINDER**: ALL functionality MUST be implemented using MCP tools.
+> NO manual Unreal Editor work is permitted.
+
+## Objective
+
+Complete the system integration:
+1. Modify player E-key handler to use BPI_Interactable
+2. Add interface implementation to BP_DialogueNPC
+3. Add OpenLootWindow/CloseLootWindow functions to player
+4. Implement side-by-side layout
+
+**USER TEST at end of phase:** E near NPC = dialogue, E near chest = loot window.
+
+## Dependencies
+
+- Phase 4 completed (loot system working)
+- Existing BP_DialogueNPC, IA_Interact
+
+---
+
+## Step 5.1: Add Player Variables
+
+### AIM
+Add variables to track loot window state.
+
+### MCP TOOL CALLS
+
+```python
+add_blueprint_variable(
+    blueprint_name="BP_ThirdPersonCharacter",
+    variable_name="ActiveLootWindow",
+    variable_type="UserWidget",
+    is_exposed=False
+)
+
+add_blueprint_variable(
+    blueprint_name="BP_ThirdPersonCharacter",
+    variable_name="IsLootOpen",
+    variable_type="Boolean",
+    is_exposed=False
+)
+
+compile_blueprint(blueprint_name="BP_ThirdPersonCharacter")
+```
+
+### VERIFICATION
+- [ ] Variables added
+- [ ] Blueprint compiles
+
+---
+
+## Step 5.2: Create OpenLootWindow Function
+
+### AIM
+Function to open loot UI with inventory side-by-side.
+
+### MCP TOOL CALLS
+
+```python
+create_custom_blueprint_function(
+    blueprint_name="BP_ThirdPersonCharacter",
+    function_name="OpenLootWindow",
+    inputs=[{"name": "Lootable", "type": "Actor"}],  # Will be cast to BP_LootableBase
+    outputs=[],
+    is_pure=False,
+    category="Loot"
+)
+```
+
+### LOGIC
+```
+Input: Lootable (Actor)
+
+1. If IsLootOpen:
+   - Return (already open)
+
+2. Cast Lootable to BP_LootableBase
+3. If cast fails:
+   - Return
+
+4. Create WBP_LootWindow widget
+5. Set ActiveLootWindow = created widget
+
+6. If NOT IsInventoryOpen:
+   - Create WBP_InventoryGrid widget
+   - Call InitializeGrid(InventoryManagerRef)
+   - Set InventoryWidget = created widget
+   - Set IsInventoryOpen = true
+
+7. Position windows side-by-side:
+   - Loot window: X = 200, Y = 200 (left side)
+   - Inventory: X = 560, Y = 200 (right side)
+
+8. Call OpenLoot(Lootable, InventoryWidget) on ActiveLootWindow
+9. Add ActiveLootWindow to viewport (Z-Order: 50)
+10. Add InventoryWidget to viewport (Z-Order: 50) if newly created
+
+11. Set IsLootOpen = true
+12. Set Input Mode Game and UI
+13. Set Show Mouse Cursor = true
+```
+
+### VERIFICATION
+- [ ] OpenLootWindow function created
+- [ ] Logic implemented
+- [ ] Blueprint compiles
+
+---
+
+## Step 5.3: Create CloseLootWindow Function
+
+### MCP TOOL CALLS
+
+```python
+create_custom_blueprint_function(
+    blueprint_name="BP_ThirdPersonCharacter",
+    function_name="CloseLootWindow",
+    inputs=[],
+    outputs=[],
+    is_pure=False,
+    category="Loot"
+)
+```
+
+### LOGIC
+```
+1. If NOT IsLootOpen:
+   - Return
+
+2. If ActiveLootWindow is valid:
+   - Remove ActiveLootWindow from parent
+   - Set ActiveLootWindow = None
+
+3. Set IsLootOpen = false
+
+4. If IsInventoryOpen:
+   - Reposition inventory to center: X = 400, Y = 200
+   - (Keep inventory open after closing loot)
+5. Else:
+   - Set Input Mode Game Only
+   - Set Show Mouse Cursor = false
+```
+
+### VERIFICATION
+- [ ] CloseLootWindow function created
+- [ ] Logic implemented
+- [ ] Blueprint compiles
+
+---
+
+## Step 5.4: Add BPI_Interactable to BP_DialogueNPC
+
+### AIM
+Update existing NPC to use interface.
+
+### MCP TOOL CALLS
+
+```python
+add_interface_to_blueprint(
+    blueprint_name="BP_DialogueNPC",
+    interface_name="/Game/Blueprints/Interfaces/BPI_Interactable"
+)
+
+# Create CanInteract implementation
+create_custom_blueprint_function(
+    blueprint_name="BP_DialogueNPC",
+    function_name="CanInteract",
+    inputs=[{"name": "Interactor", "type": "Actor"}],
+    outputs=[{"name": "CanInteract", "type": "Boolean"}],
+    is_pure=True,
+    category="Interaction"
+)
+
+# Create GetInteractionPrompt implementation
+create_custom_blueprint_function(
+    blueprint_name="BP_DialogueNPC",
+    function_name="GetInteractionPrompt",
+    inputs=[],
+    outputs=[{"name": "Prompt", "type": "String"}],
+    is_pure=True,
+    category="Interaction"
+)
+
+# Create OnInteract implementation
+create_custom_blueprint_function(
+    blueprint_name="BP_DialogueNPC",
+    function_name="OnInteract",
+    inputs=[{"name": "Interactor", "type": "Actor"}],
+    outputs=[],
+    is_pure=False,
+    category="Interaction"
+)
+
+compile_blueprint(blueprint_name="BP_DialogueNPC")
+```
+
+### FUNCTION IMPLEMENTATIONS
+
+#### CanInteract
+```
+Input: Interactor (Actor)
+Output: CanInteract (bool)
+
+1. Return NOT bDialogueActive
+   (Can interact if not already in dialogue)
+```
+
+#### GetInteractionPrompt
+```
+Output: Prompt (String)
+
+1. Return "Press E to Talk"
+```
+
+#### OnInteract
+```
+Input: Interactor (Actor)
+
+1. Call StartDialogue()
+   (Existing function that opens dialogue window)
+```
+
+### VERIFICATION
+- [ ] Interface added to BP_DialogueNPC
+- [ ] CanInteract returns based on dialogue state
+- [ ] GetInteractionPrompt returns text
+- [ ] OnInteract calls StartDialogue
+- [ ] Blueprint compiles
+
+---
+
+## Step 5.5: Modify E-Key Handler
+
+### AIM
+Update IA_Interact handler to use interface.
+
+### CURRENT IMPLEMENTATION
+```
+IA_Interact (Triggered)
+    ↓
+Sphere Overlap Actors (radius ~350cm)
+    ↓
+For Each: Cast to BP_DialogueNPC
+    ↓
+If cast succeeds: Call StartDialogue()
+```
+
+### NEW IMPLEMENTATION
+```
+IA_Interact (Triggered)
+    ↓
+Get Actor Location (Self)
+    ↓
+Sphere Overlap Actors (radius 350cm)
+    ↓
+For Each Actor:
+    ↓
+Does Implement Interface (BPI_Interactable)?
+    ↓
+YES: Call CanInteract(Self) on actor
+    ↓
+    Returns TRUE: Call OnInteract(Self) on actor
+    ↓
+    Break (only interact with first valid actor)
+```
+
+### MCP TOOL CALLS
+
+Modify existing IA_Interact event in EventGraph:
+
+```python
+# This requires modifying existing event graph nodes
+# Replace Cast to BP_DialogueNPC with Does Implement Interface
+# Replace direct StartDialogue call with interface calls
+```
+
+### VERIFICATION
+- [ ] E-key uses interface check
+- [ ] Works with NPCs (dialogue)
+- [ ] Works with lootables (loot window)
+- [ ] Blueprint compiles
+
+---
+
+## Step 5.6: Wire Close Button
+
+### AIM
+Connect loot window close button.
+
+### MCP TOOL CALLS
+
+```python
+bind_widget_component_event(
+    widget_name="WBP_LootWindow",
+    widget_component_name="CloseButton",
+    event_name="OnClicked",
+    function_name="OnCloseButtonClicked"
+)
+```
+
+### LOGIC: OnCloseButtonClicked
+```
+1. Get owning player
+2. Cast to BP_ThirdPersonCharacter
+3. Call CloseLootWindow() on character
+```
+
+### VERIFICATION
+- [ ] Close button bound
+- [ ] Clicking closes window
+- [ ] Blueprint compiles
+
+---
+
+## Step 5.7: Test Complete Flow
+
+### TEST SCENARIO 1: Basic Loot Flow
+```
+1. Walk to test loot chest
+2. Press E
+   → Expected: Loot window opens on left, inventory on right
+3. Left-click on HealthPotion in loot
+   → Expected: Grey overlay appears, drag widget follows cursor
+4. Release over inventory grid
+   → Expected: Potion appears in inventory, disappears from loot
+5. Click X on loot window
+   → Expected: Loot closes, inventory recenters
+```
+
+### TEST SCENARIO 2: Dialogue Still Works
+```
+1. Walk to NPC
+2. Press E
+   → Expected: Dialogue window opens (not loot)
+3. Complete dialogue
+4. Walk to loot chest
+5. Press E
+   → Expected: Loot window opens
+```
+
+### TEST SCENARIO 3: Cancel Drag
+```
+1. Open loot
+2. Start dragging item
+3. Release over empty area (not on container)
+   → Expected: Item returns to original slot, overlay clears
+```
+
+### TEST SCENARIO 4: Context Awareness
+```
+1. Stand between NPC and chest
+2. Face NPC, press E → Dialogue
+3. Face chest, press E → Loot
+   (Based on which is closer/in front)
+```
+
+---
+
+## Phase 5 Completion Checklist
+
+### Player Functions
+- [ ] OpenLootWindow positions both windows
+- [ ] CloseLootWindow cleans up properly
+- [ ] Variables track loot window state
+
+### Interface Integration
+- [ ] BP_DialogueNPC implements BPI_Interactable
+- [ ] BP_LootableBase implements BPI_Interactable
+- [ ] E-key uses interface to determine action
+
+### Side-by-Side Layout
+- [ ] Loot on left (X=200)
+- [ ] Inventory on right (X=560)
+- [ ] No overlapping
+- [ ] Inventory recenters when loot closes
+
+### Close Button
+- [ ] Button wired to event
+- [ ] Closes loot window properly
+
+### Full Flow Works (USER TEST)
+- [ ] E-key near loot → loot opens
+- [ ] E-key near NPC → dialogue opens
+- [ ] Drag from loot to inventory works
+- [ ] Close button works
+- [ ] Cancel drag works
+- [ ] Mouse cursor shows/hides correctly
+- [ ] Input mode switches correctly
+
+---
+
+## Final System Verification
+
+### All Success Criteria Met
+- [ ] E key opens dialogue for NPCs, loot window for lootables
+- [ ] Inventory and loot windows appear side-by-side
+- [ ] Left-click and drag from loot slot shows grey overlay
+- [ ] Dragged item visual follows cursor
+- [ ] Drop on inventory transfers full stack
+- [ ] Source slot clears, target slot shows item
+- [ ] Both containers refresh after transfer
+- [ ] Close button on loot window works
+- [ ] Empty loot containers work correctly
+
+### All Done Via MCP Tools
+- [ ] `create_blueprint_interface` used
+- [ ] `add_interface_to_blueprint` used
+- [ ] `add_blueprint_variable` used
+- [ ] `create_custom_blueprint_function` used
+- [ ] `create_node_by_action_name` used
+- [ ] `connect_blueprint_nodes` used
+- [ ] `spawn_blueprint_actor` used
+- [ ] All blueprints compile
+
+---
+
+## Return to Overview
+
+See [00_Overview.md](00_Overview.md) for complete system documentation.

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/GraphManipulation/CleanupBlueprintGraphCommand.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/GraphManipulation/CleanupBlueprintGraphCommand.cpp
@@ -1,0 +1,462 @@
+#include "Commands/GraphManipulation/CleanupBlueprintGraphCommand.h"
+#include "Services/IBlueprintService.h"
+#include "Utils/GraphUtils.h"
+#include "Dom/JsonObject.h"
+#include "Serialization/JsonSerializer.h"
+#include "Engine/Blueprint.h"
+#include "EdGraph/EdGraph.h"
+#include "EdGraph/EdGraphNode.h"
+#include "K2Node_CallFunction.h"
+#include "K2Node_FunctionResult.h"
+#include "Kismet2/BlueprintEditorUtils.h"
+#include "ScopedTransaction.h"
+
+FCleanupBlueprintGraphCommand::FCleanupBlueprintGraphCommand(IBlueprintService& InBlueprintService)
+    : BlueprintService(InBlueprintService)
+{
+}
+
+FString FCleanupBlueprintGraphCommand::Execute(const FString& Parameters)
+{
+    FString BlueprintName;
+    FString GraphName;
+    ECleanupMode CleanupMode;
+    bool bIncludeEventGraph = false;
+    FString ParseError;
+
+    if (!ParseParameters(Parameters, BlueprintName, CleanupMode, GraphName, bIncludeEventGraph, ParseError))
+    {
+        return CreateErrorResponse(ParseError);
+    }
+
+    // Find the blueprint
+    UBlueprint* Blueprint = BlueprintService.FindBlueprint(BlueprintName);
+    if (!Blueprint)
+    {
+        return CreateErrorResponse(FString::Printf(TEXT("Blueprint not found: %s"), *BlueprintName));
+    }
+
+    // Execute the appropriate cleanup mode
+    switch (CleanupMode)
+    {
+    case ECleanupMode::Orphans:
+        return ExecuteOrphansCleanup(Blueprint, GraphName, bIncludeEventGraph);
+    case ECleanupMode::PrintStrings:
+        return ExecutePrintStringsCleanup(Blueprint, GraphName, bIncludeEventGraph);
+    default:
+        return CreateErrorResponse(TEXT("Invalid cleanup mode"));
+    }
+}
+
+FString FCleanupBlueprintGraphCommand::GetCommandName() const
+{
+    return TEXT("cleanup_blueprint_graph");
+}
+
+bool FCleanupBlueprintGraphCommand::ValidateParams(const FString& Parameters) const
+{
+    FString BlueprintName, GraphName, Error;
+    ECleanupMode CleanupMode;
+    bool bIncludeEventGraph;
+    return ParseParameters(Parameters, BlueprintName, CleanupMode, GraphName, bIncludeEventGraph, Error);
+}
+
+bool FCleanupBlueprintGraphCommand::ParseParameters(const FString& JsonString, FString& OutBlueprintName,
+                                                     ECleanupMode& OutCleanupMode, FString& OutGraphName,
+                                                     bool& OutIncludeEventGraph, FString& OutError) const
+{
+    TSharedPtr<FJsonObject> JsonObject;
+    TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(JsonString);
+
+    if (!FJsonSerializer::Deserialize(Reader, JsonObject) || !JsonObject.IsValid())
+    {
+        OutError = TEXT("Invalid JSON parameters");
+        return false;
+    }
+
+    // Required: blueprint_name
+    if (!JsonObject->TryGetStringField(TEXT("blueprint_name"), OutBlueprintName))
+    {
+        OutError = TEXT("Missing required 'blueprint_name' parameter");
+        return false;
+    }
+
+    // Required: cleanup_mode
+    FString CleanupModeStr;
+    if (!JsonObject->TryGetStringField(TEXT("cleanup_mode"), CleanupModeStr))
+    {
+        OutError = TEXT("Missing required 'cleanup_mode' parameter. Options: 'orphans', 'print_strings'");
+        return false;
+    }
+
+    if (CleanupModeStr.Equals(TEXT("orphans"), ESearchCase::IgnoreCase))
+    {
+        OutCleanupMode = ECleanupMode::Orphans;
+    }
+    else if (CleanupModeStr.Equals(TEXT("print_strings"), ESearchCase::IgnoreCase))
+    {
+        OutCleanupMode = ECleanupMode::PrintStrings;
+    }
+    else
+    {
+        OutError = FString::Printf(TEXT("Invalid cleanup_mode '%s'. Options: 'orphans', 'print_strings'"), *CleanupModeStr);
+        return false;
+    }
+
+    // Optional: graph_name
+    JsonObject->TryGetStringField(TEXT("graph_name"), OutGraphName);
+
+    // Optional: include_event_graph (default: false)
+    OutIncludeEventGraph = false;
+    JsonObject->TryGetBoolField(TEXT("include_event_graph"), OutIncludeEventGraph);
+
+    return true;
+}
+
+FString FCleanupBlueprintGraphCommand::ExecuteOrphansCleanup(UBlueprint* Blueprint, const FString& GraphName,
+                                                             bool bIncludeEventGraph)
+{
+    // Collect graphs to process
+    TArray<UEdGraph*> AllGraphs;
+    Blueprint->GetAllGraphs(AllGraphs);
+
+    TArray<UEdGraph*> GraphsToProcess;
+    TArray<FString> SkippedGraphs;
+
+    for (UEdGraph* Graph : AllGraphs)
+    {
+        if (!Graph)
+        {
+            continue;
+        }
+
+        FString CurrentGraphName = Graph->GetName();
+
+        // If specific graph requested, only process that one
+        if (!GraphName.IsEmpty())
+        {
+            if (CurrentGraphName.Equals(GraphName, ESearchCase::IgnoreCase))
+            {
+                GraphsToProcess.Add(Graph);
+            }
+            continue;
+        }
+
+        // Skip EventGraph unless explicitly included
+        if (!bIncludeEventGraph && CurrentGraphName.Equals(TEXT("EventGraph"), ESearchCase::IgnoreCase))
+        {
+            SkippedGraphs.Add(TEXT("EventGraph (excluded by default)"));
+            continue;
+        }
+
+        GraphsToProcess.Add(Graph);
+    }
+
+    // Check if specific graph was requested but not found
+    if (!GraphName.IsEmpty() && GraphsToProcess.Num() == 0)
+    {
+        return CreateErrorResponse(FString::Printf(TEXT("Graph '%s' not found"), *GraphName));
+    }
+
+    // Collect and delete orphaned nodes
+    TArray<FString> DeletedNodeTitles;
+    int32 TotalDeleted = 0;
+
+    const FScopedTransaction Transaction(FText::FromString(TEXT("Delete Orphaned Nodes")));
+
+    for (UEdGraph* Graph : GraphsToProcess)
+    {
+        TArray<FString> OrphanedNodeIds;
+        if (!FGraphUtils::DetectOrphanedNodes(Graph, OrphanedNodeIds))
+        {
+            continue;
+        }
+
+        // Build node ID to node map
+        TMap<FString, UEdGraphNode*> NodeIdMap;
+        for (UEdGraphNode* Node : Graph->Nodes)
+        {
+            if (Node)
+            {
+                NodeIdMap.Add(FGraphUtils::GetReliableNodeId(Node), Node);
+            }
+        }
+
+        // Delete each orphaned node
+        for (const FString& NodeId : OrphanedNodeIds)
+        {
+            UEdGraphNode** NodePtr = NodeIdMap.Find(NodeId);
+            if (!NodePtr || !*NodePtr)
+            {
+                continue;
+            }
+
+            UEdGraphNode* Node = *NodePtr;
+
+            // Skip auto-generated Return Nodes at (0,0)
+            UK2Node_FunctionResult* ResultNode = Cast<UK2Node_FunctionResult>(Node);
+            if (ResultNode && Node->NodePosX == 0 && Node->NodePosY == 0)
+            {
+                bool bHasConnections = false;
+                for (UEdGraphPin* Pin : Node->Pins)
+                {
+                    if (Pin && Pin->LinkedTo.Num() > 0)
+                    {
+                        bHasConnections = true;
+                        break;
+                    }
+                }
+                if (!bHasConnections)
+                {
+                    continue;
+                }
+            }
+
+            FString NodeTitle = Node->GetNodeTitle(ENodeTitleType::ListView).ToString();
+            FString FullTitle = FString::Printf(TEXT("%s [%s]"), *NodeTitle, *Graph->GetName());
+
+            Graph->Modify();
+            Node->Modify();
+
+            for (UEdGraphPin* Pin : Node->Pins)
+            {
+                if (Pin)
+                {
+                    Pin->BreakAllPinLinks();
+                }
+            }
+
+            Graph->RemoveNode(Node);
+            DeletedNodeTitles.Add(FullTitle);
+            TotalDeleted++;
+        }
+    }
+
+    if (TotalDeleted > 0)
+    {
+        FBlueprintEditorUtils::MarkBlueprintAsModified(Blueprint);
+    }
+
+    return CreateSuccessResponse(Blueprint->GetName(), TEXT("orphans"), TotalDeleted, 0, DeletedNodeTitles, SkippedGraphs);
+}
+
+FString FCleanupBlueprintGraphCommand::ExecutePrintStringsCleanup(UBlueprint* Blueprint, const FString& GraphName,
+                                                                   bool bIncludeEventGraph)
+{
+    // Collect graphs to process
+    TArray<UEdGraph*> AllGraphs;
+    Blueprint->GetAllGraphs(AllGraphs);
+
+    TArray<UEdGraph*> GraphsToProcess;
+    TArray<FString> SkippedGraphs;
+
+    for (UEdGraph* Graph : AllGraphs)
+    {
+        if (!Graph)
+        {
+            continue;
+        }
+
+        FString CurrentGraphName = Graph->GetName();
+
+        // If specific graph requested, only process that one
+        if (!GraphName.IsEmpty())
+        {
+            if (CurrentGraphName.Equals(GraphName, ESearchCase::IgnoreCase))
+            {
+                GraphsToProcess.Add(Graph);
+            }
+            continue;
+        }
+
+        // Skip EventGraph unless explicitly included
+        if (!bIncludeEventGraph && CurrentGraphName.Equals(TEXT("EventGraph"), ESearchCase::IgnoreCase))
+        {
+            SkippedGraphs.Add(TEXT("EventGraph (excluded by default)"));
+            continue;
+        }
+
+        GraphsToProcess.Add(Graph);
+    }
+
+    if (!GraphName.IsEmpty() && GraphsToProcess.Num() == 0)
+    {
+        return CreateErrorResponse(FString::Printf(TEXT("Graph '%s' not found"), *GraphName));
+    }
+
+    TArray<FString> DeletedNodeTitles;
+    int32 TotalDeleted = 0;
+    int32 TotalRewired = 0;
+
+    const FScopedTransaction Transaction(FText::FromString(TEXT("Cleanup Print String Nodes")));
+
+    for (UEdGraph* Graph : GraphsToProcess)
+    {
+        // Collect all Print String nodes first (avoid modifying while iterating)
+        TArray<UEdGraphNode*> PrintStringNodes;
+        for (UEdGraphNode* Node : Graph->Nodes)
+        {
+            if (Node && IsPrintStringNode(Node))
+            {
+                PrintStringNodes.Add(Node);
+            }
+        }
+
+        // Process each Print String node
+        for (UEdGraphNode* Node : PrintStringNodes)
+        {
+            UEdGraphPin* ExecIn = GetExecInputPin(Node);
+            UEdGraphPin* ExecOut = GetExecOutputPin(Node);
+
+            bool bIsMiddleware = (ExecIn && ExecIn->LinkedTo.Num() > 0 &&
+                                  ExecOut && ExecOut->LinkedTo.Num() > 0);
+
+            Graph->Modify();
+            Node->Modify();
+
+            if (bIsMiddleware)
+            {
+                // Rewire: connect source's exec to target's exec
+                // Get the source node's output pin that connects to our execute
+                UEdGraphPin* SourceExecOut = ExecIn->LinkedTo[0];
+                // Get the target node's input pin that we connect to
+                UEdGraphPin* TargetExecIn = ExecOut->LinkedTo[0];
+
+                if (SourceExecOut && TargetExecIn)
+                {
+                    // Break existing connections
+                    ExecIn->BreakAllPinLinks();
+                    ExecOut->BreakAllPinLinks();
+
+                    // Create new connection bypassing the Print String
+                    SourceExecOut->MakeLinkTo(TargetExecIn);
+                    TotalRewired++;
+                }
+            }
+
+            // Break any remaining connections (data pins, etc.)
+            for (UEdGraphPin* Pin : Node->Pins)
+            {
+                if (Pin)
+                {
+                    Pin->BreakAllPinLinks();
+                }
+            }
+
+            FString NodeTitle = Node->GetNodeTitle(ENodeTitleType::ListView).ToString();
+            FString FullTitle = FString::Printf(TEXT("%s [%s]%s"), *NodeTitle, *Graph->GetName(),
+                                                bIsMiddleware ? TEXT(" (rewired)") : TEXT(""));
+
+            Graph->RemoveNode(Node);
+            DeletedNodeTitles.Add(FullTitle);
+            TotalDeleted++;
+        }
+    }
+
+    if (TotalDeleted > 0)
+    {
+        FBlueprintEditorUtils::MarkBlueprintAsModified(Blueprint);
+    }
+
+    return CreateSuccessResponse(Blueprint->GetName(), TEXT("print_strings"), TotalDeleted, TotalRewired,
+                                DeletedNodeTitles, SkippedGraphs);
+}
+
+bool FCleanupBlueprintGraphCommand::IsPrintStringNode(UEdGraphNode* Node) const
+{
+    UK2Node_CallFunction* FuncNode = Cast<UK2Node_CallFunction>(Node);
+    if (!FuncNode)
+    {
+        return false;
+    }
+
+    UFunction* Func = FuncNode->GetTargetFunction();
+    if (!Func)
+    {
+        return false;
+    }
+
+    // Check if this is a PrintString function
+    FString FuncName = Func->GetName();
+    return FuncName.Equals(TEXT("PrintString"), ESearchCase::IgnoreCase) ||
+           FuncName.Contains(TEXT("PrintString"));
+}
+
+UEdGraphPin* FCleanupBlueprintGraphCommand::GetExecInputPin(UEdGraphNode* Node) const
+{
+    for (UEdGraphPin* Pin : Node->Pins)
+    {
+        if (Pin && Pin->PinType.PinCategory == UEdGraphSchema_K2::PC_Exec &&
+            Pin->Direction == EGPD_Input)
+        {
+            return Pin;
+        }
+    }
+    return nullptr;
+}
+
+UEdGraphPin* FCleanupBlueprintGraphCommand::GetExecOutputPin(UEdGraphNode* Node) const
+{
+    for (UEdGraphPin* Pin : Node->Pins)
+    {
+        if (Pin && Pin->PinType.PinCategory == UEdGraphSchema_K2::PC_Exec &&
+            Pin->Direction == EGPD_Output)
+        {
+            return Pin;
+        }
+    }
+    return nullptr;
+}
+
+FString FCleanupBlueprintGraphCommand::CreateSuccessResponse(const FString& BlueprintName, const FString& CleanupMode,
+                                                              int32 DeletedCount, int32 RewiredCount,
+                                                              const TArray<FString>& DeletedNodeTitles,
+                                                              const TArray<FString>& SkippedGraphs) const
+{
+    TSharedPtr<FJsonObject> ResponseObj = MakeShared<FJsonObject>();
+    ResponseObj->SetBoolField(TEXT("success"), true);
+    ResponseObj->SetStringField(TEXT("blueprint_name"), BlueprintName);
+    ResponseObj->SetStringField(TEXT("cleanup_mode"), CleanupMode);
+    ResponseObj->SetNumberField(TEXT("deleted_count"), DeletedCount);
+
+    if (CleanupMode.Equals(TEXT("print_strings")))
+    {
+        ResponseObj->SetNumberField(TEXT("rewired_count"), RewiredCount);
+    }
+
+    TArray<TSharedPtr<FJsonValue>> DeletedArray;
+    for (const FString& Title : DeletedNodeTitles)
+    {
+        DeletedArray.Add(MakeShared<FJsonValueString>(Title));
+    }
+    ResponseObj->SetArrayField(TEXT("deleted_nodes"), DeletedArray);
+
+    if (SkippedGraphs.Num() > 0)
+    {
+        TArray<TSharedPtr<FJsonValue>> SkippedArray;
+        for (const FString& Skipped : SkippedGraphs)
+        {
+            SkippedArray.Add(MakeShared<FJsonValueString>(Skipped));
+        }
+        ResponseObj->SetArrayField(TEXT("skipped_graphs"), SkippedArray);
+    }
+
+    FString OutputString;
+    TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&OutputString);
+    FJsonSerializer::Serialize(ResponseObj.ToSharedRef(), Writer);
+
+    return OutputString;
+}
+
+FString FCleanupBlueprintGraphCommand::CreateErrorResponse(const FString& ErrorMessage) const
+{
+    TSharedPtr<FJsonObject> ResponseObj = MakeShared<FJsonObject>();
+    ResponseObj->SetBoolField(TEXT("success"), false);
+    ResponseObj->SetStringField(TEXT("error"), ErrorMessage);
+
+    FString OutputString;
+    TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&OutputString);
+    FJsonSerializer::Serialize(ResponseObj.ToSharedRef(), Writer);
+
+    return OutputString;
+}

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/GraphManipulationCommandRegistration.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/GraphManipulationCommandRegistration.cpp
@@ -6,6 +6,7 @@
 #include "Commands/GraphManipulation/SetNodePinValueCommand.h"
 #include "Commands/GraphManipulation/AutoArrangeNodesCommand.h"
 #include "Commands/GraphManipulation/DeleteOrphanedNodesCommand.h"
+#include "Commands/GraphManipulation/CleanupBlueprintGraphCommand.h"
 #include "Services/BlueprintNodeService.h"
 #include "Services/BlueprintService.h"
 
@@ -26,6 +27,7 @@ void FGraphManipulationCommandRegistration::RegisterAllGraphManipulationCommands
     RegisterSetNodePinValueCommand();
     RegisterAutoArrangeNodesCommand();
     RegisterDeleteOrphanedNodesCommand();
+    RegisterCleanupBlueprintGraphCommand();
 
     UE_LOG(LogTemp, Log, TEXT("FGraphManipulationCommandRegistration::RegisterAllGraphManipulationCommands: Registered %d Graph Manipulation commands"), 
         RegisteredCommandNames.Num());
@@ -85,6 +87,12 @@ void FGraphManipulationCommandRegistration::RegisterAutoArrangeNodesCommand()
 void FGraphManipulationCommandRegistration::RegisterDeleteOrphanedNodesCommand()
 {
     TSharedPtr<FDeleteOrphanedNodesCommand> Command = MakeShared<FDeleteOrphanedNodesCommand>(FBlueprintService::Get());
+    RegisterAndTrackCommand(Command);
+}
+
+void FGraphManipulationCommandRegistration::RegisterCleanupBlueprintGraphCommand()
+{
+    TSharedPtr<FCleanupBlueprintGraphCommand> Command = MakeShared<FCleanupBlueprintGraphCommand>(FBlueprintService::Get());
     RegisterAndTrackCommand(Command);
 }
 

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Project/DuplicateAssetCommand.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Project/DuplicateAssetCommand.cpp
@@ -1,0 +1,107 @@
+#include "Commands/Project/DuplicateAssetCommand.h"
+#include "Utils/UnrealMCPCommonUtils.h"
+
+FDuplicateAssetCommand::FDuplicateAssetCommand(TSharedPtr<IProjectService> InProjectService)
+    : ProjectService(InProjectService)
+{
+}
+
+bool FDuplicateAssetCommand::ValidateParams(const FString& Parameters) const
+{
+    TSharedPtr<FJsonObject> JsonObject;
+    TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Parameters);
+
+    if (!FJsonSerializer::Deserialize(Reader, JsonObject) || !JsonObject.IsValid())
+    {
+        return false;
+    }
+
+    // source_path is required
+    FString SourcePath;
+    if (!JsonObject->TryGetStringField(TEXT("source_path"), SourcePath) || SourcePath.IsEmpty())
+    {
+        return false;
+    }
+
+    // new_name is required
+    FString NewName;
+    if (!JsonObject->TryGetStringField(TEXT("new_name"), NewName) || NewName.IsEmpty())
+    {
+        return false;
+    }
+
+    return true;
+}
+
+FString FDuplicateAssetCommand::Execute(const FString& Parameters)
+{
+    // Parse JSON parameters
+    TSharedPtr<FJsonObject> JsonObject;
+    TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Parameters);
+
+    if (!FJsonSerializer::Deserialize(Reader, JsonObject) || !JsonObject.IsValid())
+    {
+        TSharedPtr<FJsonObject> ErrorResponse = FUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Invalid JSON parameters"));
+        FString OutputString;
+        TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&OutputString);
+        FJsonSerializer::Serialize(ErrorResponse.ToSharedRef(), Writer);
+        return OutputString;
+    }
+
+    // Validate parameters
+    if (!ValidateParams(Parameters))
+    {
+        TSharedPtr<FJsonObject> ErrorResponse = FUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Parameter validation failed. Required: source_path (string), new_name (string). Optional: destination_path (string)"));
+        FString OutputString;
+        TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&OutputString);
+        FJsonSerializer::Serialize(ErrorResponse.ToSharedRef(), Writer);
+        return OutputString;
+    }
+
+    // Extract parameters
+    FString SourcePath = JsonObject->GetStringField(TEXT("source_path"));
+    FString NewName = JsonObject->GetStringField(TEXT("new_name"));
+
+    // destination_path is optional - if not provided, use the same directory as source
+    FString DestinationPath;
+    if (!JsonObject->TryGetStringField(TEXT("destination_path"), DestinationPath) || DestinationPath.IsEmpty())
+    {
+        // Extract directory from source path
+        int32 LastSlashIndex;
+        if (SourcePath.FindLastChar('/', LastSlashIndex))
+        {
+            DestinationPath = SourcePath.Left(LastSlashIndex);
+        }
+        else
+        {
+            DestinationPath = TEXT("/Game");
+        }
+    }
+
+    // Execute the operation
+    FString NewAssetPath;
+    FString Error;
+    if (!ProjectService->DuplicateAsset(SourcePath, DestinationPath, NewName, NewAssetPath, Error))
+    {
+        TSharedPtr<FJsonObject> ErrorResponse = FUnrealMCPCommonUtils::CreateErrorResponse(Error);
+        FString OutputString;
+        TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&OutputString);
+        FJsonSerializer::Serialize(ErrorResponse.ToSharedRef(), Writer);
+        return OutputString;
+    }
+
+    // Create success response
+    TSharedPtr<FJsonObject> ResponseData = MakeShared<FJsonObject>();
+    ResponseData->SetBoolField(TEXT("success"), true);
+    ResponseData->SetStringField(TEXT("source_path"), SourcePath);
+    ResponseData->SetStringField(TEXT("destination_path"), DestinationPath);
+    ResponseData->SetStringField(TEXT("new_name"), NewName);
+    ResponseData->SetStringField(TEXT("new_asset_path"), NewAssetPath);
+    ResponseData->SetStringField(TEXT("message"), FString::Printf(TEXT("Successfully duplicated asset to %s"), *NewAssetPath));
+
+    // Convert response to JSON string
+    FString OutputString;
+    TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&OutputString);
+    FJsonSerializer::Serialize(ResponseData.ToSharedRef(), Writer);
+    return OutputString;
+}

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/ProjectCommandRegistration.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/ProjectCommandRegistration.cpp
@@ -11,6 +11,7 @@
 #include "Commands/Project/UpdateStructCommand.h"
 #include "Commands/Project/GetProjectMetadataCommand.h"
 #include "Commands/Project/GetStructPinNamesCommand.h"
+#include "Commands/Project/DuplicateAssetCommand.h"
 #include "Services/IProjectService.h"
 
 void FProjectCommandRegistration::RegisterCommands(FUnrealMCPCommandRegistry& Registry, TSharedPtr<IProjectService> ProjectService)
@@ -49,6 +50,9 @@ void FProjectCommandRegistration::RegisterCommands(FUnrealMCPCommandRegistry& Re
 
     // Register struct pin names command for discovering struct field/pin names
     Registry.RegisterCommand(MakeShared<FGetStructPinNamesCommand>(ProjectService));
+
+    // Register asset duplication command
+    Registry.RegisterCommand(MakeShared<FDuplicateAssetCommand>(ProjectService));
 
     UE_LOG(LogTemp, Log, TEXT("Registered project commands successfully"));
 }

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/GraphManipulation/CleanupBlueprintGraphCommand.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/GraphManipulation/CleanupBlueprintGraphCommand.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Commands/IUnrealMCPCommand.h"
+
+class IBlueprintService;
+
+/**
+ * Unified command for cleaning up Blueprint graphs.
+ *
+ * Supports multiple cleanup modes:
+ * - "orphans": Delete orphaned nodes not reachable from entry points
+ * - "print_strings": Delete Print String nodes and rewire execution flow
+ *
+ * For print_strings mode:
+ * - If Print String is middleware (has both execute input and then output connected):
+ *   Rewires the source node's exec to the target node's exec, then deletes
+ * - If Print String is a dead end (only execute input connected):
+ *   Simply deletes the node
+ */
+class UNREALMCP_API FCleanupBlueprintGraphCommand : public IUnrealMCPCommand
+{
+public:
+    FCleanupBlueprintGraphCommand(IBlueprintService& InBlueprintService);
+
+    virtual FString Execute(const FString& Parameters) override;
+    virtual FString GetCommandName() const override;
+    virtual bool ValidateParams(const FString& Parameters) const override;
+
+private:
+    IBlueprintService& BlueprintService;
+
+    /** Cleanup mode enum */
+    enum class ECleanupMode
+    {
+        Orphans,
+        PrintStrings
+    };
+
+    /**
+     * Parse command parameters
+     */
+    bool ParseParameters(const FString& JsonString, FString& OutBlueprintName,
+                        ECleanupMode& OutCleanupMode, FString& OutGraphName,
+                        bool& OutIncludeEventGraph, FString& OutError) const;
+
+    /**
+     * Execute orphans cleanup (delegates to existing logic)
+     */
+    FString ExecuteOrphansCleanup(UBlueprint* Blueprint, const FString& GraphName,
+                                  bool bIncludeEventGraph);
+
+    /**
+     * Execute print strings cleanup
+     */
+    FString ExecutePrintStringsCleanup(UBlueprint* Blueprint, const FString& GraphName,
+                                       bool bIncludeEventGraph);
+
+    /**
+     * Check if a node is a Print String node
+     */
+    bool IsPrintStringNode(UEdGraphNode* Node) const;
+
+    /**
+     * Get the exec input pin for a node
+     */
+    UEdGraphPin* GetExecInputPin(UEdGraphNode* Node) const;
+
+    /**
+     * Get the exec output pin (then) for a node
+     */
+    UEdGraphPin* GetExecOutputPin(UEdGraphNode* Node) const;
+
+    FString CreateSuccessResponse(const FString& BlueprintName, const FString& CleanupMode,
+                                 int32 DeletedCount, int32 RewiredCount,
+                                 const TArray<FString>& DeletedNodeTitles,
+                                 const TArray<FString>& SkippedGraphs) const;
+    FString CreateErrorResponse(const FString& ErrorMessage) const;
+};

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/GraphManipulationCommandRegistration.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/GraphManipulationCommandRegistration.h
@@ -24,6 +24,7 @@ private:
     static void RegisterSetNodePinValueCommand();
     static void RegisterAutoArrangeNodesCommand();
     static void RegisterDeleteOrphanedNodesCommand();
+    static void RegisterCleanupBlueprintGraphCommand();
     
     /** Helper to register and track a command */
     static void RegisterAndTrackCommand(TSharedPtr<IUnrealMCPCommand> Command);

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Project/DuplicateAssetCommand.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Project/DuplicateAssetCommand.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Commands/IUnrealMCPCommand.h"
+#include "Services/IProjectService.h"
+
+/**
+ * Command for duplicating assets (Blueprints, Widgets, DataTables, etc.)
+ */
+class UNREALMCP_API FDuplicateAssetCommand : public IUnrealMCPCommand
+{
+public:
+    FDuplicateAssetCommand(TSharedPtr<IProjectService> InProjectService);
+    virtual ~FDuplicateAssetCommand() = default;
+
+    // IUnrealMCPCommand interface
+    virtual FString Execute(const FString& Parameters) override;
+    virtual FString GetCommandName() const override { return TEXT("duplicate_asset"); }
+    virtual bool ValidateParams(const FString& Parameters) const override;
+
+private:
+    TSharedPtr<IProjectService> ProjectService;
+};

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/UMG/GetWidgetBlueprintMetadataCommand.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/UMG/GetWidgetBlueprintMetadataCommand.h
@@ -71,6 +71,12 @@ private:
 	/** Helper to get available delegate events for a widget */
 	TArray<FString> GetAvailableDelegateEvents(class UWidget* Widget) const;
 
+	/**
+	 * Find and load widget blueprint with retry mechanism.
+	 * Handles transient asset loading issues by retrying after a brief delay.
+	 */
+	class UWidgetBlueprint* FindWidgetBlueprintWithRetry(const FString& WidgetName, TArray<FString>& OutAttemptedPaths) const;
+
 	/** Response builders */
 	TSharedPtr<FJsonObject> CreateSuccessResponse(const TSharedPtr<FJsonObject>& MetadataObj) const;
 	TSharedPtr<FJsonObject> CreateErrorResponse(const FString& ErrorMessage) const;

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Services/IProjectService.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Services/IProjectService.h
@@ -37,4 +37,7 @@ public:
     
     // Utility operations
     virtual FString GetProjectDirectory() const = 0;
+
+    // Asset operations
+    virtual bool DuplicateAsset(const FString& SourcePath, const FString& DestinationPath, const FString& NewName, FString& OutNewAssetPath, FString& OutError) = 0;
 };

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Services/ProjectService.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Services/ProjectService.h
@@ -27,6 +27,7 @@ public:
     virtual TArray<TSharedPtr<FJsonObject>> ListInputActions(const FString& Path, bool& bOutSuccess, FString& OutError) override;
     virtual TArray<TSharedPtr<FJsonObject>> ListInputMappingContexts(const FString& Path, bool& bOutSuccess, FString& OutError) override;
     virtual FString GetProjectDirectory() const override;
+    virtual bool DuplicateAsset(const FString& SourcePath, const FString& DestinationPath, const FString& NewName, FString& OutNewAssetPath, FString& OutError) override;
 
 private:
     // Helper methods for struct operations

--- a/Python/project_tools/project_tools.py
+++ b/Python/project_tools/project_tools.py
@@ -559,4 +559,91 @@ def register_project_tools(mcp: FastMCP):
             logger.error(error_msg)
             return {"success": False, "message": error_msg}
 
+    @mcp.tool()
+    def duplicate_asset(
+        ctx: Context,
+        source_path: str,
+        new_name: str,
+        destination_path: str = None
+    ) -> Dict[str, Any]:
+        """
+        Duplicate an existing asset (Blueprint, Widget, DataTable, Material, etc.) to a new location.
+
+        This is useful for creating copies of existing assets as starting points for new functionality,
+        avoiding the need to recreate complex assets from scratch.
+
+        Args:
+            source_path: Full path to the source asset (e.g., "/Game/Inventory/UI/WBP_InventorySlot")
+            new_name: Name for the new asset (e.g., "WBP_LootSlot")
+            destination_path: Optional destination folder path. If not provided, uses the same
+                            folder as the source asset.
+
+        Returns:
+            Dictionary containing:
+            - success: Whether the duplication succeeded
+            - source_path: The original asset path
+            - destination_path: The destination folder
+            - new_name: The new asset name
+            - new_asset_path: Full path to the newly created asset
+            - message: Status message
+
+        Examples:
+            # Duplicate an inventory slot to create a loot slot in the same folder
+            duplicate_asset(
+                source_path="/Game/Inventory/UI/WBP_InventorySlot",
+                new_name="WBP_LootSlot"
+            )
+
+            # Duplicate to a different folder
+            duplicate_asset(
+                source_path="/Game/Inventory/UI/WBP_InventorySlot",
+                new_name="WBP_LootSlot",
+                destination_path="/Game/Loot/UI"
+            )
+
+            # Duplicate a Blueprint actor
+            duplicate_asset(
+                source_path="/Game/Blueprints/BP_BaseEnemy",
+                new_name="BP_BossEnemy",
+                destination_path="/Game/Blueprints/Enemies"
+            )
+
+            # Duplicate a DataTable
+            duplicate_asset(
+                source_path="/Game/Data/DT_Items",
+                new_name="DT_LootItems",
+                destination_path="/Game/Loot/Data"
+            )
+        """
+        from utils.unreal_connection_utils import get_unreal_engine_connection as get_unreal_connection
+
+        try:
+            unreal = get_unreal_connection()
+            if not unreal:
+                logger.error("Failed to connect to Unreal Engine")
+                return {"success": False, "message": "Failed to connect to Unreal Engine"}
+
+            params = {
+                "source_path": source_path,
+                "new_name": new_name
+            }
+
+            if destination_path:
+                params["destination_path"] = destination_path
+
+            logger.info(f"Duplicating asset '{source_path}' to '{new_name}'")
+            response = unreal.send_command("duplicate_asset", params)
+
+            if not response:
+                logger.error("No response from Unreal Engine")
+                return {"success": False, "message": "No response from Unreal Engine"}
+
+            logger.info(f"Duplicate asset response: {response}")
+            return response
+
+        except Exception as e:
+            error_msg = f"Error duplicating asset: {e}"
+            logger.error(error_msg)
+            return {"success": False, "message": error_msg}
+
     logger.info("Project tools registered successfully")


### PR DESCRIPTION
New unified cleanup_blueprint_graph MCP tool with two modes:
- "orphans": Delete orphaned nodes not reachable from entry points
- "print_strings": Delete Print String nodes and rewire execution flow when they're middleware (has both execute input AND then output connected)

New duplicate_asset command for copying existing assets to new locations, useful for creating copies of Blueprints, Widgets, DataTables, etc.

Also includes:
- Loot system implementation plan documentation
- Widget metadata hierarchy field improvements
- CLAUDE.md updates for test-first phase planning

🤖 Generated with [Claude Code](https://claude.com/claude-code)