### PR TITLE
Add missing Python MCP wrappers for Niagara/Material, fix color curve…

### DIFF
--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Niagara/RemoveEmitterFromSystemCommand.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Niagara/RemoveEmitterFromSystemCommand.cpp
@@ -1,0 +1,120 @@
+#include "Commands/Niagara/RemoveEmitterFromSystemCommand.h"
+#include "Dom/JsonObject.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonWriter.h"
+
+FRemoveEmitterFromSystemCommand::FRemoveEmitterFromSystemCommand(INiagaraService& InNiagaraService)
+    : NiagaraService(InNiagaraService)
+{
+}
+
+FString FRemoveEmitterFromSystemCommand::Execute(const FString& Parameters)
+{
+    FRemoveEmitterParams Params;
+    FString Error;
+
+    if (!ParseParameters(Parameters, Params, Error))
+    {
+        return CreateErrorResponse(Error);
+    }
+
+    bool bSuccess = NiagaraService.RemoveEmitterFromSystem(
+        Params.SystemPath,
+        Params.EmitterName,
+        Error
+    );
+
+    if (!bSuccess)
+    {
+        return CreateErrorResponse(Error);
+    }
+
+    return CreateSuccessResponse(Params.SystemPath, Params.EmitterName);
+}
+
+FString FRemoveEmitterFromSystemCommand::GetCommandName() const
+{
+    return TEXT("remove_emitter_from_system");
+}
+
+bool FRemoveEmitterFromSystemCommand::ValidateParams(const FString& Parameters) const
+{
+    FRemoveEmitterParams Params;
+    FString Error;
+    return ParseParameters(Parameters, Params, Error);
+}
+
+bool FRemoveEmitterFromSystemCommand::ParseParameters(const FString& JsonString, FRemoveEmitterParams& OutParams, FString& OutError) const
+{
+    TSharedPtr<FJsonObject> JsonObject;
+    TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(JsonString);
+
+    if (!FJsonSerializer::Deserialize(Reader, JsonObject) || !JsonObject.IsValid())
+    {
+        OutError = TEXT("Invalid JSON parameters");
+        return false;
+    }
+
+    // Try both "system_path" and "system" for flexibility
+    if (!JsonObject->TryGetStringField(TEXT("system_path"), OutParams.SystemPath))
+    {
+        if (!JsonObject->TryGetStringField(TEXT("system"), OutParams.SystemPath))
+        {
+            OutError = TEXT("Missing 'system_path' or 'system' parameter");
+            return false;
+        }
+    }
+
+    // Try both "emitter_name" and "emitter" for flexibility
+    if (!JsonObject->TryGetStringField(TEXT("emitter_name"), OutParams.EmitterName))
+    {
+        if (!JsonObject->TryGetStringField(TEXT("emitter"), OutParams.EmitterName))
+        {
+            OutError = TEXT("Missing 'emitter_name' or 'emitter' parameter");
+            return false;
+        }
+    }
+
+    if (OutParams.SystemPath.IsEmpty())
+    {
+        OutError = TEXT("System path cannot be empty");
+        return false;
+    }
+
+    if (OutParams.EmitterName.IsEmpty())
+    {
+        OutError = TEXT("Emitter name cannot be empty");
+        return false;
+    }
+
+    return true;
+}
+
+FString FRemoveEmitterFromSystemCommand::CreateSuccessResponse(const FString& SystemPath, const FString& EmitterName) const
+{
+    TSharedPtr<FJsonObject> ResponseObj = MakeShared<FJsonObject>();
+    ResponseObj->SetBoolField(TEXT("success"), true);
+    ResponseObj->SetStringField(TEXT("system"), SystemPath);
+    ResponseObj->SetStringField(TEXT("emitter"), EmitterName);
+    ResponseObj->SetStringField(TEXT("message"),
+        FString::Printf(TEXT("Emitter '%s' removed from system successfully"), *EmitterName));
+
+    FString OutputString;
+    TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&OutputString);
+    FJsonSerializer::Serialize(ResponseObj.ToSharedRef(), Writer);
+
+    return OutputString;
+}
+
+FString FRemoveEmitterFromSystemCommand::CreateErrorResponse(const FString& ErrorMessage) const
+{
+    TSharedPtr<FJsonObject> ErrorObj = MakeShared<FJsonObject>();
+    ErrorObj->SetBoolField(TEXT("success"), false);
+    ErrorObj->SetStringField(TEXT("error"), ErrorMessage);
+
+    FString OutputString;
+    TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&OutputString);
+    FJsonSerializer::Serialize(ErrorObj.ToSharedRef(), Writer);
+
+    return OutputString;
+}

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Niagara/SetEmitterEnabledCommand.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Niagara/SetEmitterEnabledCommand.cpp
@@ -1,0 +1,128 @@
+#include "Commands/Niagara/SetEmitterEnabledCommand.h"
+#include "Dom/JsonObject.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonWriter.h"
+
+FSetEmitterEnabledCommand::FSetEmitterEnabledCommand(INiagaraService& InNiagaraService)
+    : NiagaraService(InNiagaraService)
+{
+}
+
+FString FSetEmitterEnabledCommand::Execute(const FString& Parameters)
+{
+    FSetEmitterEnabledParams Params;
+    FString Error;
+
+    if (!ParseParameters(Parameters, Params, Error))
+    {
+        return CreateErrorResponse(Error);
+    }
+
+    bool bSuccess = NiagaraService.SetEmitterEnabled(
+        Params.SystemPath,
+        Params.EmitterName,
+        Params.bEnabled,
+        Error
+    );
+
+    if (!bSuccess)
+    {
+        return CreateErrorResponse(Error);
+    }
+
+    return CreateSuccessResponse(Params.EmitterName, Params.bEnabled);
+}
+
+FString FSetEmitterEnabledCommand::GetCommandName() const
+{
+    return TEXT("set_emitter_enabled");
+}
+
+bool FSetEmitterEnabledCommand::ValidateParams(const FString& Parameters) const
+{
+    FSetEmitterEnabledParams Params;
+    FString Error;
+    return ParseParameters(Parameters, Params, Error);
+}
+
+bool FSetEmitterEnabledCommand::ParseParameters(const FString& JsonString, FSetEmitterEnabledParams& OutParams, FString& OutError) const
+{
+    TSharedPtr<FJsonObject> JsonObject;
+    TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(JsonString);
+
+    if (!FJsonSerializer::Deserialize(Reader, JsonObject) || !JsonObject.IsValid())
+    {
+        OutError = TEXT("Invalid JSON parameters");
+        return false;
+    }
+
+    // Try both "system_path" and "system" for flexibility
+    if (!JsonObject->TryGetStringField(TEXT("system_path"), OutParams.SystemPath))
+    {
+        if (!JsonObject->TryGetStringField(TEXT("system"), OutParams.SystemPath))
+        {
+            OutError = TEXT("Missing 'system_path' or 'system' parameter");
+            return false;
+        }
+    }
+
+    // Try both "emitter_name" and "emitter" for flexibility
+    if (!JsonObject->TryGetStringField(TEXT("emitter_name"), OutParams.EmitterName))
+    {
+        if (!JsonObject->TryGetStringField(TEXT("emitter"), OutParams.EmitterName))
+        {
+            OutError = TEXT("Missing 'emitter_name' or 'emitter' parameter");
+            return false;
+        }
+    }
+
+    // Default to enabled=true if not specified
+    if (!JsonObject->TryGetBoolField(TEXT("enabled"), OutParams.bEnabled))
+    {
+        OutParams.bEnabled = true;
+    }
+
+    if (OutParams.SystemPath.IsEmpty())
+    {
+        OutError = TEXT("System path cannot be empty");
+        return false;
+    }
+
+    if (OutParams.EmitterName.IsEmpty())
+    {
+        OutError = TEXT("Emitter name cannot be empty");
+        return false;
+    }
+
+    return true;
+}
+
+FString FSetEmitterEnabledCommand::CreateSuccessResponse(const FString& EmitterName, bool bEnabled) const
+{
+    TSharedPtr<FJsonObject> ResponseObj = MakeShared<FJsonObject>();
+    ResponseObj->SetBoolField(TEXT("success"), true);
+    ResponseObj->SetStringField(TEXT("emitter"), EmitterName);
+    ResponseObj->SetBoolField(TEXT("enabled"), bEnabled);
+    ResponseObj->SetStringField(TEXT("message"),
+        FString::Printf(TEXT("Emitter '%s' %s successfully"),
+            *EmitterName, bEnabled ? TEXT("enabled") : TEXT("disabled")));
+
+    FString OutputString;
+    TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&OutputString);
+    FJsonSerializer::Serialize(ResponseObj.ToSharedRef(), Writer);
+
+    return OutputString;
+}
+
+FString FSetEmitterEnabledCommand::CreateErrorResponse(const FString& ErrorMessage) const
+{
+    TSharedPtr<FJsonObject> ErrorObj = MakeShared<FJsonObject>();
+    ErrorObj->SetBoolField(TEXT("success"), false);
+    ErrorObj->SetStringField(TEXT("error"), ErrorMessage);
+
+    FString OutputString;
+    TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&OutputString);
+    FJsonSerializer::Serialize(ErrorObj.ToSharedRef(), Writer);
+
+    return OutputString;
+}

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Niagara/SetModuleColorCurveInputCommand.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Niagara/SetModuleColorCurveInputCommand.cpp
@@ -1,0 +1,164 @@
+#include "Commands/Niagara/SetModuleColorCurveInputCommand.h"
+#include "Dom/JsonObject.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonWriter.h"
+
+FSetModuleColorCurveInputCommand::FSetModuleColorCurveInputCommand(INiagaraService& InNiagaraService)
+    : NiagaraService(InNiagaraService)
+{
+}
+
+FString FSetModuleColorCurveInputCommand::Execute(const FString& Parameters)
+{
+    FNiagaraModuleColorCurveInputParams Params;
+    FString Error;
+
+    if (!ParseParameters(Parameters, Params, Error))
+    {
+        return CreateErrorResponse(Error);
+    }
+
+    bool bSuccess = NiagaraService.SetModuleColorCurveInput(Params, Error);
+
+    if (!bSuccess)
+    {
+        return CreateErrorResponse(Error);
+    }
+
+    return CreateSuccessResponse(Params.ModuleName, Params.InputName, Params.Keyframes.Num());
+}
+
+FString FSetModuleColorCurveInputCommand::GetCommandName() const
+{
+    return TEXT("set_module_color_curve_input");
+}
+
+bool FSetModuleColorCurveInputCommand::ValidateParams(const FString& Parameters) const
+{
+    FNiagaraModuleColorCurveInputParams Params;
+    FString Error;
+    return ParseParameters(Parameters, Params, Error);
+}
+
+bool FSetModuleColorCurveInputCommand::ParseParameters(const FString& JsonString, FNiagaraModuleColorCurveInputParams& OutParams, FString& OutError) const
+{
+    TSharedPtr<FJsonObject> JsonObject;
+    TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(JsonString);
+
+    if (!FJsonSerializer::Deserialize(Reader, JsonObject) || !JsonObject.IsValid())
+    {
+        OutError = TEXT("Invalid JSON parameters");
+        return false;
+    }
+
+    // Required parameters
+    if (!JsonObject->TryGetStringField(TEXT("system_path"), OutParams.SystemPath))
+    {
+        OutError = TEXT("Missing 'system_path' parameter");
+        return false;
+    }
+
+    if (!JsonObject->TryGetStringField(TEXT("emitter_name"), OutParams.EmitterName))
+    {
+        OutError = TEXT("Missing 'emitter_name' parameter");
+        return false;
+    }
+
+    if (!JsonObject->TryGetStringField(TEXT("module_name"), OutParams.ModuleName))
+    {
+        OutError = TEXT("Missing 'module_name' parameter");
+        return false;
+    }
+
+    if (!JsonObject->TryGetStringField(TEXT("stage"), OutParams.Stage))
+    {
+        OutError = TEXT("Missing 'stage' parameter");
+        return false;
+    }
+
+    if (!JsonObject->TryGetStringField(TEXT("input_name"), OutParams.InputName))
+    {
+        OutError = TEXT("Missing 'input_name' parameter");
+        return false;
+    }
+
+    // Parse keyframes array
+    const TArray<TSharedPtr<FJsonValue>>* KeyframesArray = nullptr;
+    if (!JsonObject->TryGetArrayField(TEXT("keyframes"), KeyframesArray))
+    {
+        OutError = TEXT("Missing 'keyframes' array parameter");
+        return false;
+    }
+
+    for (const TSharedPtr<FJsonValue>& KeyframeValue : *KeyframesArray)
+    {
+        const TSharedPtr<FJsonObject>* KeyframeObj = nullptr;
+        if (!KeyframeValue->TryGetObject(KeyframeObj) || !KeyframeObj->IsValid())
+        {
+            OutError = TEXT("Invalid keyframe object in array");
+            return false;
+        }
+
+        FNiagaraColorCurveKeyframe Keyframe;
+
+        if (!(*KeyframeObj)->TryGetNumberField(TEXT("time"), Keyframe.Time))
+        {
+            OutError = TEXT("Missing 'time' field in keyframe");
+            return false;
+        }
+
+        // RGBA values - default to 1.0 if not provided
+        if (!(*KeyframeObj)->TryGetNumberField(TEXT("r"), Keyframe.R))
+        {
+            Keyframe.R = 1.0f;
+        }
+        if (!(*KeyframeObj)->TryGetNumberField(TEXT("g"), Keyframe.G))
+        {
+            Keyframe.G = 1.0f;
+        }
+        if (!(*KeyframeObj)->TryGetNumberField(TEXT("b"), Keyframe.B))
+        {
+            Keyframe.B = 1.0f;
+        }
+        if (!(*KeyframeObj)->TryGetNumberField(TEXT("a"), Keyframe.A))
+        {
+            Keyframe.A = 1.0f;
+        }
+
+        OutParams.Keyframes.Add(Keyframe);
+    }
+
+    // Validate using the struct's validation
+    return OutParams.IsValid(OutError);
+}
+
+FString FSetModuleColorCurveInputCommand::CreateSuccessResponse(const FString& ModuleName, const FString& InputName, int32 KeyframeCount) const
+{
+    TSharedPtr<FJsonObject> ResponseObj = MakeShared<FJsonObject>();
+    ResponseObj->SetBoolField(TEXT("success"), true);
+    ResponseObj->SetStringField(TEXT("module_name"), ModuleName);
+    ResponseObj->SetStringField(TEXT("input_name"), InputName);
+    ResponseObj->SetNumberField(TEXT("keyframe_count"), KeyframeCount);
+    ResponseObj->SetStringField(TEXT("message"),
+        FString::Printf(TEXT("Set color curve input '%s' on module '%s' with %d keyframes"),
+            *InputName, *ModuleName, KeyframeCount));
+
+    FString OutputString;
+    TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&OutputString);
+    FJsonSerializer::Serialize(ResponseObj.ToSharedRef(), Writer);
+
+    return OutputString;
+}
+
+FString FSetModuleColorCurveInputCommand::CreateErrorResponse(const FString& ErrorMessage) const
+{
+    TSharedPtr<FJsonObject> ErrorObj = MakeShared<FJsonObject>();
+    ErrorObj->SetBoolField(TEXT("success"), false);
+    ErrorObj->SetStringField(TEXT("error"), ErrorMessage);
+
+    FString OutputString;
+    TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&OutputString);
+    FJsonSerializer::Serialize(ErrorObj.ToSharedRef(), Writer);
+
+    return OutputString;
+}

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Niagara/SetModuleCurveInputCommand.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Niagara/SetModuleCurveInputCommand.cpp
@@ -1,0 +1,152 @@
+#include "Commands/Niagara/SetModuleCurveInputCommand.h"
+#include "Dom/JsonObject.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonWriter.h"
+
+FSetModuleCurveInputCommand::FSetModuleCurveInputCommand(INiagaraService& InNiagaraService)
+    : NiagaraService(InNiagaraService)
+{
+}
+
+FString FSetModuleCurveInputCommand::Execute(const FString& Parameters)
+{
+    FNiagaraModuleCurveInputParams Params;
+    FString Error;
+
+    if (!ParseParameters(Parameters, Params, Error))
+    {
+        return CreateErrorResponse(Error);
+    }
+
+    bool bSuccess = NiagaraService.SetModuleCurveInput(Params, Error);
+
+    if (!bSuccess)
+    {
+        return CreateErrorResponse(Error);
+    }
+
+    return CreateSuccessResponse(Params.ModuleName, Params.InputName, Params.Keyframes.Num());
+}
+
+FString FSetModuleCurveInputCommand::GetCommandName() const
+{
+    return TEXT("set_module_curve_input");
+}
+
+bool FSetModuleCurveInputCommand::ValidateParams(const FString& Parameters) const
+{
+    FNiagaraModuleCurveInputParams Params;
+    FString Error;
+    return ParseParameters(Parameters, Params, Error);
+}
+
+bool FSetModuleCurveInputCommand::ParseParameters(const FString& JsonString, FNiagaraModuleCurveInputParams& OutParams, FString& OutError) const
+{
+    TSharedPtr<FJsonObject> JsonObject;
+    TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(JsonString);
+
+    if (!FJsonSerializer::Deserialize(Reader, JsonObject) || !JsonObject.IsValid())
+    {
+        OutError = TEXT("Invalid JSON parameters");
+        return false;
+    }
+
+    // Required parameters
+    if (!JsonObject->TryGetStringField(TEXT("system_path"), OutParams.SystemPath))
+    {
+        OutError = TEXT("Missing 'system_path' parameter");
+        return false;
+    }
+
+    if (!JsonObject->TryGetStringField(TEXT("emitter_name"), OutParams.EmitterName))
+    {
+        OutError = TEXT("Missing 'emitter_name' parameter");
+        return false;
+    }
+
+    if (!JsonObject->TryGetStringField(TEXT("module_name"), OutParams.ModuleName))
+    {
+        OutError = TEXT("Missing 'module_name' parameter");
+        return false;
+    }
+
+    if (!JsonObject->TryGetStringField(TEXT("stage"), OutParams.Stage))
+    {
+        OutError = TEXT("Missing 'stage' parameter");
+        return false;
+    }
+
+    if (!JsonObject->TryGetStringField(TEXT("input_name"), OutParams.InputName))
+    {
+        OutError = TEXT("Missing 'input_name' parameter");
+        return false;
+    }
+
+    // Parse keyframes array
+    const TArray<TSharedPtr<FJsonValue>>* KeyframesArray = nullptr;
+    if (!JsonObject->TryGetArrayField(TEXT("keyframes"), KeyframesArray))
+    {
+        OutError = TEXT("Missing 'keyframes' array parameter");
+        return false;
+    }
+
+    for (const TSharedPtr<FJsonValue>& KeyframeValue : *KeyframesArray)
+    {
+        const TSharedPtr<FJsonObject>* KeyframeObj = nullptr;
+        if (!KeyframeValue->TryGetObject(KeyframeObj) || !KeyframeObj->IsValid())
+        {
+            OutError = TEXT("Invalid keyframe object in array");
+            return false;
+        }
+
+        FNiagaraCurveKeyframe Keyframe;
+
+        if (!(*KeyframeObj)->TryGetNumberField(TEXT("time"), Keyframe.Time))
+        {
+            OutError = TEXT("Missing 'time' field in keyframe");
+            return false;
+        }
+
+        if (!(*KeyframeObj)->TryGetNumberField(TEXT("value"), Keyframe.Value))
+        {
+            OutError = TEXT("Missing 'value' field in keyframe");
+            return false;
+        }
+
+        OutParams.Keyframes.Add(Keyframe);
+    }
+
+    // Validate using the struct's validation
+    return OutParams.IsValid(OutError);
+}
+
+FString FSetModuleCurveInputCommand::CreateSuccessResponse(const FString& ModuleName, const FString& InputName, int32 KeyframeCount) const
+{
+    TSharedPtr<FJsonObject> ResponseObj = MakeShared<FJsonObject>();
+    ResponseObj->SetBoolField(TEXT("success"), true);
+    ResponseObj->SetStringField(TEXT("module_name"), ModuleName);
+    ResponseObj->SetStringField(TEXT("input_name"), InputName);
+    ResponseObj->SetNumberField(TEXT("keyframe_count"), KeyframeCount);
+    ResponseObj->SetStringField(TEXT("message"),
+        FString::Printf(TEXT("Set curve input '%s' on module '%s' with %d keyframes"),
+            *InputName, *ModuleName, KeyframeCount));
+
+    FString OutputString;
+    TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&OutputString);
+    FJsonSerializer::Serialize(ResponseObj.ToSharedRef(), Writer);
+
+    return OutputString;
+}
+
+FString FSetModuleCurveInputCommand::CreateErrorResponse(const FString& ErrorMessage) const
+{
+    TSharedPtr<FJsonObject> ErrorObj = MakeShared<FJsonObject>();
+    ErrorObj->SetBoolField(TEXT("success"), false);
+    ErrorObj->SetStringField(TEXT("error"), ErrorMessage);
+
+    FString OutputString;
+    TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&OutputString);
+    FJsonSerializer::Serialize(ErrorObj.ToSharedRef(), Writer);
+
+    return OutputString;
+}

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/NiagaraCommandRegistration.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/NiagaraCommandRegistration.cpp
@@ -7,6 +7,8 @@
 #include "Commands/Niagara/CreateNiagaraSystemCommand.h"
 #include "Commands/Niagara/CreateNiagaraEmitterCommand.h"
 #include "Commands/Niagara/AddEmitterToSystemCommand.h"
