### PR TITLE
Add MaterialFunctionCall support, get_module_inputs tool, and multipl…

### DIFF
--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Niagara/GetModuleInputsCommand.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Niagara/GetModuleInputsCommand.cpp
@@ -1,0 +1,96 @@
+#include "Commands/Niagara/GetModuleInputsCommand.h"
+#include "Dom/JsonObject.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonWriter.h"
+
+FGetModuleInputsCommand::FGetModuleInputsCommand(INiagaraService& InNiagaraService)
+    : NiagaraService(InNiagaraService)
+{
+}
+
+FString FGetModuleInputsCommand::Execute(const FString& Parameters)
+{
+    FString SystemPath, EmitterName, ModuleName, Stage, Error;
+
+    if (!ParseParameters(Parameters, SystemPath, EmitterName, ModuleName, Stage, Error))
+    {
+        return CreateErrorResponse(Error);
+    }
+
+    TSharedPtr<FJsonObject> InputsResult;
+    if (!NiagaraService.GetModuleInputs(SystemPath, EmitterName, ModuleName, Stage, InputsResult))
+    {
+        FString ErrorMsg = InputsResult.IsValid() ? InputsResult->GetStringField(TEXT("error")) : TEXT("Unknown error");
+        return CreateErrorResponse(ErrorMsg);
+    }
+
+    // The service already builds a complete JSON response
+    FString OutputString;
+    TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&OutputString);
+    FJsonSerializer::Serialize(InputsResult.ToSharedRef(), Writer);
+
+    return OutputString;
+}
+
+FString FGetModuleInputsCommand::GetCommandName() const
+{
+    return TEXT("get_module_inputs");
+}
+
+bool FGetModuleInputsCommand::ValidateParams(const FString& Parameters) const
+{
+    FString SystemPath, EmitterName, ModuleName, Stage, Error;
+    return ParseParameters(Parameters, SystemPath, EmitterName, ModuleName, Stage, Error);
+}
+
+bool FGetModuleInputsCommand::ParseParameters(const FString& JsonString, FString& OutSystemPath, FString& OutEmitterName,
+                                              FString& OutModuleName, FString& OutStage, FString& OutError) const
+{
+    TSharedPtr<FJsonObject> JsonObject;
+    TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(JsonString);
+
+    if (!FJsonSerializer::Deserialize(Reader, JsonObject) || !JsonObject.IsValid())
+    {
+        OutError = TEXT("Invalid JSON parameters");
+        return false;
+    }
+
+    if (!JsonObject->TryGetStringField(TEXT("system_path"), OutSystemPath) || OutSystemPath.IsEmpty())
+    {
+        OutError = TEXT("system_path is required");
+        return false;
+    }
+
+    if (!JsonObject->TryGetStringField(TEXT("emitter_name"), OutEmitterName) || OutEmitterName.IsEmpty())
+    {
+        OutError = TEXT("emitter_name is required");
+        return false;
+    }
+
+    if (!JsonObject->TryGetStringField(TEXT("module_name"), OutModuleName) || OutModuleName.IsEmpty())
+    {
+        OutError = TEXT("module_name is required");
+        return false;
+    }
+
+    if (!JsonObject->TryGetStringField(TEXT("stage"), OutStage) || OutStage.IsEmpty())
+    {
+        OutError = TEXT("stage is required");
+        return false;
+    }
+
+    return true;
+}
+
+FString FGetModuleInputsCommand::CreateErrorResponse(const FString& ErrorMessage) const
+{
+    TSharedPtr<FJsonObject> ErrorObj = MakeShared<FJsonObject>();
+    ErrorObj->SetBoolField(TEXT("success"), false);
+    ErrorObj->SetStringField(TEXT("error"), ErrorMessage);
+
+    FString OutputString;
+    TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&OutputString);
+    FJsonSerializer::Serialize(ErrorObj.ToSharedRef(), Writer);
+
+    return OutputString;
+}

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Niagara/SetModuleRandomInputCommand.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Niagara/SetModuleRandomInputCommand.cpp
@@ -1,0 +1,131 @@
+#include "Commands/Niagara/SetModuleRandomInputCommand.h"
+#include "Dom/JsonObject.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonWriter.h"
+
+FSetModuleRandomInputCommand::FSetModuleRandomInputCommand(INiagaraService& InNiagaraService)
+    : NiagaraService(InNiagaraService)
+{
+}
+
+FString FSetModuleRandomInputCommand::Execute(const FString& Parameters)
+{
+    FNiagaraModuleRandomInputParams Params;
+    FString Error;
+
+    if (!ParseParameters(Parameters, Params, Error))
+    {
+        return CreateErrorResponse(Error);
+    }
+
+    bool bSuccess = NiagaraService.SetModuleRandomInput(Params, Error);
+
+    if (!bSuccess)
+    {
+        return CreateErrorResponse(Error);
+    }
+
+    return CreateSuccessResponse(Params.ModuleName, Params.InputName, Params.MinValue, Params.MaxValue);
+}
+
+FString FSetModuleRandomInputCommand::GetCommandName() const
+{
+    return TEXT("set_module_random_input");
+}
+
+bool FSetModuleRandomInputCommand::ValidateParams(const FString& Parameters) const
+{
+    FNiagaraModuleRandomInputParams Params;
+    FString Error;
+    return ParseParameters(Parameters, Params, Error);
+}
+
+bool FSetModuleRandomInputCommand::ParseParameters(const FString& JsonString, FNiagaraModuleRandomInputParams& OutParams, FString& OutError) const
+{
+    TSharedPtr<FJsonObject> JsonObject;
+    TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(JsonString);
+
+    if (!FJsonSerializer::Deserialize(Reader, JsonObject) || !JsonObject.IsValid())
+    {
+        OutError = TEXT("Invalid JSON parameters");
+        return false;
+    }
+
+    // Required parameters
+    if (!JsonObject->TryGetStringField(TEXT("system_path"), OutParams.SystemPath))
+    {
+        OutError = TEXT("Missing 'system_path' parameter");
+        return false;
+    }
+
+    if (!JsonObject->TryGetStringField(TEXT("emitter_name"), OutParams.EmitterName))
+    {
+        OutError = TEXT("Missing 'emitter_name' parameter");
+        return false;
+    }
+
+    if (!JsonObject->TryGetStringField(TEXT("module_name"), OutParams.ModuleName))
+    {
+        OutError = TEXT("Missing 'module_name' parameter");
+        return false;
+    }
+
+    if (!JsonObject->TryGetStringField(TEXT("stage"), OutParams.Stage))
+    {
+        OutError = TEXT("Missing 'stage' parameter");
+        return false;
+    }
+
+    if (!JsonObject->TryGetStringField(TEXT("input_name"), OutParams.InputName))
+    {
+        OutError = TEXT("Missing 'input_name' parameter");
+        return false;
+    }
+
+    if (!JsonObject->TryGetStringField(TEXT("min_value"), OutParams.MinValue))
+    {
+        OutError = TEXT("Missing 'min_value' parameter");
+        return false;
+    }
+
+    if (!JsonObject->TryGetStringField(TEXT("max_value"), OutParams.MaxValue))
+    {
+        OutError = TEXT("Missing 'max_value' parameter");
+        return false;
+    }
+
+    // Validate using the struct's validation
+    return OutParams.IsValid(OutError);
+}
+
+FString FSetModuleRandomInputCommand::CreateSuccessResponse(const FString& ModuleName, const FString& InputName, const FString& MinValue, const FString& MaxValue) const
+{
+    TSharedPtr<FJsonObject> ResponseObj = MakeShared<FJsonObject>();
+    ResponseObj->SetBoolField(TEXT("success"), true);
+    ResponseObj->SetStringField(TEXT("module_name"), ModuleName);
+    ResponseObj->SetStringField(TEXT("input_name"), InputName);
+    ResponseObj->SetStringField(TEXT("min_value"), MinValue);
+    ResponseObj->SetStringField(TEXT("max_value"), MaxValue);
+    ResponseObj->SetStringField(TEXT("message"),
+        FString::Printf(TEXT("Set random input '%s' on module '%s' with range [%s, %s]"),
+            *InputName, *ModuleName, *MinValue, *MaxValue));
+
+    FString OutputString;
+    TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&OutputString);
+    FJsonSerializer::Serialize(ResponseObj.ToSharedRef(), Writer);
+
+    return OutputString;
+}
+
+FString FSetModuleRandomInputCommand::CreateErrorResponse(const FString& ErrorMessage) const
+{
+    TSharedPtr<FJsonObject> ErrorObj = MakeShared<FJsonObject>();
+    ErrorObj->SetBoolField(TEXT("success"), false);
+    ErrorObj->SetStringField(TEXT("error"), ErrorMessage);
+
+    FString OutputString;
+    TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&OutputString);
+    FJsonSerializer::Serialize(ErrorObj.ToSharedRef(), Writer);
+
+    return OutputString;
+}

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/NiagaraCommandRegistration.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/NiagaraCommandRegistration.cpp
@@ -19,6 +19,8 @@
 #include "Commands/Niagara/MoveModuleCommand.h"
 #include "Commands/Niagara/SetModuleCurveInputCommand.h"
 #include "Commands/Niagara/SetModuleColorCurveInputCommand.h"
