### PR TITLE
Add search_material_palette tool and MaterialFunctionCall validation

### DIFF
--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Material/SearchMaterialPaletteCommand.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Material/SearchMaterialPaletteCommand.cpp
@@ -1,0 +1,304 @@
+#include "Commands/Material/SearchMaterialPaletteCommand.h"
+#include "Materials/MaterialExpression.h"
+#include "Materials/MaterialFunction.h"
+#include "AssetRegistry/AssetRegistryModule.h"
+#include "UObject/UObjectIterator.h"
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonWriter.h"
+
+FSearchMaterialPaletteCommand::FSearchMaterialPaletteCommand()
+{
+}
+
+FString FSearchMaterialPaletteCommand::GetCommandName() const
+{
+    return TEXT("search_material_palette");
+}
+
+bool FSearchMaterialPaletteCommand::ValidateParams(const FString& Parameters) const
+{
+    // All parameters are optional, so always valid
+    return true;
+}
+
+FString FSearchMaterialPaletteCommand::Execute(const FString& Parameters)
+{
+    // Parse parameters
+    TSharedPtr<FJsonObject> JsonParams;
+    TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Parameters);
+
+    if (!FJsonSerializer::Deserialize(Reader, JsonParams) || !JsonParams.IsValid())
+    {
+        return CreateErrorResponse(TEXT("Invalid JSON parameters"));
+    }
+
+    FString SearchQuery = JsonParams->HasField(TEXT("search_query"))
+        ? JsonParams->GetStringField(TEXT("search_query")) : TEXT("");
+    FString CategoryFilter = JsonParams->HasField(TEXT("category_filter"))
+        ? JsonParams->GetStringField(TEXT("category_filter")) : TEXT("");
+    FString TypeFilter = JsonParams->HasField(TEXT("type_filter"))
+        ? JsonParams->GetStringField(TEXT("type_filter")) : TEXT("All");
+    int32 MaxResults = JsonParams->HasField(TEXT("max_results"))
+        ? (int32)JsonParams->GetNumberField(TEXT("max_results")) : 50;
+
+    TArray<TSharedPtr<FJsonValue>> Results;
+    TSet<FString> Categories;
+    int32 TotalExpressionCount = 0;
+    int32 TotalFunctionCount = 0;
+
+    // Search expressions if type filter allows
+    if (TypeFilter.Equals(TEXT("All"), ESearchCase::IgnoreCase) ||
+        TypeFilter.Equals(TEXT("Expression"), ESearchCase::IgnoreCase))
+    {
+        // Iterate all UMaterialExpression-derived classes
+        for (TObjectIterator<UClass> It; It; ++It)
+        {
+            UClass* Class = *It;
+
+            // Skip abstract, deprecated, private classes
+            if (Class->HasAnyClassFlags(CLASS_Abstract | CLASS_Deprecated))
+                continue;
+            if (Class->HasMetaData(TEXT("Private")))
+                continue;
+            if (!Class->IsChildOf(UMaterialExpression::StaticClass()))
+                continue;
+
+            // Get display name (remove "MaterialExpression" prefix)
+            FString DisplayName;
+            if (Class->HasMetaData("DisplayName"))
+            {
+                DisplayName = Class->GetDisplayNameText().ToString();
+            }
+            else
+            {
+                DisplayName = Class->GetName();
+                static const FString Prefix = TEXT("MaterialExpression");
+                if (DisplayName.StartsWith(Prefix))
+                {
+                    DisplayName = DisplayName.Mid(Prefix.Len());
+                }
+            }
+
+            // Get categories from default object
+            TArray<FString> ItemCategories;
+            UMaterialExpression* DefaultObj = Cast<UMaterialExpression>(Class->GetDefaultObject());
+            if (DefaultObj)
+            {
+                for (const FText& Category : DefaultObj->MenuCategories)
+                {
+                    FString CategoryStr = Category.ToString();
+                    ItemCategories.Add(CategoryStr);
+                    Categories.Add(CategoryStr);
+                }
+            }
+
+            // Apply search filter
+            if (!SearchQuery.IsEmpty())
+            {
+                bool bMatchesSearch = DisplayName.Contains(SearchQuery, ESearchCase::IgnoreCase);
+                if (!bMatchesSearch)
+                {
+                    bMatchesSearch = Class->GetName().Contains(SearchQuery, ESearchCase::IgnoreCase);
+                }
+                if (!bMatchesSearch && DefaultObj)
+                {
+                    FString Description = DefaultObj->GetCreationDescription().ToString();
+                    bMatchesSearch = Description.Contains(SearchQuery, ESearchCase::IgnoreCase);
+                }
+                if (!bMatchesSearch)
+                    continue;
+            }
+
+            // Apply category filter
+            if (!CategoryFilter.IsEmpty())
+            {
+                bool bMatchesCategory = false;
+                for (const FString& Cat : ItemCategories)
+                {
+                    if (Cat.Contains(CategoryFilter, ESearchCase::IgnoreCase))
+                    {
+                        bMatchesCategory = true;
+                        break;
+                    }
+                }
+                if (!bMatchesCategory)
+                    continue;
+            }
+
+            TotalExpressionCount++;
+
+            // Skip if we've reached max results
+            if (Results.Num() >= MaxResults)
+                continue;
+
+            // Build result object
+            TSharedPtr<FJsonObject> ItemObj = MakeShared<FJsonObject>();
+            ItemObj->SetStringField(TEXT("type"), TEXT("Expression"));
+            ItemObj->SetStringField(TEXT("name"), DisplayName);
+            ItemObj->SetStringField(TEXT("class_name"), Class->GetName());
+
+            // Add categories
+            if (ItemCategories.Num() == 1)
+            {
+                ItemObj->SetStringField(TEXT("category"), ItemCategories[0]);
+            }
+            else if (ItemCategories.Num() > 1)
+            {
+                TArray<TSharedPtr<FJsonValue>> CatArray;
+                for (const FString& Cat : ItemCategories)
+                {
+                    CatArray.Add(MakeShared<FJsonValueString>(Cat));
+                }
+                ItemObj->SetArrayField(TEXT("category"), CatArray);
+            }
+            else
+            {
+                ItemObj->SetStringField(TEXT("category"), TEXT("Uncategorized"));
+            }
+
+            // Add description
+            if (DefaultObj)
+            {
+                FString Description = DefaultObj->GetCreationDescription().ToString();
+                if (!Description.IsEmpty())
+                {
+                    ItemObj->SetStringField(TEXT("description"), Description);
+                }
+            }
+
+            Results.Add(MakeShared<FJsonValueObject>(ItemObj));
+        }
+    }
+
+    // Search functions if type filter allows
+    if (TypeFilter.Equals(TEXT("All"), ESearchCase::IgnoreCase) ||
+        TypeFilter.Equals(TEXT("Function"), ESearchCase::IgnoreCase))
+    {
+        // Use Asset Registry to find MaterialFunction assets
+        FAssetRegistryModule& AssetRegistryModule = FModuleManager::LoadModuleChecked<FAssetRegistryModule>(TEXT("AssetRegistry"));
+
+        TArray<FAssetData> AssetDataList;
+        AssetRegistryModule.Get().GetAssetsByClass(UMaterialFunction::StaticClass()->GetClassPathName(), AssetDataList);
+
+        for (const FAssetData& AssetData : AssetDataList)
+        {
+            // Only show functions exposed to library
+            const bool bExposeToLibrary = AssetData.GetTagValueRef<bool>("bExposeToLibrary");
+            if (!bExposeToLibrary)
+                continue;
+
+            // Skip transient packages
+            if (AssetData.IsAssetLoaded())
+            {
+                if (AssetData.GetAsset()->GetOutermost() == GetTransientPackage())
+                    continue;
+            }
+
+            FString FunctionName = AssetData.AssetName.ToString();
+            FString FunctionPath = AssetData.GetObjectPathString();
+
+            // Get category from library categories tag
+            FString LibraryCategories;
+            AssetData.GetTagValue("LibraryCategories", LibraryCategories);
+
+            // Apply search filter
+            if (!SearchQuery.IsEmpty())
+            {
+                bool bMatchesSearch = FunctionName.Contains(SearchQuery, ESearchCase::IgnoreCase);
+                if (!bMatchesSearch)
+                {
+                    bMatchesSearch = FunctionPath.Contains(SearchQuery, ESearchCase::IgnoreCase);
+                }
+                if (!bMatchesSearch && !LibraryCategories.IsEmpty())
+                {
+                    bMatchesSearch = LibraryCategories.Contains(SearchQuery, ESearchCase::IgnoreCase);
+                }
+                if (!bMatchesSearch)
+                    continue;
+            }
+
+            // Apply category filter
+            if (!CategoryFilter.IsEmpty())
+            {
+                if (!LibraryCategories.Contains(CategoryFilter, ESearchCase::IgnoreCase))
+                    continue;
+            }
+
+            TotalFunctionCount++;
+
+            // Skip if we've reached max results
+            if (Results.Num() >= MaxResults)
+                continue;
+
+            // Build result object
+            TSharedPtr<FJsonObject> ItemObj = MakeShared<FJsonObject>();
+            ItemObj->SetStringField(TEXT("type"), TEXT("Function"));
+            ItemObj->SetStringField(TEXT("name"), FunctionName);
+            ItemObj->SetStringField(TEXT("path"), FunctionPath);
+
+            if (!LibraryCategories.IsEmpty())
+            {
+                ItemObj->SetStringField(TEXT("category"), LibraryCategories);
+            }
+            else
+            {
+                ItemObj->SetStringField(TEXT("category"), TEXT("Uncategorized"));
+            }
+
+            // Add description if available
+            FString Description;
+            if (AssetData.GetTagValue("Description", Description) && !Description.IsEmpty())
+            {
+                ItemObj->SetStringField(TEXT("description"), Description);
+            }
+
+            Results.Add(MakeShared<FJsonValueObject>(ItemObj));
+        }
+    }
+
+    // Build category list
+    TArray<TSharedPtr<FJsonValue>> CategoryArray;
+    for (const FString& Category : Categories)
+    {
+        CategoryArray.Add(MakeShared<FJsonValueString>(Category));
+    }
+
+    // Build result
+    TSharedPtr<FJsonObject> ResultObj = MakeShared<FJsonObject>();
+    ResultObj->SetBoolField(TEXT("success"), true);
+    ResultObj->SetArrayField(TEXT("results"), Results);
+    ResultObj->SetNumberField(TEXT("total_count"), TotalExpressionCount + TotalFunctionCount);
+    ResultObj->SetNumberField(TEXT("returned_count"), Results.Num());
+    ResultObj->SetNumberField(TEXT("expression_count"), TotalExpressionCount);
+    ResultObj->SetNumberField(TEXT("function_count"), TotalFunctionCount);
+    ResultObj->SetArrayField(TEXT("categories"), CategoryArray);
+    ResultObj->SetStringField(TEXT("message"),
+        FString::Printf(TEXT("Found %d expressions and %d functions (showing %d)"),
+            TotalExpressionCount, TotalFunctionCount, Results.Num()));
+
+    return CreateSuccessResponse(ResultObj);
+}
+
+FString FSearchMaterialPaletteCommand::CreateErrorResponse(const FString& ErrorMessage) const
+{
+    TSharedPtr<FJsonObject> ErrorObj = MakeShared<FJsonObject>();
+    ErrorObj->SetBoolField(TEXT("success"), false);
+    ErrorObj->SetStringField(TEXT("error"), ErrorMessage);
+
+    FString OutputString;
+    TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&OutputString);
+    FJsonSerializer::Serialize(ErrorObj.ToSharedRef(), Writer);
+
+    return OutputString;
+}
+
+FString FSearchMaterialPaletteCommand::CreateSuccessResponse(TSharedPtr<FJsonObject> ResultObj) const
+{
+    FString OutputString;
+    TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&OutputString);
+    FJsonSerializer::Serialize(ResultObj.ToSharedRef(), Writer);
+
+    return OutputString;
+}

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/MaterialCommandRegistration.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/MaterialCommandRegistration.cpp
@@ -27,6 +27,7 @@
 #include "Commands/Material/DeleteMaterialExpressionCommand.h"
 #include "Commands/Material/SetMaterialExpressionPropertyCommand.h"
 #include "Commands/Material/CompileMaterialCommand.h"