+#include "Commands/Niagara/SetEmitterEnabledCommand.h"
+#include "Commands/Niagara/RemoveEmitterFromSystemCommand.h"
 #include "Commands/Niagara/GetNiagaraMetadataCommand.h"
 #include "Commands/Niagara/CompileNiagaraAssetCommand.h"
 
@@ -15,6 +17,8 @@
 #include "Commands/Niagara/AddModuleToEmitterCommand.h"
 #include "Commands/Niagara/SetModuleInputCommand.h"
 #include "Commands/Niagara/MoveModuleCommand.h"
+#include "Commands/Niagara/SetModuleCurveInputCommand.h"
+#include "Commands/Niagara/SetModuleColorCurveInputCommand.h"
 
 // Feature 3: Parameters
 #include "Commands/Niagara/AddNiagaraParameterCommand.h"
@@ -53,6 +57,8 @@ void FNiagaraCommandRegistration::RegisterAllCommands()
     RegisterAndTrackCommand(MakeShared<FCreateNiagaraSystemCommand>(NiagaraService));
     RegisterAndTrackCommand(MakeShared<FCreateNiagaraEmitterCommand>(NiagaraService));
     RegisterAndTrackCommand(MakeShared<FAddEmitterToSystemCommand>(NiagaraService));
+    RegisterAndTrackCommand(MakeShared<FSetEmitterEnabledCommand>(NiagaraService));
+    RegisterAndTrackCommand(MakeShared<FRemoveEmitterFromSystemCommand>(NiagaraService));
     RegisterAndTrackCommand(MakeShared<FGetNiagaraMetadataCommand>(NiagaraService));
     RegisterAndTrackCommand(MakeShared<FCompileNiagaraAssetCommand>(NiagaraService));
 