+#include "Commands/Niagara/SetModuleRandomInputCommand.h"
+#include "Commands/Niagara/GetModuleInputsCommand.h"
 
 // Feature 3: Parameters
 #include "Commands/Niagara/AddNiagaraParameterCommand.h"
@@ -69,6 +71,8 @@ void FNiagaraCommandRegistration::RegisterAllCommands()
     RegisterAndTrackCommand(MakeShared<FMoveModuleCommand>(NiagaraService));
     RegisterAndTrackCommand(MakeShared<FSetModuleCurveInputCommand>(NiagaraService));
     RegisterAndTrackCommand(MakeShared<FSetModuleColorCurveInputCommand>(NiagaraService));
+    RegisterAndTrackCommand(MakeShared<FSetModuleRandomInputCommand>(NiagaraService));
+    RegisterAndTrackCommand(MakeShared<FGetModuleInputsCommand>(NiagaraService));
 
     // Register Feature 3: Parameter commands
     RegisterAndTrackCommand(MakeShared<FAddNiagaraParameterCommand>(NiagaraService));

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Material/MaterialExpressionCore.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Material/MaterialExpressionCore.cpp
@@ -44,6 +44,9 @@
 #include "Materials/MaterialExpressionNormalize.h"
 #include "Materials/MaterialExpressionSaturate.h"
 #include "Materials/MaterialExpressionSquareRoot.h"
+// Material Function support
+#include "Materials/MaterialExpressionMaterialFunctionCall.h"
+#include "Materials/MaterialFunctionInterface.h"
 #include "Dom/JsonValue.h"
 #include "Engine/Texture.h"
 #include "Toolkits/ToolkitManager.h"  // For FToolkitManager - correct API for finding Material Editor