+#include "Commands/Material/SearchMaterialPaletteCommand.h"
 
 TArray<TSharedPtr<IUnrealMCPCommand>> FMaterialCommandRegistration::RegisteredCommands;
 
@@ -62,6 +63,7 @@ void FMaterialCommandRegistration::RegisterAllCommands()
     RegisterAndTrackCommand(MakeShared<FDeleteMaterialExpressionCommand>());
     RegisterAndTrackCommand(MakeShared<FSetMaterialExpressionPropertyCommand>());
     RegisterAndTrackCommand(MakeShared<FCompileMaterialCommand>());
+    RegisterAndTrackCommand(MakeShared<FSearchMaterialPaletteCommand>());
 
     UE_LOG(LogTemp, Log, TEXT("Registered %d Material commands"), RegisteredCommands.Num());
 }

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Material/MaterialExpressionManagement.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Material/MaterialExpressionManagement.cpp
@@ -157,7 +157,10 @@ bool FMaterialExpressionService::SetExpressionProperty(
     Properties->SetField(PropertyName, Value);
 
     // Apply the property
-    ApplyExpressionProperties(Expression, Properties);
+    if (!ApplyExpressionProperties(Expression, Properties, OutError))
+    {
+        return false;
+    }
 
     // Check if material editor is open and close it (we'll reopen after save)
     bool bEditorWasOpen = false;

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Material/SearchMaterialPaletteCommand.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Material/SearchMaterialPaletteCommand.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Commands/IUnrealMCPCommand.h"
+
+/**
+ * Command to search the Material Palette for expressions and functions.
+ * Uses UE's built-in MaterialExpressionClasses and Asset Registry.
+ */
+class UNREALMCP_API FSearchMaterialPaletteCommand : public IUnrealMCPCommand
+{
+public:
+    FSearchMaterialPaletteCommand();
+
+    virtual FString Execute(const FString& Parameters) override;
+    virtual FString GetCommandName() const override;
+    virtual bool ValidateParams(const FString& Parameters) const override;
+
+private:
+    FString CreateErrorResponse(const FString& ErrorMessage) const;
+    FString CreateSuccessResponse(TSharedPtr<FJsonObject> ResultObj) const;
+};

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Services/MaterialExpressionService.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Services/MaterialExpressionService.h
@@ -277,8 +277,10 @@ private:
      * Apply type-specific properties to an expression
      * @param Expression - Expression to modify
      * @param Properties - Properties to apply
+     * @param OutError - Error message if validation fails (output)
+     * @return true if properties applied successfully, false if validation failed
      */
-    void ApplyExpressionProperties(UMaterialExpression* Expression, const TSharedPtr<FJsonObject>& Properties);
+    bool ApplyExpressionProperties(UMaterialExpression* Expression, const TSharedPtr<FJsonObject>& Properties, FString& OutError);
 
     /**
      * Build JSON metadata for an expression

--- a/Python/material_mcp_server.py
+++ b/Python/material_mcp_server.py
@@ -592,6 +592,66 @@ async def connect_expression_to_material_output(
 
 
 # ============================================================================
+# Material Palette Search
+# ============================================================================
+
+@app.tool()
+async def search_material_palette(
+    search_query: str = "",
+    category_filter: str = "",
+    type_filter: str = "All",
+    max_results: int = 50
+) -> Dict[str, Any]:
+    """
+    Search the Material Palette for expressions and functions.
+
+    Uses UE's built-in MaterialExpressionClasses and Asset Registry to find
+    available material nodes that can be added to materials.
+
+    Args:
+        search_query: Text to search in names (case-insensitive). Leave empty to list all.
+        category_filter: Filter by category name (e.g., "Math", "Texture", "Utility")
+        type_filter: Filter by type - "Expression", "Function", or "All" (default)
+        max_results: Maximum results to return (default: 50)
+
+    Returns:
+        Dictionary containing:
+        - success: Whether search was successful
+        - results: Array of items with:
+            - type: "Expression" or "Function"
+            - name: Display name
+            - category: Category name(s)
+            - class_name: For expressions, the UClass name (use for add_material_expression)
+            - path: For functions, the asset path (use for MaterialFunctionCall)
+            - description: Tooltip/description if available
+        - total_count: Total results before limit
+        - returned_count: Number of results returned
+        - categories: List of available categories
+
+    Examples:
+        # Search for radial gradient related nodes
+        search_material_palette(search_query="radial")
+
+        # List all texture-related expressions
+        search_material_palette(category_filter="Texture", type_filter="Expression")
+
+        # Find all available material functions
+        search_material_palette(type_filter="Function", max_results=100)
+
+        # List all categories (empty search, low limit)
+        search_material_palette(max_results=1)
+    """
+    params = {
+        "search_query": search_query,
+        "category_filter": category_filter,
+        "type_filter": type_filter,
+        "max_results": max_results
+    }
+
+    return await send_tcp_command("search_material_palette", params)
+
+
+# ============================================================================
 # Run Server
 # ============================================================================
 


### PR DESCRIPTION
- Add search_material_palette MCP tool to search Material Expressions and Functions
  - Search by name, filter by category (Math, Texture, Particles, etc.)
  - Filter by type (Expression, Function, or All)
  - Returns class_name for expressions (use with add_material_expression)
  - Returns asset path for functions (use with MaterialFunctionCall)

- Add property validation for MaterialFunctionCall expressions
  - Requires 'Function' or 'FunctionPath' property (not 'MaterialFunction')
  - Returns clear error message with example when wrong property name used
  - Prevents silent creation of "Unspecified Function" nodes

- Update ApplyExpressionProperties to return bool + OutError for validation