@@ -61,6 +67,8 @@ void FNiagaraCommandRegistration::RegisterAllCommands()
     RegisterAndTrackCommand(MakeShared<FAddModuleToEmitterCommand>(NiagaraService));
     RegisterAndTrackCommand(MakeShared<FSetModuleInputCommand>(NiagaraService));
     RegisterAndTrackCommand(MakeShared<FMoveModuleCommand>(NiagaraService));
+    RegisterAndTrackCommand(MakeShared<FSetModuleCurveInputCommand>(NiagaraService));
+    RegisterAndTrackCommand(MakeShared<FSetModuleColorCurveInputCommand>(NiagaraService));
 
     // Register Feature 3: Parameter commands
     RegisterAndTrackCommand(MakeShared<FAddNiagaraParameterCommand>(NiagaraService));

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Niagara/NiagaraCurveInputService.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Niagara/NiagaraCurveInputService.cpp
@@ -1,0 +1,804 @@
+// NiagaraCurveInputService.cpp - Curve and Color Curve Inputs for Niagara Modules
+// SetModuleCurveInput, SetModuleColorCurveInput
+
+#include "Services/NiagaraService.h"
+
+#include "NiagaraSystem.h"
+#include "NiagaraEmitter.h"
+#include "NiagaraScript.h"
+#include "NiagaraGraph.h"
+#include "NiagaraNodeOutput.h"
+#include "NiagaraNodeFunctionCall.h"
+#include "NiagaraScriptSource.h"
+#include "NiagaraTypes.h"
+#include "NiagaraCommon.h"
+#include "NiagaraDataInterfaceCurve.h"
+#include "NiagaraDataInterfaceColorCurve.h"
+#include "EdGraphSchema_Niagara.h"
+#include "ViewModels/Stack/NiagaraStackGraphUtilities.h"
+#include "ViewModels/Stack/NiagaraParameterHandle.h"
+#include "NiagaraEditorUtilities.h"
+#include "AssetRegistry/AssetRegistryModule.h"
+#include "Curves/RichCurve.h"
+
+// ============================================================================
+// Helper to find module node by name (shared logic)
+// ============================================================================
+
+static UNiagaraNodeFunctionCall* FindModuleNodeByName(
+    UNiagaraGraph* Graph,
+    const FString& ModuleName)
+{
+    FString NormalizedSearchName = ModuleName.Replace(TEXT(" "), TEXT(""));
+    for (UEdGraphNode* Node : Graph->Nodes)
+    {
+        UNiagaraNodeFunctionCall* FunctionNode = Cast<UNiagaraNodeFunctionCall>(Node);
+        if (FunctionNode)
+        {
+            FString NodeName = FunctionNode->GetFunctionName();
+            FString NormalizedNodeName = NodeName.Replace(TEXT(" "), TEXT(""));
+            if (NormalizedNodeName.Contains(NormalizedSearchName, ESearchCase::IgnoreCase) ||
+                NormalizedSearchName.Contains(NormalizedNodeName, ESearchCase::IgnoreCase))
+            {
+                return FunctionNode;
+            }
+        }
+    }
+    return nullptr;
+}
+
+// ============================================================================
+// Helper to find Dynamic Input script that outputs the target type
+// ============================================================================
+
+static UNiagaraScript* FindDynamicInputScriptForType(
+    const FNiagaraTypeDefinition& TargetType,
+    const FString& PreferredNameContains = TEXT(""))
+{
+    // Query for all Dynamic Input scripts
+    FNiagaraEditorUtilities::FGetFilteredScriptAssetsOptions FilterOptions;
+    FilterOptions.ScriptUsageToInclude = ENiagaraScriptUsage::DynamicInput;
+    FilterOptions.bIncludeNonLibraryScripts = false; // Only use library scripts
+
+    TArray<FAssetData> DynamicInputAssets;
+    FNiagaraEditorUtilities::GetFilteredScriptAssets(FilterOptions, DynamicInputAssets);
+
+    const UEdGraphSchema_Niagara* NiagaraSchema = GetDefault<UEdGraphSchema_Niagara>();
+    UNiagaraScript* BestMatch = nullptr;
+    UNiagaraScript* FirstMatch = nullptr;
+
+    for (const FAssetData& AssetData : DynamicInputAssets)
+    {
+        UNiagaraScript* Script = Cast<UNiagaraScript>(AssetData.GetAsset());
+        if (!Script)
+        {
+            continue;
+        }
+
+        // Get the script source and check output type
+        UNiagaraScriptSource* ScriptSource = Cast<UNiagaraScriptSource>(Script->GetLatestSource());
+        if (!ScriptSource || !ScriptSource->NodeGraph)
+        {
+            continue;
+        }
+
+        // Find the output node
+        TArray<UNiagaraNodeOutput*> OutputNodes;
+        ScriptSource->NodeGraph->GetNodesOfClass<UNiagaraNodeOutput>(OutputNodes);
+        if (OutputNodes.Num() != 1)
+        {
+            continue;
+        }
+
+        // Get output pins and check type
+        FPinCollectorArray InputPins;
+        OutputNodes[0]->GetInputPins(InputPins);
+        if (InputPins.Num() != 1)
+        {
+            continue;
+        }
+
+        FNiagaraTypeDefinition OutputType = NiagaraSchema->PinToTypeDefinition(InputPins[0]);
+
+        // Check if output type is assignable to target type
+        if (FNiagaraEditorUtilities::AreTypesAssignable(OutputType, TargetType))
+        {
+            // Found a match
+            if (!FirstMatch)
+            {
+                FirstMatch = Script;
+            }
+
+            // Check if this matches the preferred name pattern
+            if (!PreferredNameContains.IsEmpty())
+            {
+                FString ScriptName = Script->GetName();
+                if (ScriptName.Contains(PreferredNameContains, ESearchCase::IgnoreCase))
+                {
+                    BestMatch = Script;
+                    break; // Found preferred match
+                }
+            }
+        }
+    }
+
+    return BestMatch ? BestMatch : FirstMatch;
+}
+
+// ============================================================================
+// Helper to find ColorCurve input on a Dynamic Input script's function call
+// ============================================================================
+
+static bool FindAndConfigureColorCurveOnDynamicInput(
+    UNiagaraNodeFunctionCall* DynamicInputNode,
+    UNiagaraSystem* System,
+    const TArray<FNiagaraColorCurveKeyframe>& Keyframes,
+    FString& OutError)
+{
+    if (!DynamicInputNode || !DynamicInputNode->FunctionScript)
+    {
+        OutError = TEXT("Invalid dynamic input node");
+        return false;
+    }
+
+    UNiagaraGraph* Graph = Cast<UNiagaraGraph>(DynamicInputNode->GetGraph());
+    if (!Graph)
+    {
+        OutError = TEXT("Could not get graph from dynamic input node");
+        return false;
+    }
+
+    // Get the script source to find inputs
+    UNiagaraScriptSource* ScriptSource = Cast<UNiagaraScriptSource>(DynamicInputNode->FunctionScript->GetLatestSource());
+    if (!ScriptSource || !ScriptSource->NodeGraph)
+    {
+        OutError = TEXT("Could not get script source for dynamic input");
+        return false;
+    }
+
+    // Get inputs for this function call
+    FCompileConstantResolver ConstantResolver(System, ENiagaraScriptUsage::ParticleUpdateScript);
+    TArray<FNiagaraVariable> FunctionInputs;
+    FNiagaraStackGraphUtilities::GetStackFunctionInputs(
+        *DynamicInputNode,
+        FunctionInputs,
+        ConstantResolver,
+        FNiagaraStackGraphUtilities::ENiagaraGetStackFunctionInputPinsOptions::ModuleInputsOnly
+    );
+
+    // Find an input that accepts ColorCurve DI
+    FNiagaraTypeDefinition ColorCurveType = FNiagaraTypeDefinition(UNiagaraDataInterfaceColorCurve::StaticClass());
+    FNiagaraVariable* CurveInput = nullptr;
+
+    for (FNiagaraVariable& Input : FunctionInputs)
+    {
+        // Check for ColorCurve type or look for "Curve" in name
+        if (Input.GetType() == ColorCurveType ||
+            Input.GetName().ToString().Contains(TEXT("Curve"), ESearchCase::IgnoreCase) ||
+            Input.GetName().ToString().Contains(TEXT("Color"), ESearchCase::IgnoreCase))
+        {
+            CurveInput = &Input;
+            break;
+        }
+    }
+
+    if (!CurveInput)
+    {
+        // List available inputs for debugging
+        TArray<FString> AvailableInputs;
+        for (const FNiagaraVariable& Input : FunctionInputs)
+        {
+            AvailableInputs.Add(FString::Printf(TEXT("%s (%s)"),
+                *Input.GetName().ToString(), *Input.GetType().GetName()));
+        }
+        OutError = FString::Printf(TEXT("Could not find ColorCurve input on dynamic input '%s'. Available inputs: %s"),
+            *DynamicInputNode->GetFunctionName(), *FString::Join(AvailableInputs, TEXT(", ")));
+        return false;
+    }
+
+    // Create aliased handle for this input
+    FNiagaraParameterHandle AliasedHandle = FNiagaraParameterHandle::CreateAliasedModuleParameterHandle(
+        CurveInput->GetName(),
+        FName(*DynamicInputNode->GetFunctionName())
+    );
+
+    // Get or create override pin for the curve input
+    UEdGraphPin& CurveOverridePin = FNiagaraStackGraphUtilities::GetOrCreateStackFunctionInputOverridePin(
+        *DynamicInputNode,
+        AliasedHandle,
+        ColorCurveType,
+        FGuid(),
+        FGuid()
+    );
+
+    // Clear existing connections
+    if (CurveOverridePin.LinkedTo.Num() > 0)
+    {
+        CurveOverridePin.BreakAllPinLinks(true);
+    }
+
+    // Create the color curve data interface
+    UNiagaraDataInterface* DataInterface = nullptr;
+    FNiagaraStackGraphUtilities::SetDataInterfaceValueForFunctionInput(
+        CurveOverridePin,
+        UNiagaraDataInterfaceColorCurve::StaticClass(),
+        AliasedHandle.GetParameterHandleString().ToString(),
+        DataInterface,
+        FGuid()
+    );
+
+    if (!DataInterface)
+    {
+        OutError = TEXT("Failed to create color curve data interface for dynamic input");
+        return false;
+    }
+
+    // Configure the curve
+    UNiagaraDataInterfaceColorCurve* ColorCurveDI = Cast<UNiagaraDataInterfaceColorCurve>(DataInterface);
+    if (!ColorCurveDI)
+    {
+        OutError = TEXT("Failed to cast to UNiagaraDataInterfaceColorCurve");
+        return false;
+    }
+
+    ColorCurveDI->Modify();
+    ColorCurveDI->RedCurve.Reset();
+    ColorCurveDI->GreenCurve.Reset();
+    ColorCurveDI->BlueCurve.Reset();
+    ColorCurveDI->AlphaCurve.Reset();
+
+    for (const FNiagaraColorCurveKeyframe& Keyframe : Keyframes)
+    {
+        ColorCurveDI->RedCurve.AddKey(Keyframe.Time, Keyframe.R);
+        ColorCurveDI->GreenCurve.AddKey(Keyframe.Time, Keyframe.G);
+        ColorCurveDI->BlueCurve.AddKey(Keyframe.Time, Keyframe.B);
+        ColorCurveDI->AlphaCurve.AddKey(Keyframe.Time, Keyframe.A);
+    }
+
+    ColorCurveDI->UpdateTimeRanges();
+    ColorCurveDI->UpdateLUT();
+    ColorCurveDI->MarkPackageDirty();
+
+    return true;
+}
+
+// ============================================================================
+// Helper to find input variable
+// ============================================================================
+
+static bool FindModuleInputVariable(
+    UNiagaraNodeFunctionCall* ModuleNode,
+    UNiagaraSystem* System,
+    ENiagaraScriptUsage ScriptUsage,
+    const FString& InputName,
+    FNiagaraVariable& OutVariable,
+    FString& OutError)
+{
+    FCompileConstantResolver ConstantResolver(System, ScriptUsage);
+
+    TArray<FNiagaraVariable> ModuleInputs;
+    FNiagaraStackGraphUtilities::GetStackFunctionInputs(
+        *ModuleNode,
+        ModuleInputs,
+        ConstantResolver,
+        FNiagaraStackGraphUtilities::ENiagaraGetStackFunctionInputPinsOptions::ModuleInputsOnly
+    );
+
+    // Find the input by name
+    for (FNiagaraVariable& Input : ModuleInputs)
+    {
+        FString InputNameStr = Input.GetName().ToString();
+
+        // Try exact full name match first
+        if (InputNameStr.Equals(InputName, ESearchCase::IgnoreCase))
+        {
+            OutVariable = Input;
+            return true;
+        }
+
+        // Try suffix match
+        if (InputNameStr.EndsWith(InputName, ESearchCase::IgnoreCase))
+        {
+            int32 MatchPos = InputNameStr.Len() - InputName.Len();
+            if (MatchPos == 0 || (MatchPos > 0 && InputNameStr[MatchPos - 1] == '.'))
+            {
+                OutVariable = Input;
+                return true;
+            }
+        }
+
+        // Try simple name match (last component)
+        FString SimpleName = InputNameStr;
+        int32 DotIndex = INDEX_NONE;
+        if (InputNameStr.FindLastChar('.', DotIndex))
+        {
+            SimpleName = InputNameStr.RightChop(DotIndex + 1);
+        }
+
+        if (SimpleName.Equals(InputName, ESearchCase::IgnoreCase))
+        {
+            OutVariable = Input;
+            return true;
+        }
+    }
+
+    // Build error with available inputs
+    TArray<FString> AvailableInputs;
+    for (const FNiagaraVariable& Input : ModuleInputs)
+    {
+        AvailableInputs.Add(Input.GetName().ToString());
+    }
+    OutError = FString::Printf(TEXT("Input '%s' not found. Available: %s"),
+        *InputName, *FString::Join(AvailableInputs, TEXT(", ")));
+    return false;
+}
+
+// ============================================================================
+// Set Module Curve Input
+// ============================================================================
+
+bool FNiagaraService::SetModuleCurveInput(const FNiagaraModuleCurveInputParams& Params, FString& OutError)
+{
+    // Validate params
+    if (!Params.IsValid(OutError))
+    {
+        return false;
+    }
+
+    // Find the system
+    UNiagaraSystem* System = FindSystem(Params.SystemPath);
+    if (!System)
+    {
+        OutError = FString::Printf(TEXT("System not found: %s"), *Params.SystemPath);
+        return false;
+    }
+
+    // Find the emitter handle by name
+    int32 EmitterIndex = FindEmitterHandleIndex(System, Params.EmitterName);
+    if (EmitterIndex == INDEX_NONE)
+    {
+        OutError = FString::Printf(TEXT("Emitter '%s' not found in system '%s'"), *Params.EmitterName, *Params.SystemPath);
+        return false;
+    }
+
+    const FNiagaraEmitterHandle& EmitterHandle = System->GetEmitterHandle(EmitterIndex);
+    FVersionedNiagaraEmitterData* EmitterData = EmitterHandle.GetEmitterData();
+    if (!EmitterData)
+    {
+        OutError = FString::Printf(TEXT("Could not get emitter data for '%s'"), *Params.EmitterName);
+        return false;
+    }
+
+    // Convert stage to script usage
+    uint8 UsageValue;
+    if (!GetScriptUsageFromStage(Params.Stage, UsageValue, OutError))
+    {
+        return false;
+    }
+    ENiagaraScriptUsage ScriptUsage = static_cast<ENiagaraScriptUsage>(UsageValue);
+
+    // Get the script for this stage
+    UNiagaraScript* Script = nullptr;
+    switch (ScriptUsage)
+    {
+    case ENiagaraScriptUsage::ParticleSpawnScript:
+        Script = EmitterData->SpawnScriptProps.Script;
+        break;
+    case ENiagaraScriptUsage::ParticleUpdateScript:
+        Script = EmitterData->UpdateScriptProps.Script;
+        break;
+    default:
+        OutError = FString::Printf(TEXT("Unsupported script usage for stage '%s'"), *Params.Stage);
+        return false;
+    }
+
+    if (!Script)
+    {
+        OutError = FString::Printf(TEXT("Script not found for stage '%s' in emitter '%s'"), *Params.Stage, *Params.EmitterName);
+        return false;
+    }
+
+    // Get the script source and graph
+    UNiagaraScriptSource* ScriptSource = Cast<UNiagaraScriptSource>(Script->GetLatestSource());
+    if (!ScriptSource)
+    {
+        OutError = TEXT("Could not get script source");
+        return false;
+    }
+
+    UNiagaraGraph* Graph = ScriptSource->NodeGraph;
+    if (!Graph)
+    {
+        OutError = TEXT("Could not get script graph");
+        return false;
+    }
+
+    // Find the module node
+    UNiagaraNodeFunctionCall* ModuleNode = FindModuleNodeByName(Graph, Params.ModuleName);
+    if (!ModuleNode)
+    {
+        OutError = FString::Printf(TEXT("Module '%s' not found in stage '%s'"), *Params.ModuleName, *Params.Stage);
+        return false;
+    }
+
+    // Find the input variable
+    FNiagaraVariable InputVariable;
+    if (!FindModuleInputVariable(ModuleNode, System, ScriptUsage, Params.InputName, InputVariable, OutError))
+    {
+        OutError = FString::Printf(TEXT("Input '%s' not found on module '%s'. %s"), *Params.InputName, *Params.ModuleName, *OutError);
+        return false;
+    }
+
+    // Check that the input type accepts a curve (should be float or compatible)
+    FNiagaraTypeDefinition InputType = InputVariable.GetType();
+    if (InputType != FNiagaraTypeDefinition::GetFloatDef())
+    {
+        UE_LOG(LogNiagaraService, Warning, TEXT("Input '%s' type is '%s', curve input typically used for float types"),
+            *Params.InputName, *InputType.GetName());
+    }
+
+    // Mark system for modification
+    System->Modify();
+    Graph->Modify();
+
+    // Create the aliased module parameter handle
+    FNiagaraParameterHandle AliasedHandle = FNiagaraParameterHandle::CreateAliasedModuleParameterHandle(
+        InputVariable.GetName(),
+        FName(*ModuleNode->GetFunctionName())
+    );
+
+    // Get or create the override pin for this input
+    // We need to use the curve data interface type
+    FNiagaraTypeDefinition CurveType = FNiagaraTypeDefinition(UNiagaraDataInterfaceCurve::StaticClass());
+
+    UEdGraphPin& OverridePin = FNiagaraStackGraphUtilities::GetOrCreateStackFunctionInputOverridePin(
+        *ModuleNode,
+        AliasedHandle,
+        CurveType,
+        FGuid(),  // No script variable ID
+        FGuid()   // No preferred node GUID
+    );
+
+    // Check if the pin already has a connection (an existing curve DI)
+    if (OverridePin.LinkedTo.Num() > 0)
+    {
+        // Break existing connections using UEdGraphPin's built-in method
+        OverridePin.BreakAllPinLinks(true);
+    }
+
+    // Create the curve data interface
+    UNiagaraDataInterface* DataInterface = nullptr;
+    FNiagaraStackGraphUtilities::SetDataInterfaceValueForFunctionInput(
+        OverridePin,
+        UNiagaraDataInterfaceCurve::StaticClass(),
+        AliasedHandle.GetParameterHandleString().ToString(),
+        DataInterface,
+        FGuid()
+    );
+
+    if (!DataInterface)
+    {
+        OutError = TEXT("Failed to create curve data interface");
+        return false;
+    }
+
+    // Cast to curve DI and populate with keyframes
+    UNiagaraDataInterfaceCurve* CurveDI = Cast<UNiagaraDataInterfaceCurve>(DataInterface);
+    if (!CurveDI)
+    {
+        OutError = TEXT("Failed to cast to UNiagaraDataInterfaceCurve");
+        return false;
+    }
+
+    // Mark the data interface for modification (required for proper undo/redo support)
+    CurveDI->Modify();
+
+    // Clear existing keys and add new ones
+    CurveDI->Curve.Reset();
+
+    for (const FNiagaraCurveKeyframe& Keyframe : Params.Keyframes)
+    {
+        CurveDI->Curve.AddKey(Keyframe.Time, Keyframe.Value);
+    }
+
+    // Update the curve's time ranges and LUT
+    CurveDI->UpdateTimeRanges();
+    CurveDI->UpdateLUT();
+
+    // Mark package dirty to ensure changes are saved
+    CurveDI->MarkPackageDirty();
+
+    // Mark system dirty
+    MarkSystemDirty(System);
+
+    // Notify graph of changes
+    Graph->NotifyGraphChanged();
+
+    // Refresh editors
+    RefreshEditors(System);
+
+    UE_LOG(LogNiagaraService, Log, TEXT("Set curve input '%s' on module '%s' with %d keyframes"),
+        *Params.InputName, *Params.ModuleName, Params.Keyframes.Num());
+
+    return true;
+}
+
+// ============================================================================
+// Set Module Color Curve Input
+// ============================================================================
+
+bool FNiagaraService::SetModuleColorCurveInput(const FNiagaraModuleColorCurveInputParams& Params, FString& OutError)
+{
+    // Validate params
+    if (!Params.IsValid(OutError))
+    {
+        return false;
+    }
+
+    // Find the system
+    UNiagaraSystem* System = FindSystem(Params.SystemPath);
+    if (!System)
+    {
+        OutError = FString::Printf(TEXT("System not found: %s"), *Params.SystemPath);
+        return false;
+    }
+
+    // Find the emitter handle by name
+    int32 EmitterIndex = FindEmitterHandleIndex(System, Params.EmitterName);
+    if (EmitterIndex == INDEX_NONE)
+    {
+        OutError = FString::Printf(TEXT("Emitter '%s' not found in system '%s'"), *Params.EmitterName, *Params.SystemPath);
+        return false;
+    }
+
+    const FNiagaraEmitterHandle& EmitterHandle = System->GetEmitterHandle(EmitterIndex);
+    FVersionedNiagaraEmitterData* EmitterData = EmitterHandle.GetEmitterData();
+    if (!EmitterData)
+    {
+        OutError = FString::Printf(TEXT("Could not get emitter data for '%s'"), *Params.EmitterName);
+        return false;
+    }
+
+    // Convert stage to script usage
+    uint8 UsageValue;
+    if (!GetScriptUsageFromStage(Params.Stage, UsageValue, OutError))
+    {
+        return false;
+    }
+    ENiagaraScriptUsage ScriptUsage = static_cast<ENiagaraScriptUsage>(UsageValue);
+
+    // Get the script for this stage
+    UNiagaraScript* Script = nullptr;
+    switch (ScriptUsage)
+    {
+    case ENiagaraScriptUsage::ParticleSpawnScript:
+        Script = EmitterData->SpawnScriptProps.Script;
+        break;
+    case ENiagaraScriptUsage::ParticleUpdateScript:
+        Script = EmitterData->UpdateScriptProps.Script;
+        break;
+    default:
+        OutError = FString::Printf(TEXT("Unsupported script usage for stage '%s'"), *Params.Stage);
+        return false;
+    }
+
+    if (!Script)
+    {
+        OutError = FString::Printf(TEXT("Script not found for stage '%s' in emitter '%s'"), *Params.Stage, *Params.EmitterName);
+        return false;
+    }
+
+    // Get the script source and graph
+    UNiagaraScriptSource* ScriptSource = Cast<UNiagaraScriptSource>(Script->GetLatestSource());
+    if (!ScriptSource)
+    {
+        OutError = TEXT("Could not get script source");
+        return false;
+    }
+
+    UNiagaraGraph* Graph = ScriptSource->NodeGraph;
+    if (!Graph)
+    {
+        OutError = TEXT("Could not get script graph");
+        return false;
+    }
+
+    // Find the module node
+    UNiagaraNodeFunctionCall* ModuleNode = FindModuleNodeByName(Graph, Params.ModuleName);
+    if (!ModuleNode)
+    {
+        OutError = FString::Printf(TEXT("Module '%s' not found in stage '%s'"), *Params.ModuleName, *Params.Stage);
+        return false;
+    }
+
+    // Find the input variable
+    FNiagaraVariable InputVariable;
+    if (!FindModuleInputVariable(ModuleNode, System, ScriptUsage, Params.InputName, InputVariable, OutError))
+    {
+        OutError = FString::Printf(TEXT("Input '%s' not found on module '%s'. %s"), *Params.InputName, *Params.ModuleName, *OutError);
+        return false;
+    }
+
+    // Check input type to determine approach
+    FNiagaraTypeDefinition InputType = InputVariable.GetType();
+    FNiagaraTypeDefinition ColorCurveType = FNiagaraTypeDefinition(UNiagaraDataInterfaceColorCurve::StaticClass());
+
+    // Mark system for modification
+    System->Modify();
+    Graph->Modify();
+
+    // Create the aliased module parameter handle
+    FNiagaraParameterHandle AliasedHandle = FNiagaraParameterHandle::CreateAliasedModuleParameterHandle(
+        InputVariable.GetName(),
+        FName(*ModuleNode->GetFunctionName())
+    );
+
+    // ========================================================================
+    // APPROACH 1: LinearColor inputs - Use Dynamic Input wrapper
+    // ========================================================================
+    if (InputType == FNiagaraTypeDefinition::GetColorDef())
+    {
+        UE_LOG(LogNiagaraService, Log, TEXT("Input '%s' is LinearColor type - using Dynamic Input approach"),
+            *Params.InputName);
+
+        // Find a Dynamic Input script that outputs LinearColor and accepts a curve
+        // Prefer scripts with "Scale" or "Curve" in their name
+        UNiagaraScript* DynamicInputScript = FindDynamicInputScriptForType(
+            FNiagaraTypeDefinition::GetColorDef(),
+            TEXT("Scale")  // Prefer "Scale Linear Color by Curve" style scripts
+        );
+
+        if (!DynamicInputScript)
+        {
+            // Try without preference
+            DynamicInputScript = FindDynamicInputScriptForType(
+                FNiagaraTypeDefinition::GetColorDef(),
+                TEXT("Curve")
+            );
+        }
+
+        if (!DynamicInputScript)
+        {
+            OutError = FString::Printf(
+                TEXT("Could not find a Dynamic Input script that outputs LinearColor and accepts a color curve. ")
+                TEXT("This is required because input '%s' is a LinearColor type, which cannot directly accept ColorCurve data interfaces. ")
+                TEXT("Please ensure Niagara content is loaded (you may need to restart the editor)."),
+                *Params.InputName);
+            return false;
+        }
+
+        UE_LOG(LogNiagaraService, Log, TEXT("Found Dynamic Input script: %s"), *DynamicInputScript->GetPathName());
+
+        // Get or create override pin for the LinearColor input
+        UEdGraphPin& OverridePin = FNiagaraStackGraphUtilities::GetOrCreateStackFunctionInputOverridePin(
+            *ModuleNode,
+            AliasedHandle,
+            InputType,  // Use the actual input type (LinearColor)
+            FGuid(),
+            FGuid()
+        );
+
+        // Remove any existing override by breaking pin links
+        // Note: This clears the connection but may leave orphan nodes - acceptable for MCP use
+        if (OverridePin.LinkedTo.Num() > 0)
+        {
+            OverridePin.BreakAllPinLinks(true);
+        }
+
+        // Set the Dynamic Input script on the override pin
+        UNiagaraNodeFunctionCall* DynamicInputNode = nullptr;
+        FNiagaraStackGraphUtilities::SetDynamicInputForFunctionInput(
+            OverridePin,
+            DynamicInputScript,
+            DynamicInputNode,
+            FGuid(),
+            TEXT(""),  // Let it auto-generate name
+            FGuid()    // Use default version
+        );
+
+        if (!DynamicInputNode)
+        {
+            OutError = TEXT("Failed to create Dynamic Input function call node");
+            return false;
+        }
+
+        // Now configure the curve on the Dynamic Input's nested inputs
+        if (!FindAndConfigureColorCurveOnDynamicInput(DynamicInputNode, System, Params.Keyframes, OutError))
+        {
+            // OutError already set
+            return false;
+        }
+
+        UE_LOG(LogNiagaraService, Log, TEXT("Successfully configured Dynamic Input '%s' with color curve"),
+            *DynamicInputNode->GetFunctionName());
+    }
+    // ========================================================================
+    // APPROACH 2: ColorCurve or compatible inputs - Direct assignment
+    // ========================================================================
+    else
+    {
+        // Check if input type is compatible with ColorCurve DI
+        if (InputType != ColorCurveType)
+        {
+            UE_LOG(LogNiagaraService, Warning,
+                TEXT("Input '%s' type is '%s', which may not be compatible with ColorCurve. ")
+                TEXT("Attempting direct assignment anyway."),
+                *Params.InputName, *InputType.GetName());
+        }
+
+        // Get or create the override pin for this input
+        UEdGraphPin& OverridePin = FNiagaraStackGraphUtilities::GetOrCreateStackFunctionInputOverridePin(
+            *ModuleNode,
+            AliasedHandle,
+            ColorCurveType,
+            FGuid(),
+            FGuid()
+        );
+
+        // Check if the pin already has a connection (an existing color curve DI)
+        if (OverridePin.LinkedTo.Num() > 0)
+        {
+            OverridePin.BreakAllPinLinks(true);
+        }
+
+        // Create the color curve data interface
+        UNiagaraDataInterface* DataInterface = nullptr;
+        FNiagaraStackGraphUtilities::SetDataInterfaceValueForFunctionInput(
+            OverridePin,
+            UNiagaraDataInterfaceColorCurve::StaticClass(),
+            AliasedHandle.GetParameterHandleString().ToString(),
+            DataInterface,
+            FGuid()
+        );
+
+        if (!DataInterface)
+        {
+            OutError = TEXT("Failed to create color curve data interface");
+            return false;
+        }
+
+        // Cast to color curve DI and populate with keyframes
+        UNiagaraDataInterfaceColorCurve* ColorCurveDI = Cast<UNiagaraDataInterfaceColorCurve>(DataInterface);
+        if (!ColorCurveDI)
+        {
+            OutError = TEXT("Failed to cast to UNiagaraDataInterfaceColorCurve");
+            return false;
+        }
+
+        // Mark the data interface for modification
+        ColorCurveDI->Modify();
+
+        // Clear existing keys and add new ones to each channel
+        ColorCurveDI->RedCurve.Reset();
+        ColorCurveDI->GreenCurve.Reset();
+        ColorCurveDI->BlueCurve.Reset();
+        ColorCurveDI->AlphaCurve.Reset();
+
+        for (const FNiagaraColorCurveKeyframe& Keyframe : Params.Keyframes)
+        {
+            ColorCurveDI->RedCurve.AddKey(Keyframe.Time, Keyframe.R);
+            ColorCurveDI->GreenCurve.AddKey(Keyframe.Time, Keyframe.G);
+            ColorCurveDI->BlueCurve.AddKey(Keyframe.Time, Keyframe.B);
+            ColorCurveDI->AlphaCurve.AddKey(Keyframe.Time, Keyframe.A);
+        }
+
+        // Update the curve's time ranges and LUT
+        ColorCurveDI->UpdateTimeRanges();
+        ColorCurveDI->UpdateLUT();
+        ColorCurveDI->MarkPackageDirty();
+    }
+
+    // Mark system dirty
+    MarkSystemDirty(System);
+
+    // Notify graph of changes
+    Graph->NotifyGraphChanged();
+
+    // Refresh editors
+    RefreshEditors(System);
+
+    UE_LOG(LogNiagaraService, Log, TEXT("Set color curve input '%s' on module '%s' with %d keyframes"),
+        *Params.InputName, *Params.ModuleName, Params.Keyframes.Num());
+
+    return true;
+}

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Niagara/NiagaraLevelService.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Niagara/NiagaraLevelService.cpp
@@ -4,6 +4,7 @@
 #include "Services/NiagaraService.h"
 
 #include "Editor.h"