@@ -122,6 +125,10 @@ UClass* FMaterialExpressionService::GetExpressionClassFromTypeName(const FString
         ExpressionTypeMap.Add(TEXT("ParticleColor"), UMaterialExpressionParticleColor::StaticClass());
         ExpressionTypeMap.Add(TEXT("VertexColor"), UMaterialExpressionVertexColor::StaticClass());
         ExpressionTypeMap.Add(TEXT("SphereMask"), UMaterialExpressionSphereMask::StaticClass());
+
+        // Material Function Call - allows using any Material Function by path
+        ExpressionTypeMap.Add(TEXT("MaterialFunctionCall"), UMaterialExpressionMaterialFunctionCall::StaticClass());
+        ExpressionTypeMap.Add(TEXT("FunctionCall"), UMaterialExpressionMaterialFunctionCall::StaticClass());
     }
 
     return ExpressionTypeMap.FindRef(TypeName);

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Niagara/NiagaraModuleService.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Niagara/NiagaraModuleService.cpp
@@ -326,10 +326,29 @@ bool FNiagaraService::SearchModules(const FString& SearchQuery, const FString& S
 
         FString AssetName = Asset.AssetName.ToString();
 
-        // Apply search filter
-        if (!SearchQuery.IsEmpty() && !AssetName.Contains(SearchQuery, ESearchCase::IgnoreCase))
+        // Apply search filter - split query into words and match ALL
+        if (!SearchQuery.IsEmpty())
         {
-            continue;
+            TArray<FString> SearchWords;
+            SearchQuery.ParseIntoArray(SearchWords, TEXT(" "), true);
+
+            if (SearchWords.Num() > 0)
+            {
+                bool bAllWordsFound = true;
+                for (const FString& Word : SearchWords)
+                {
+                    if (!AssetName.Contains(Word, ESearchCase::IgnoreCase))
+                    {
+                        bAllWordsFound = false;
+                        break;
+                    }
+                }
+
+                if (!bAllWordsFound)
+                {
+                    continue;
+                }
+            }
         }
 
         TSharedPtr<FJsonObject> ModuleInfo = MakeShared<FJsonObject>();

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Niagara/NiagaraRandomInputService.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Niagara/NiagaraRandomInputService.cpp
@@ -1,0 +1,630 @@
+// NiagaraRandomInputService.cpp - Random Range Inputs for Niagara Modules
+// SetModuleRandomInput - Uniform random between min and max values
+
+#include "Services/NiagaraService.h"
+
+#include "NiagaraSystem.h"
+#include "NiagaraEmitter.h"
+#include "NiagaraScript.h"
+#include "NiagaraGraph.h"
+#include "NiagaraNodeOutput.h"
+#include "NiagaraNodeFunctionCall.h"
+#include "NiagaraScriptSource.h"
+#include "NiagaraTypes.h"
+#include "NiagaraCommon.h"
+#include "EdGraphSchema_Niagara.h"
+#include "ViewModels/Stack/NiagaraStackGraphUtilities.h"
+#include "ViewModels/Stack/NiagaraParameterHandle.h"
+
+// ============================================================================
+// Helper to find module node by name
+// ============================================================================
+
+static UNiagaraNodeFunctionCall* FindModuleNodeByNameForRandom(
+    UNiagaraGraph* Graph,
+    const FString& ModuleName)
+{
+    FString NormalizedSearchName = ModuleName.Replace(TEXT(" "), TEXT(""));
+    for (UEdGraphNode* Node : Graph->Nodes)
+    {
+        UNiagaraNodeFunctionCall* FunctionNode = Cast<UNiagaraNodeFunctionCall>(Node);
+        if (FunctionNode)
+        {
+            FString NodeName = FunctionNode->GetFunctionName();
+            FString NormalizedNodeName = NodeName.Replace(TEXT(" "), TEXT(""));
+            if (NormalizedNodeName.Contains(NormalizedSearchName, ESearchCase::IgnoreCase) ||
+                NormalizedSearchName.Contains(NormalizedNodeName, ESearchCase::IgnoreCase))
+            {
+                return FunctionNode;
+            }
+        }
+    }
+    return nullptr;
+}
+
+// ============================================================================
+// Helper to find input variable
+// ============================================================================
+
+static bool FindModuleInputVariableForRandom(
+    UNiagaraNodeFunctionCall* ModuleNode,
+    UNiagaraSystem* System,
+    ENiagaraScriptUsage ScriptUsage,
+    const FString& InputName,
+    FNiagaraVariable& OutVariable,
+    FString& OutError)
+{
+    FCompileConstantResolver ConstantResolver(System, ScriptUsage);
+
+    TArray<FNiagaraVariable> ModuleInputs;
+    FNiagaraStackGraphUtilities::GetStackFunctionInputs(
+        *ModuleNode,
+        ModuleInputs,
+        ConstantResolver,
+        FNiagaraStackGraphUtilities::ENiagaraGetStackFunctionInputPinsOptions::ModuleInputsOnly
+    );
+
+    // Find the input by name
+    for (FNiagaraVariable& Input : ModuleInputs)
+    {
+        FString InputNameStr = Input.GetName().ToString();
+
+        // Try exact full name match first
+        if (InputNameStr.Equals(InputName, ESearchCase::IgnoreCase))
+        {
+            OutVariable = Input;
+            return true;
+        }
+
+        // Try suffix match
+        if (InputNameStr.EndsWith(InputName, ESearchCase::IgnoreCase))
+        {
+            int32 MatchPos = InputNameStr.Len() - InputName.Len();
+            if (MatchPos == 0 || (MatchPos > 0 && InputNameStr[MatchPos - 1] == '.'))
+            {
+                OutVariable = Input;
+                return true;
+            }
+        }
+
+        // Try simple name match (last component)
+        FString SimpleName = InputNameStr;
+        int32 DotIndex = INDEX_NONE;
+        if (InputNameStr.FindLastChar('.', DotIndex))
+        {
+            SimpleName = InputNameStr.RightChop(DotIndex + 1);
+        }
+
+        if (SimpleName.Equals(InputName, ESearchCase::IgnoreCase))
+        {
+            OutVariable = Input;
+            return true;
+        }
+    }
+
+    // Build error with available inputs
+    TArray<FString> AvailableInputs;
+    for (const FNiagaraVariable& Input : ModuleInputs)
+    {
+        AvailableInputs.Add(Input.GetName().ToString());
+    }
+    OutError = FString::Printf(TEXT("Input '%s' not found. Available: %s"),
+        *InputName, *FString::Join(AvailableInputs, TEXT(", ")));
+    return false;
+}
+
+// ============================================================================
+// Helper to get the appropriate UniformRanged dynamic input script path
+// ============================================================================
+
+static FString GetUniformRangedScriptPath(const FNiagaraTypeDefinition& InputType)
+{
+    // Map input types to their corresponding UniformRanged dynamic input scripts
+    if (InputType == FNiagaraTypeDefinition::GetFloatDef())
+    {
+        return TEXT("/Niagara/DynamicInputs/UniformRange/UniformRangedFloat.UniformRangedFloat");
+    }
+    else if (InputType == FNiagaraTypeDefinition::GetIntDef())
+    {
+        return TEXT("/Niagara/DynamicInputs/UniformRange/UniformRangedInt.UniformRangedInt");
+    }
+    else if (InputType == FNiagaraTypeDefinition::GetVec2Def())
+    {
+        return TEXT("/Niagara/DynamicInputs/UniformRange/UniformRangedVector2D.UniformRangedVector2D");
+    }
+    else if (InputType == FNiagaraTypeDefinition::GetVec3Def())
+    {
+        return TEXT("/Niagara/DynamicInputs/UniformRange/UniformRangedVector.UniformRangedVector");
+    }
+    else if (InputType == FNiagaraTypeDefinition::GetVec4Def())
+    {
+        return TEXT("/Niagara/DynamicInputs/UniformRange/UniformRangedVector4.UniformRangedVector4");
+    }
+    else if (InputType == FNiagaraTypeDefinition::GetColorDef())
+    {
+        return TEXT("/Niagara/DynamicInputs/UniformRange/UniformRangedLinearColor.UniformRangedLinearColor");
+    }
+
+    return TEXT("");
+}
+
+// ============================================================================
+// Helper to parse value string into FNiagaraVariable
+// ============================================================================
+
+static bool ParseValueToVariable(
+    const FString& ValueStr,
+    const FNiagaraTypeDefinition& InputType,
+    FNiagaraVariable& OutVariable,
+    FString& OutError)
+{
+    // Clean up the value string
+    FString CleanValueStr = ValueStr;
+    CleanValueStr.TrimStartAndEndInline();
+    CleanValueStr = CleanValueStr.Replace(TEXT("("), TEXT(""));
+    CleanValueStr = CleanValueStr.Replace(TEXT(")"), TEXT(""));
+    CleanValueStr = CleanValueStr.Replace(TEXT(" "), TEXT(""));
+    // Remove common component prefixes
+    CleanValueStr = CleanValueStr.Replace(TEXT("R="), TEXT(""));
+    CleanValueStr = CleanValueStr.Replace(TEXT("G="), TEXT(""));
+    CleanValueStr = CleanValueStr.Replace(TEXT("B="), TEXT(""));
+    CleanValueStr = CleanValueStr.Replace(TEXT("A="), TEXT(""));
+    CleanValueStr = CleanValueStr.Replace(TEXT("X="), TEXT(""));
+    CleanValueStr = CleanValueStr.Replace(TEXT("Y="), TEXT(""));
+    CleanValueStr = CleanValueStr.Replace(TEXT("Z="), TEXT(""));
+    CleanValueStr = CleanValueStr.Replace(TEXT("W="), TEXT(""));
+
+    OutVariable = FNiagaraVariable(InputType, NAME_None);
+
+    if (InputType == FNiagaraTypeDefinition::GetFloatDef())
+    {
+        float FloatValue = FCString::Atof(*CleanValueStr);
+        OutVariable.AllocateData();
+        OutVariable.SetValue<float>(FloatValue);
+        return true;
+    }
+    else if (InputType == FNiagaraTypeDefinition::GetIntDef())
+    {
+        int32 IntValue = FCString::Atoi(*CleanValueStr);
+        OutVariable.AllocateData();
+        OutVariable.SetValue<int32>(IntValue);
+        return true;
+    }
+    else if (InputType == FNiagaraTypeDefinition::GetVec2Def())
+    {
+        TArray<FString> Components;
+        CleanValueStr.ParseIntoArray(Components, TEXT(","), true);
+        if (Components.Num() >= 2)
+        {
+            FVector2f Vec(FCString::Atof(*Components[0]), FCString::Atof(*Components[1]));
+            OutVariable.AllocateData();
+            OutVariable.SetValue<FVector2f>(Vec);
+            return true;
+        }
+        OutError = TEXT("Vector2D requires at least 2 comma-separated values");
+        return false;
+    }
+    else if (InputType == FNiagaraTypeDefinition::GetVec3Def())
+    {
+        TArray<FString> Components;
+        CleanValueStr.ParseIntoArray(Components, TEXT(","), true);
+        if (Components.Num() >= 3)
+        {
+            FVector3f Vec(FCString::Atof(*Components[0]), FCString::Atof(*Components[1]), FCString::Atof(*Components[2]));
+            OutVariable.AllocateData();
+            OutVariable.SetValue<FVector3f>(Vec);
+            return true;
+        }
+        OutError = TEXT("Vector3 requires at least 3 comma-separated values");
+        return false;
+    }
+    else if (InputType == FNiagaraTypeDefinition::GetVec4Def())
+    {
+        TArray<FString> Components;
+        CleanValueStr.ParseIntoArray(Components, TEXT(","), true);
+        if (Components.Num() >= 4)
+        {
+            FVector4f Vec(FCString::Atof(*Components[0]), FCString::Atof(*Components[1]),
+                          FCString::Atof(*Components[2]), FCString::Atof(*Components[3]));
+            OutVariable.AllocateData();
+            OutVariable.SetValue<FVector4f>(Vec);
+            return true;
+        }
+        OutError = TEXT("Vector4 requires at least 4 comma-separated values");
+        return false;
+    }
+    else if (InputType == FNiagaraTypeDefinition::GetColorDef())
+    {
+        TArray<FString> Components;
+        CleanValueStr.ParseIntoArray(Components, TEXT(","), true);
+        if (Components.Num() >= 4)
+        {
+            FLinearColor Color(FCString::Atof(*Components[0]), FCString::Atof(*Components[1]),
+                               FCString::Atof(*Components[2]), FCString::Atof(*Components[3]));
+            OutVariable.AllocateData();
+            OutVariable.SetValue<FLinearColor>(Color);
+            return true;
+        }
+        else if (Components.Num() >= 3)
+        {
+            FLinearColor Color(FCString::Atof(*Components[0]), FCString::Atof(*Components[1]),
+                               FCString::Atof(*Components[2]), 1.0f);
+            OutVariable.AllocateData();
+            OutVariable.SetValue<FLinearColor>(Color);
+            return true;
+        }
+        OutError = TEXT("LinearColor requires at least 3 comma-separated values (RGBA or RGB)");
+        return false;
+    }
+
+    OutError = FString::Printf(TEXT("Unsupported type '%s' for random input"), *InputType.GetName());
+    return false;
+}
+
+// ============================================================================
+// Helper to set min/max values on the dynamic input's nested inputs
+// ============================================================================
+
+static bool SetMinMaxOnDynamicInput(
+    UNiagaraNodeFunctionCall* DynamicInputNode,
+    UNiagaraSystem* System,
+    const FNiagaraTypeDefinition& ValueType,
+    const FString& MinValueStr,
+    const FString& MaxValueStr,
+    FString& OutError)
+{
+    if (!DynamicInputNode || !DynamicInputNode->FunctionScript)
+    {
+        OutError = TEXT("Invalid dynamic input node");
+        return false;
+    }
+
+    UNiagaraGraph* Graph = Cast<UNiagaraGraph>(DynamicInputNode->GetGraph());
+    if (!Graph)
+    {
+        OutError = TEXT("Could not get graph from dynamic input node");
+        return false;
+    }
+
+    // Get inputs for this function call
+    FCompileConstantResolver ConstantResolver(System, ENiagaraScriptUsage::ParticleSpawnScript);
+    TArray<FNiagaraVariable> FunctionInputs;
+    FNiagaraStackGraphUtilities::GetStackFunctionInputs(
+        *DynamicInputNode,
+        FunctionInputs,
+        ConstantResolver,
+        FNiagaraStackGraphUtilities::ENiagaraGetStackFunctionInputPinsOptions::ModuleInputsOnly
+    );
+
+    // Find Minimum and Maximum inputs
+    FNiagaraVariable* MinInput = nullptr;
+    FNiagaraVariable* MaxInput = nullptr;
+
+    for (FNiagaraVariable& Input : FunctionInputs)
+    {
+        FString InputNameStr = Input.GetName().ToString();
+        if (InputNameStr.Contains(TEXT("Minimum"), ESearchCase::IgnoreCase) ||
+            InputNameStr.Contains(TEXT("Min"), ESearchCase::IgnoreCase))
+        {
+            MinInput = &Input;
+        }
+        else if (InputNameStr.Contains(TEXT("Maximum"), ESearchCase::IgnoreCase) ||
+                 InputNameStr.Contains(TEXT("Max"), ESearchCase::IgnoreCase))
+        {
+            MaxInput = &Input;
+        }
+    }
+
+    if (!MinInput || !MaxInput)
+    {
+        // List available inputs for debugging
+        TArray<FString> AvailableInputs;
+        for (const FNiagaraVariable& Input : FunctionInputs)
+        {
+            AvailableInputs.Add(FString::Printf(TEXT("%s (%s)"),
+                *Input.GetName().ToString(), *Input.GetType().GetName()));
+        }
+        OutError = FString::Printf(TEXT("Could not find Minimum/Maximum inputs on dynamic input '%s'. Available inputs: %s"),
+            *DynamicInputNode->GetFunctionName(), *FString::Join(AvailableInputs, TEXT(", ")));
+        return false;
+    }
+
+    // Parse min value
+    FNiagaraVariable MinVariable;
+    if (!ParseValueToVariable(MinValueStr, ValueType, MinVariable, OutError))
+    {
+        OutError = FString::Printf(TEXT("Failed to parse min value '%s': %s"), *MinValueStr, *OutError);
+        return false;
+    }
+
+    // Parse max value
+    FNiagaraVariable MaxVariable;
+    if (!ParseValueToVariable(MaxValueStr, ValueType, MaxVariable, OutError))
+    {
+        OutError = FString::Printf(TEXT("Failed to parse max value '%s': %s"), *MaxValueStr, *OutError);
+        return false;
+    }
+
+    // Set the min value via override pin
+    {
+        FNiagaraParameterHandle MinAliasedHandle = FNiagaraParameterHandle::CreateAliasedModuleParameterHandle(
+            MinInput->GetName(),
+            FName(*DynamicInputNode->GetFunctionName())
+        );
+
+        UEdGraphPin& MinOverridePin = FNiagaraStackGraphUtilities::GetOrCreateStackFunctionInputOverridePin(
+            *DynamicInputNode,
+            MinAliasedHandle,
+            ValueType,
+            FGuid(),
+            FGuid()
+        );
+
+        // Set the default value on the pin
+        if (ValueType == FNiagaraTypeDefinition::GetFloatDef())
+        {
+            float FloatVal = MinVariable.GetValue<float>();
+            MinOverridePin.DefaultValue = FString::SanitizeFloat(FloatVal);
+        }
+        else if (ValueType == FNiagaraTypeDefinition::GetIntDef())
+        {
+            int32 IntVal = MinVariable.GetValue<int32>();
+            MinOverridePin.DefaultValue = FString::FromInt(IntVal);
+        }
+        else if (ValueType == FNiagaraTypeDefinition::GetVec2Def())
+        {
+            FVector2f Vec = MinVariable.GetValue<FVector2f>();
+            MinOverridePin.DefaultValue = FString::Printf(TEXT("(X=%f,Y=%f)"), Vec.X, Vec.Y);
+        }
+        else if (ValueType == FNiagaraTypeDefinition::GetVec3Def())
+        {
+            FVector3f Vec = MinVariable.GetValue<FVector3f>();
+            MinOverridePin.DefaultValue = FString::Printf(TEXT("(X=%f,Y=%f,Z=%f)"), Vec.X, Vec.Y, Vec.Z);
+        }
+        else if (ValueType == FNiagaraTypeDefinition::GetVec4Def())
+        {
+            FVector4f Vec = MinVariable.GetValue<FVector4f>();
+            MinOverridePin.DefaultValue = FString::Printf(TEXT("(X=%f,Y=%f,Z=%f,W=%f)"), Vec.X, Vec.Y, Vec.Z, Vec.W);
+        }
+        else if (ValueType == FNiagaraTypeDefinition::GetColorDef())
+        {
+            FLinearColor Color = MinVariable.GetValue<FLinearColor>();
+            MinOverridePin.DefaultValue = FString::Printf(TEXT("(R=%f,G=%f,B=%f,A=%f)"), Color.R, Color.G, Color.B, Color.A);
+        }
+    }
+
+    // Set the max value via override pin
+    {
+        FNiagaraParameterHandle MaxAliasedHandle = FNiagaraParameterHandle::CreateAliasedModuleParameterHandle(
+            MaxInput->GetName(),
+            FName(*DynamicInputNode->GetFunctionName())
+        );
+
+        UEdGraphPin& MaxOverridePin = FNiagaraStackGraphUtilities::GetOrCreateStackFunctionInputOverridePin(
+            *DynamicInputNode,
+            MaxAliasedHandle,
+            ValueType,
+            FGuid(),
+            FGuid()
+        );
+
+        // Set the default value on the pin
+        if (ValueType == FNiagaraTypeDefinition::GetFloatDef())
+        {
+            float FloatVal = MaxVariable.GetValue<float>();
+            MaxOverridePin.DefaultValue = FString::SanitizeFloat(FloatVal);
+        }
+        else if (ValueType == FNiagaraTypeDefinition::GetIntDef())
+        {
+            int32 IntVal = MaxVariable.GetValue<int32>();
+            MaxOverridePin.DefaultValue = FString::FromInt(IntVal);
+        }
+        else if (ValueType == FNiagaraTypeDefinition::GetVec2Def())
+        {
+            FVector2f Vec = MaxVariable.GetValue<FVector2f>();
+            MaxOverridePin.DefaultValue = FString::Printf(TEXT("(X=%f,Y=%f)"), Vec.X, Vec.Y);
+        }
+        else if (ValueType == FNiagaraTypeDefinition::GetVec3Def())
+        {
+            FVector3f Vec = MaxVariable.GetValue<FVector3f>();
+            MaxOverridePin.DefaultValue = FString::Printf(TEXT("(X=%f,Y=%f,Z=%f)"), Vec.X, Vec.Y, Vec.Z);
+        }
+        else if (ValueType == FNiagaraTypeDefinition::GetVec4Def())
+        {
+            FVector4f Vec = MaxVariable.GetValue<FVector4f>();
+            MaxOverridePin.DefaultValue = FString::Printf(TEXT("(X=%f,Y=%f,Z=%f,W=%f)"), Vec.X, Vec.Y, Vec.Z, Vec.W);
+        }
+        else if (ValueType == FNiagaraTypeDefinition::GetColorDef())
+        {
+            FLinearColor Color = MaxVariable.GetValue<FLinearColor>();
+            MaxOverridePin.DefaultValue = FString::Printf(TEXT("(R=%f,G=%f,B=%f,A=%f)"), Color.R, Color.G, Color.B, Color.A);
+        }
+    }
+
+    return true;
+}
+
+// ============================================================================
+// Set Module Random Input
+// ============================================================================
+
+bool FNiagaraService::SetModuleRandomInput(const FNiagaraModuleRandomInputParams& Params, FString& OutError)
+{
+    // Validate params
+    if (!Params.IsValid(OutError))
+    {
+        return false;
+    }
+
+    // Find the system
+    UNiagaraSystem* System = FindSystem(Params.SystemPath);
+    if (!System)
+    {
+        OutError = FString::Printf(TEXT("System not found: %s"), *Params.SystemPath);
+        return false;
+    }
+
+    // Find the emitter handle by name
+    int32 EmitterIndex = FindEmitterHandleIndex(System, Params.EmitterName);
+    if (EmitterIndex == INDEX_NONE)
+    {
+        OutError = FString::Printf(TEXT("Emitter '%s' not found in system '%s'"), *Params.EmitterName, *Params.SystemPath);
+        return false;
+    }
+
+    const FNiagaraEmitterHandle& EmitterHandle = System->GetEmitterHandle(EmitterIndex);
+    FVersionedNiagaraEmitterData* EmitterData = EmitterHandle.GetEmitterData();
+    if (!EmitterData)
+    {
+        OutError = FString::Printf(TEXT("Could not get emitter data for '%s'"), *Params.EmitterName);
+        return false;
+    }
+
+    // Convert stage to script usage
+    uint8 UsageValue;
+    if (!GetScriptUsageFromStage(Params.Stage, UsageValue, OutError))
+    {
+        return false;
+    }
+    ENiagaraScriptUsage ScriptUsage = static_cast<ENiagaraScriptUsage>(UsageValue);
+
+    // Get the script for this stage
+    UNiagaraScript* Script = nullptr;
+    switch (ScriptUsage)
+    {
+    case ENiagaraScriptUsage::ParticleSpawnScript:
+        Script = EmitterData->SpawnScriptProps.Script;
+        break;
+    case ENiagaraScriptUsage::ParticleUpdateScript:
+        Script = EmitterData->UpdateScriptProps.Script;
+        break;
+    default:
+        OutError = FString::Printf(TEXT("Unsupported script usage for stage '%s'"), *Params.Stage);
+        return false;
+    }
+
+    if (!Script)
+    {
+        OutError = FString::Printf(TEXT("Script not found for stage '%s' in emitter '%s'"), *Params.Stage, *Params.EmitterName);
+        return false;
+    }
+
+    // Get the script source and graph
+    UNiagaraScriptSource* ScriptSource = Cast<UNiagaraScriptSource>(Script->GetLatestSource());
+    if (!ScriptSource)
+    {
+        OutError = TEXT("Could not get script source");
+        return false;
+    }
+
+    UNiagaraGraph* Graph = ScriptSource->NodeGraph;
+    if (!Graph)
+    {
+        OutError = TEXT("Could not get script graph");
+        return false;
+    }
+
+    // Find the module node
+    UNiagaraNodeFunctionCall* ModuleNode = FindModuleNodeByNameForRandom(Graph, Params.ModuleName);
+    if (!ModuleNode)
+    {
+        OutError = FString::Printf(TEXT("Module '%s' not found in stage '%s'"), *Params.ModuleName, *Params.Stage);
+        return false;
+    }
+
+    // Find the input variable
+    FNiagaraVariable InputVariable;
+    if (!FindModuleInputVariableForRandom(ModuleNode, System, ScriptUsage, Params.InputName, InputVariable, OutError))
+    {
+        OutError = FString::Printf(TEXT("Input '%s' not found on module '%s'. %s"), *Params.InputName, *Params.ModuleName, *OutError);
+        return false;
+    }
+
+    // Get the input type
+    FNiagaraTypeDefinition InputType = InputVariable.GetType();
+
+    // Get the appropriate dynamic input script path
+    FString DynamicInputPath = GetUniformRangedScriptPath(InputType);
+    if (DynamicInputPath.IsEmpty())
+    {
+        OutError = FString::Printf(TEXT("No UniformRanged dynamic input available for type '%s'. Supported types: Float, Int, Vec2, Vec3, Vec4, LinearColor"),
+            *InputType.GetName());
+        return false;
+    }
+
+    // Load the dynamic input script
+    UNiagaraScript* DynamicInputScript = LoadObject<UNiagaraScript>(nullptr, *DynamicInputPath);
+    if (!DynamicInputScript)
+    {
+        OutError = FString::Printf(TEXT("Failed to load UniformRanged dynamic input script: %s"), *DynamicInputPath);
+        return false;
+    }
+
+    UE_LOG(LogNiagaraService, Log, TEXT("Loaded dynamic input script: %s"), *DynamicInputScript->GetPathName());
+
+    // Mark system for modification
+    System->Modify();
+    Graph->Modify();
+
+    // Create the aliased module parameter handle
+    FNiagaraParameterHandle AliasedHandle = FNiagaraParameterHandle::CreateAliasedModuleParameterHandle(
+        InputVariable.GetName(),
+        FName(*ModuleNode->GetFunctionName())
+    );
+
+    // Get or create override pin for the input
+    UEdGraphPin& OverridePin = FNiagaraStackGraphUtilities::GetOrCreateStackFunctionInputOverridePin(
+        *ModuleNode,
+        AliasedHandle,
+        InputType,
+        FGuid(),
+        FGuid()
+    );
+
+    // Remove any existing override by breaking pin links
+    if (OverridePin.LinkedTo.Num() > 0)
+    {
+        OverridePin.BreakAllPinLinks(true);
+    }
+
+    // Set the Dynamic Input script on the override pin
+    UNiagaraNodeFunctionCall* DynamicInputNode = nullptr;
+    FNiagaraStackGraphUtilities::SetDynamicInputForFunctionInput(
+        OverridePin,
+        DynamicInputScript,
+        DynamicInputNode,
+        FGuid(),
+        TEXT(""),  // Let it auto-generate name
+        FGuid()    // Use default version
+    );
+
+    if (!DynamicInputNode)
+    {
+        OutError = TEXT("Failed to create Dynamic Input function call node");
+        return false;
+    }
+
+    // Now configure the min/max values on the Dynamic Input's nested inputs
+    if (!SetMinMaxOnDynamicInput(DynamicInputNode, System, InputType, Params.MinValue, Params.MaxValue, OutError))
+    {
+        // OutError already set
+        return false;
+    }
+
+    UE_LOG(LogNiagaraService, Log, TEXT("Successfully configured Dynamic Input '%s' with Min=%s, Max=%s"),
+        *DynamicInputNode->GetFunctionName(), *Params.MinValue, *Params.MaxValue);
+
+    // Mark system dirty
+    MarkSystemDirty(System);
+
+    // Notify graph of changes
+    Graph->NotifyGraphChanged();
+
+    // Refresh editors
+    RefreshEditors(System);
+
+    UE_LOG(LogNiagaraService, Log, TEXT("Set random input '%s' on module '%s' with range [%s, %s]"),
+        *Params.InputName, *Params.ModuleName, *Params.MinValue, *Params.MaxValue);
+
+    return true;
+}

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Niagara/GetModuleInputsCommand.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Niagara/GetModuleInputsCommand.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Commands/IUnrealMCPCommand.h"
+#include "Services/INiagaraService.h"
+
+/**
+ * Command for getting input information (names, types) for a module
+ */
+class UNREALMCP_API FGetModuleInputsCommand : public IUnrealMCPCommand
+{
+public:
+    explicit FGetModuleInputsCommand(INiagaraService& InNiagaraService);
+
+    virtual FString Execute(const FString& Parameters) override;
+    virtual FString GetCommandName() const override;
+    virtual bool ValidateParams(const FString& Parameters) const override;
+
+private:
+    INiagaraService& NiagaraService;
+
+    bool ParseParameters(const FString& JsonString, FString& OutSystemPath, FString& OutEmitterName,
+                        FString& OutModuleName, FString& OutStage, FString& OutError) const;
+    FString CreateErrorResponse(const FString& ErrorMessage) const;
+};

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Niagara/SetModuleRandomInputCommand.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Niagara/SetModuleRandomInputCommand.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Commands/IUnrealMCPCommand.h"
+#include "Services/INiagaraService.h"
+
+/**
+ * Command for setting a random range input on a Niagara module
+ * Allows defining uniform random values between min and max for inputs
+ * like particle size, lifetime, velocity to create natural variation
+ */
+class UNREALMCP_API FSetModuleRandomInputCommand : public IUnrealMCPCommand
+{
+public:
+    explicit FSetModuleRandomInputCommand(INiagaraService& InNiagaraService);
+
+    virtual FString Execute(const FString& Parameters) override;
+    virtual FString GetCommandName() const override;
+    virtual bool ValidateParams(const FString& Parameters) const override;
+
+private:
+    INiagaraService& NiagaraService;
+
+    bool ParseParameters(const FString& JsonString, FNiagaraModuleRandomInputParams& OutParams, FString& OutError) const;
+    FString CreateSuccessResponse(const FString& ModuleName, const FString& InputName, const FString& MinValue, const FString& MaxValue) const;
+    FString CreateErrorResponse(const FString& ErrorMessage) const;
+};

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Services/INiagaraService.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Services/INiagaraService.h
@@ -534,6 +534,76 @@ struct UNREALMCP_API FNiagaraModuleColorCurveInputParams
 };
 
 /**
+ * Parameters for setting a random range input on a module (Uniform Random Float/Vector)
+ */
+struct UNREALMCP_API FNiagaraModuleRandomInputParams
+{
+    /** Path to the system */
+    FString SystemPath;
+
+    /** Name of the emitter */
+    FString EmitterName;
+
+    /** Name of the module */
+    FString ModuleName;
+
+    /** Stage the module is in */
+    FString Stage;
+
+    /** Name of the input to set */
+    FString InputName;
+
+    /** Minimum value (as string - supports float "1.0" or vector "0,0,100") */
+    FString MinValue;
+
+    /** Maximum value (as string - supports float "5.0" or vector "100,100,500") */
+    FString MaxValue;
+
+    /** Default constructor */
+    FNiagaraModuleRandomInputParams() = default;
+
+    /**
+     * Validate the parameters
+     * @param OutError - Error message if validation fails
+     * @return true if parameters are valid
+     */
+    bool IsValid(FString& OutError) const
+    {
+        if (SystemPath.IsEmpty())
+        {
+            OutError = TEXT("System path cannot be empty");
+            return false;
+        }
+        if (EmitterName.IsEmpty())
+        {
+            OutError = TEXT("Emitter name cannot be empty");
+            return false;
+        }
+        if (ModuleName.IsEmpty())
+        {
+            OutError = TEXT("Module name cannot be empty");
+            return false;
+        }
+        if (InputName.IsEmpty())
+        {
+            OutError = TEXT("Input name cannot be empty");
+            return false;
+        }
+        if (MinValue.IsEmpty())
+        {
+            OutError = TEXT("Min value cannot be empty");
+            return false;
+        }
+        if (MaxValue.IsEmpty())
+        {
+            OutError = TEXT("Max value cannot be empty");
+            return false;
+        }
+        return true;
+    }
+};
+
+/**
  * Parameters for adding a renderer
  */
 struct UNREALMCP_API FNiagaraRendererParams