+#include "EngineUtils.h"  // For TActorIterator
 #include "NiagaraSystem.h"
 #include "NiagaraActor.h"
 #include "NiagaraComponent.h"
@@ -36,9 +37,20 @@ ANiagaraActor* FNiagaraService::SpawnActor(const FNiagaraActorSpawnParams& Param
         return nullptr;
     }
 
+    // Check if actor with same name already exists
+    FName RequestedName(*Params.ActorName);
+    for (TActorIterator<AActor> It(World); It; ++It)
+    {
+        if (It->GetFName() == RequestedName || It->GetActorLabel() == Params.ActorName)
+        {
+            OutError = FString::Printf(TEXT("Actor with name '%s' already exists. Delete it first or use a different name."), *Params.ActorName);
+            return nullptr;
+        }
+    }
+
     // Spawn the actor
     FActorSpawnParameters SpawnParams;
-    SpawnParams.Name = FName(*Params.ActorName);
+    SpawnParams.Name = RequestedName;
     SpawnParams.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
 
     ANiagaraActor* NiagaraActor = World->SpawnActor<ANiagaraActor>(

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Niagara/RemoveEmitterFromSystemCommand.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Niagara/RemoveEmitterFromSystemCommand.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Commands/IUnrealMCPCommand.h"
+#include "Services/INiagaraService.h"
+
+/**
+ * Command for removing an emitter from a Niagara System
+ */
+class UNREALMCP_API FRemoveEmitterFromSystemCommand : public IUnrealMCPCommand
+{
+public:
+    explicit FRemoveEmitterFromSystemCommand(INiagaraService& InNiagaraService);
+
+    virtual FString Execute(const FString& Parameters) override;
+    virtual FString GetCommandName() const override;
+    virtual bool ValidateParams(const FString& Parameters) const override;
+
+private:
+    INiagaraService& NiagaraService;
+
+    struct FRemoveEmitterParams
+    {
+        FString SystemPath;
+        FString EmitterName;
+    };
+
+    bool ParseParameters(const FString& JsonString, FRemoveEmitterParams& OutParams, FString& OutError) const;
+    FString CreateSuccessResponse(const FString& SystemPath, const FString& EmitterName) const;
+    FString CreateErrorResponse(const FString& ErrorMessage) const;
+};

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Niagara/SetEmitterEnabledCommand.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Niagara/SetEmitterEnabledCommand.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Commands/IUnrealMCPCommand.h"
+#include "Services/INiagaraService.h"
+
+/**
+ * Command for enabling/disabling an emitter within a Niagara System
+ */
+class UNREALMCP_API FSetEmitterEnabledCommand : public IUnrealMCPCommand
+{
+public:
+    explicit FSetEmitterEnabledCommand(INiagaraService& InNiagaraService);
+
+    virtual FString Execute(const FString& Parameters) override;
+    virtual FString GetCommandName() const override;
+    virtual bool ValidateParams(const FString& Parameters) const override;
+
+private:
+    INiagaraService& NiagaraService;
+
+    struct FSetEmitterEnabledParams
+    {
+        FString SystemPath;
+        FString EmitterName;
+        bool bEnabled = true;
+    };
+
+    bool ParseParameters(const FString& JsonString, FSetEmitterEnabledParams& OutParams, FString& OutError) const;
+    FString CreateSuccessResponse(const FString& EmitterName, bool bEnabled) const;
+    FString CreateErrorResponse(const FString& ErrorMessage) const;
+};

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Niagara/SetModuleColorCurveInputCommand.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Niagara/SetModuleColorCurveInputCommand.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Commands/IUnrealMCPCommand.h"
+#include "Services/INiagaraService.h"
+
+/**
+ * Command for setting a color curve input on a Niagara module
+ * Allows defining RGBA color gradients for inputs like "Color" to create
+ * color-over-life effects
+ */
+class UNREALMCP_API FSetModuleColorCurveInputCommand : public IUnrealMCPCommand
+{
+public:
+    explicit FSetModuleColorCurveInputCommand(INiagaraService& InNiagaraService);
+
+    virtual FString Execute(const FString& Parameters) override;
+    virtual FString GetCommandName() const override;
+    virtual bool ValidateParams(const FString& Parameters) const override;
+
+private:
+    INiagaraService& NiagaraService;
+
+    bool ParseParameters(const FString& JsonString, FNiagaraModuleColorCurveInputParams& OutParams, FString& OutError) const;
+    FString CreateSuccessResponse(const FString& ModuleName, const FString& InputName, int32 KeyframeCount) const;
+    FString CreateErrorResponse(const FString& ErrorMessage) const;
+};

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Niagara/SetModuleCurveInputCommand.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Niagara/SetModuleCurveInputCommand.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Commands/IUnrealMCPCommand.h"
+#include "Services/INiagaraService.h"
+
+/**
+ * Command for setting a curve input on a Niagara module
+ * Allows defining float curves for inputs like "Scale Factor" to create
+ * scale-over-life effects
+ */
+class UNREALMCP_API FSetModuleCurveInputCommand : public IUnrealMCPCommand
+{
+public:
+    explicit FSetModuleCurveInputCommand(INiagaraService& InNiagaraService);
+
+    virtual FString Execute(const FString& Parameters) override;
+    virtual FString GetCommandName() const override;
+    virtual bool ValidateParams(const FString& Parameters) const override;
+
+private:
+    INiagaraService& NiagaraService;
+
+    bool ParseParameters(const FString& JsonString, FNiagaraModuleCurveInputParams& OutParams, FString& OutError) const;
+    FString CreateSuccessResponse(const FString& ModuleName, const FString& InputName, int32 KeyframeCount) const;
+    FString CreateErrorResponse(const FString& ErrorMessage) const;
+};

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Services/INiagaraService.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Services/INiagaraService.h
@@ -365,6 +365,175 @@ struct UNREALMCP_API FNiagaraDataInterfaceParams
 };
 
 /**
+ * A single keyframe for a curve input
+ */
+struct UNREALMCP_API FNiagaraCurveKeyframe
+{
+    /** Time position (normalized 0-1 for lifetime curves) */
+    float Time = 0.0f;
+
+    /** Value at this time */
+    float Value = 0.0f;
+
+    /** Default constructor */
+    FNiagaraCurveKeyframe() = default;
+
+    FNiagaraCurveKeyframe(float InTime, float InValue)
+        : Time(InTime), Value(InValue) {}
+};
+
+/**
+ * Parameters for setting a curve input on a module
+ */
+struct UNREALMCP_API FNiagaraModuleCurveInputParams
+{
+    /** Path to the system */
+    FString SystemPath;
+
+    /** Name of the emitter */
+    FString EmitterName;
+
+    /** Name of the module */
+    FString ModuleName;
+
+    /** Stage the module is in */
+    FString Stage;
+
+    /** Name of the input to set */
+    FString InputName;
+
+    /** Curve keyframes */
+    TArray<FNiagaraCurveKeyframe> Keyframes;
+
+    /** Default constructor */
+    FNiagaraModuleCurveInputParams() = default;
+
+    /**
+     * Validate the parameters
+     * @param OutError - Error message if validation fails
+     * @return true if parameters are valid
+     */
+    bool IsValid(FString& OutError) const
+    {
+        if (SystemPath.IsEmpty())
+        {
+            OutError = TEXT("System path cannot be empty");
+            return false;
+        }
+        if (EmitterName.IsEmpty())
+        {
+            OutError = TEXT("Emitter name cannot be empty");
+            return false;
+        }
+        if (ModuleName.IsEmpty())
+        {
+            OutError = TEXT("Module name cannot be empty");
+            return false;
+        }
+        if (InputName.IsEmpty())
+        {
+            OutError = TEXT("Input name cannot be empty");
+            return false;
+        }
+        if (Keyframes.Num() < 2)
+        {
+            OutError = TEXT("Curve must have at least 2 keyframes");
+            return false;
+        }
+        return true;
+    }
+};
+
+/**
+ * A single color keyframe for a color curve input
+ */
+struct UNREALMCP_API FNiagaraColorCurveKeyframe
+{
+    /** Time position (normalized 0-1 for lifetime curves) */
+    float Time = 0.0f;
+
+    /** Red value */
+    float R = 1.0f;
+
+    /** Green value */
+    float G = 1.0f;
+
+    /** Blue value */
+    float B = 1.0f;
+
+    /** Alpha value */
+    float A = 1.0f;
+
+    /** Default constructor */
+    FNiagaraColorCurveKeyframe() = default;
+
+    FNiagaraColorCurveKeyframe(float InTime, float InR, float InG, float InB, float InA)
+        : Time(InTime), R(InR), G(InG), B(InB), A(InA) {}
+};
+
+/**
+ * Parameters for setting a color curve input on a module
+ */
+struct UNREALMCP_API FNiagaraModuleColorCurveInputParams
+{
+    /** Path to the system */
+    FString SystemPath;
+
+    /** Name of the emitter */
+    FString EmitterName;
+
+    /** Name of the module */
+    FString ModuleName;
+
+    /** Stage the module is in */
+    FString Stage;
+
+    /** Name of the input to set */
+    FString InputName;
+
+    /** Color curve keyframes */
+    TArray<FNiagaraColorCurveKeyframe> Keyframes;
+
+    /** Default constructor */
+    FNiagaraModuleColorCurveInputParams() = default;
+
+    /**
+     * Validate the parameters
+     * @param OutError - Error message if validation fails
+     * @return true if parameters are valid
+     */
+    bool IsValid(FString& OutError) const
+    {
+        if (SystemPath.IsEmpty())
+        {
+            OutError = TEXT("System path cannot be empty");
+            return false;
+        }
+        if (EmitterName.IsEmpty())
+        {
+            OutError = TEXT("Emitter name cannot be empty");
+            return false;
+        }
+        if (ModuleName.IsEmpty())
+        {
+            OutError = TEXT("Module name cannot be empty");
+            return false;
+        }
+        if (InputName.IsEmpty())
+        {
+            OutError = TEXT("Input name cannot be empty");
+            return false;
+        }
+        if (Keyframes.Num() < 2)
+        {
+            OutError = TEXT("Color curve must have at least 2 keyframes");
+            return false;
+        }
+        return true;
+    }
+};
+
+/**
  * Parameters for adding a renderer
  */
 struct UNREALMCP_API FNiagaraRendererParams
@@ -497,6 +666,25 @@ public:
     virtual bool AddEmitterToSystem(const FString& SystemPath, const FString& EmitterPath, const FString& EmitterName, FGuid& OutEmitterHandleId, FString& OutError) = 0;
 
     /**
+     * Enable or disable an emitter within a system
+     * @param SystemPath - Path to the system containing the emitter
+     * @param EmitterName - Name of the emitter to enable/disable
+     * @param bEnabled - Whether to enable (true) or disable (false) the emitter
+     * @param OutError - Error message if operation fails
+     * @return true if emitter enabled state was changed successfully
+     */
+    virtual bool SetEmitterEnabled(const FString& SystemPath, const FString& EmitterName, bool bEnabled, FString& OutError) = 0;
+
+    /**
+     * Remove an emitter from a system
+     * @param SystemPath - Path to the system containing the emitter
+     * @param EmitterName - Name of the emitter to remove
+     * @param OutError - Error message if operation fails
+     * @return true if emitter was removed successfully
+     */
+    virtual bool RemoveEmitterFromSystem(const FString& SystemPath, const FString& EmitterName, FString& OutError) = 0;
+
+    /**
      * Get metadata about a Niagara System or Emitter
      * @param AssetPath - Path to the asset
      * @param Fields - Optional fields to include (nullptr = all)
@@ -575,6 +763,22 @@ public:
      * @return true if module was moved successfully
      */
     virtual bool MoveModule(const FNiagaraModuleMoveParams& Params, FString& OutError) = 0;