@@ -779,6 +849,14 @@ public:
      * @return true if color curve input was set successfully
      */
     virtual bool SetModuleColorCurveInput(const FNiagaraModuleColorCurveInputParams& Params, FString& OutError) = 0;
+
+    /**
+     * Set a random range input on a module (uniform random between min and max)
+     * @param Params - Random input parameters with min/max values
+     * @param OutError - Error message if setting fails
+     * @return true if random input was set successfully
+     */
+    virtual bool SetModuleRandomInput(const FNiagaraModuleRandomInputParams& Params, FString& OutError) = 0;
 
     // ========================================================================
     // Parameters (Feature 3)

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Services/NiagaraService.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Services/NiagaraService.h
@@ -58,6 +58,7 @@ public:
     virtual bool MoveModule(const FNiagaraModuleMoveParams& Params, FString& OutError) override;
     virtual bool SetModuleCurveInput(const FNiagaraModuleCurveInputParams& Params, FString& OutError) override;
     virtual bool SetModuleColorCurveInput(const FNiagaraModuleColorCurveInputParams& Params, FString& OutError) override;
+    virtual bool SetModuleRandomInput(const FNiagaraModuleRandomInputParams& Params, FString& OutError) override;
 
     // ========================================================================
     // INiagaraService interface implementation - Parameters


### PR DESCRIPTION
…e fixes

MaterialMCP:
- Add MaterialFunctionCall expression type for using any UE Material Function
- Supports RadialGradientExponential and all engine functions via path

NiagaraMCP:
- Add get_module_inputs tool to discover module input names, types, values
- Add set_module_random_input command for randomized particle values
- Fix multi-word module search (split query into words, match ALL)
- Fix create_if_missing response handling (unwrap MCP response format)

Documentation:
- Move 5 resolved issues from Active to Resolved in known-issues.md
- Clean up duplicate entries and improve organization