+
+    /**
+     * Set a curve input on a module (for float curves like scale over life)
+     * @param Params - Curve input parameters with keyframes
+     * @param OutError - Error message if setting fails
+     * @return true if curve input was set successfully
+     */
+    virtual bool SetModuleCurveInput(const FNiagaraModuleCurveInputParams& Params, FString& OutError) = 0;
+
+    /**
+     * Set a color curve input on a module (for color gradients over life)
+     * @param Params - Color curve input parameters with keyframes
+     * @param OutError - Error message if setting fails
+     * @return true if color curve input was set successfully
+     */
+    virtual bool SetModuleColorCurveInput(const FNiagaraModuleColorCurveInputParams& Params, FString& OutError) = 0;
 
     // ========================================================================
     // Parameters (Feature 3)

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Services/NiagaraService.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Services/NiagaraService.h
@@ -41,6 +41,8 @@ public:
     virtual UNiagaraSystem* CreateSystem(const FNiagaraSystemCreationParams& Params, FString& OutSystemPath, FString& OutError) override;
     virtual UNiagaraEmitter* CreateEmitter(const FNiagaraEmitterCreationParams& Params, FString& OutEmitterPath, FString& OutError) override;
     virtual bool AddEmitterToSystem(const FString& SystemPath, const FString& EmitterPath, const FString& EmitterName, FGuid& OutEmitterHandleId, FString& OutError) override;
+    virtual bool SetEmitterEnabled(const FString& SystemPath, const FString& EmitterName, bool bEnabled, FString& OutError) override;
+    virtual bool RemoveEmitterFromSystem(const FString& SystemPath, const FString& EmitterName, FString& OutError) override;
     virtual bool GetMetadata(const FString& AssetPath, const TArray<FString>* Fields, TSharedPtr<FJsonObject>& OutMetadata, const FString& EmitterName = TEXT(""), const FString& Stage = TEXT("")) override;
     virtual bool GetModuleInputs(const FString& SystemPath, const FString& EmitterName, const FString& ModuleName, const FString& Stage, TSharedPtr<FJsonObject>& OutInputs) override;
     virtual bool CompileAsset(const FString& AssetPath, FString& OutError) override;
@@ -54,6 +56,8 @@ public:
     virtual bool SearchModules(const FString& SearchQuery, const FString& StageFilter, int32 MaxResults, TArray<TSharedPtr<FJsonObject>>& OutModules) override;
     virtual bool SetModuleInput(const FNiagaraModuleInputParams& Params, FString& OutError) override;
     virtual bool MoveModule(const FNiagaraModuleMoveParams& Params, FString& OutError) override;
+    virtual bool SetModuleCurveInput(const FNiagaraModuleCurveInputParams& Params, FString& OutError) override;
+    virtual bool SetModuleColorCurveInput(const FNiagaraModuleColorCurveInputParams& Params, FString& OutError) override;
 
     // ========================================================================
     // INiagaraService interface implementation - Parameters


### PR DESCRIPTION
… crash

Python MCP tools added (wrappers for existing C++ commands):
- Niagara: search_niagara_modules, add_module_to_emitter, set_module_input, move_module, set_module_curve_input, set_module_color_curve_input, set_renderer_property, spawn_niagara_actor, remove_emitter_from_system, set_emitter_enabled
- Material: create_material, add_material_expression, connect_material_expressions, connect_expression_to_material_output

New C++ commands implemented:
- SetEmitterEnabledCommand, RemoveEmitterFromSystemCommand
- SetModuleCurveInputCommand, SetModuleColorCurveInputCommand
- NiagaraCurveInputService for curve operations

Fix: set_module_color_curve_input crash on LinearColor inputs
- ColorCurve DIs cannot be directly assigned to LinearColor inputs
- Now uses Dynamic Inputs (e.g., "Scale Linear Color by Curve") via SetDynamicInputForFunctionInput() for LinearColor inputs
- Direct ColorCurve DI assignment still works for explicit curve inputs