### PR TITLE
Fix curve keyframe extraction and add static switch/linked input tools

### DIFF
--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Niagara/SetModuleLinkedInputCommand.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Niagara/SetModuleLinkedInputCommand.cpp
@@ -1,0 +1,124 @@
+#include "Commands/Niagara/SetModuleLinkedInputCommand.h"
+#include "Dom/JsonObject.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonWriter.h"
+
+FSetModuleLinkedInputCommand::FSetModuleLinkedInputCommand(INiagaraService& InNiagaraService)
+    : NiagaraService(InNiagaraService)
+{
+}
+
+FString FSetModuleLinkedInputCommand::Execute(const FString& Parameters)
+{
+    FNiagaraModuleLinkedInputParams Params;
+    FString Error;
+
+    if (!ParseParameters(Parameters, Params, Error))
+    {
+        return CreateErrorResponse(Error);
+    }
+
+    bool bSuccess = NiagaraService.SetModuleLinkedInput(Params, Error);
+
+    if (!bSuccess)
+    {
+        return CreateErrorResponse(Error);
+    }
+
+    return CreateSuccessResponse(Params.ModuleName, Params.InputName, Params.LinkedValue);
+}
+
+FString FSetModuleLinkedInputCommand::GetCommandName() const
+{
+    return TEXT("set_module_linked_input");
+}
+
+bool FSetModuleLinkedInputCommand::ValidateParams(const FString& Parameters) const
+{
+    FNiagaraModuleLinkedInputParams Params;
+    FString Error;
+    return ParseParameters(Parameters, Params, Error);
+}
+
+bool FSetModuleLinkedInputCommand::ParseParameters(const FString& JsonString, FNiagaraModuleLinkedInputParams& OutParams, FString& OutError) const
+{
+    TSharedPtr<FJsonObject> JsonObject;
+    TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(JsonString);
+
+    if (!FJsonSerializer::Deserialize(Reader, JsonObject) || !JsonObject.IsValid())
+    {
+        OutError = TEXT("Invalid JSON parameters");
+        return false;
+    }
+
+    // Required parameters
+    if (!JsonObject->TryGetStringField(TEXT("system_path"), OutParams.SystemPath))
+    {
+        OutError = TEXT("Missing 'system_path' parameter");
+        return false;
+    }
+
+    if (!JsonObject->TryGetStringField(TEXT("emitter_name"), OutParams.EmitterName))
+    {
+        OutError = TEXT("Missing 'emitter_name' parameter");
+        return false;
+    }
+
+    if (!JsonObject->TryGetStringField(TEXT("module_name"), OutParams.ModuleName))
+    {
+        OutError = TEXT("Missing 'module_name' parameter");
+        return false;
+    }
+
+    if (!JsonObject->TryGetStringField(TEXT("stage"), OutParams.Stage))
+    {
+        OutError = TEXT("Missing 'stage' parameter");
+        return false;
+    }
+
+    if (!JsonObject->TryGetStringField(TEXT("input_name"), OutParams.InputName))
+    {
+        OutError = TEXT("Missing 'input_name' parameter");
+        return false;
+    }
+
+    if (!JsonObject->TryGetStringField(TEXT("linked_value"), OutParams.LinkedValue))
+    {
+        OutError = TEXT("Missing 'linked_value' parameter");
+        return false;
+    }
+
+    // Validate using the struct's validation
+    return OutParams.IsValid(OutError);
+}
+
+FString FSetModuleLinkedInputCommand::CreateSuccessResponse(const FString& ModuleName, const FString& InputName, const FString& LinkedValue) const
+{
+    TSharedPtr<FJsonObject> ResponseObj = MakeShared<FJsonObject>();
+    ResponseObj->SetBoolField(TEXT("success"), true);
+    ResponseObj->SetStringField(TEXT("module_name"), ModuleName);
+    ResponseObj->SetStringField(TEXT("input_name"), InputName);
+    ResponseObj->SetStringField(TEXT("linked_value"), LinkedValue);
+    ResponseObj->SetStringField(TEXT("message"),
+        FString::Printf(TEXT("Set linked input '%s' on module '%s' to '%s'"),
+            *InputName, *ModuleName, *LinkedValue));
+
+    FString OutputString;
+    TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&OutputString);
+    FJsonSerializer::Serialize(ResponseObj.ToSharedRef(), Writer);
+
+    return OutputString;
+}
+
+FString FSetModuleLinkedInputCommand::CreateErrorResponse(const FString& ErrorMessage) const
+{
+    TSharedPtr<FJsonObject> ErrorObj = MakeShared<FJsonObject>();
+    ErrorObj->SetBoolField(TEXT("success"), false);
+    ErrorObj->SetStringField(TEXT("error"), ErrorMessage);
+
+    FString OutputString;
+    TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&OutputString);
+    FJsonSerializer::Serialize(ErrorObj.ToSharedRef(), Writer);
+
+    return OutputString;
+}

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Niagara/SetModuleStaticSwitchCommand.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Niagara/SetModuleStaticSwitchCommand.cpp
@@ -1,0 +1,117 @@
+#include "Commands/Niagara/SetModuleStaticSwitchCommand.h"
+#include "Dom/JsonObject.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonWriter.h"
+
+FSetModuleStaticSwitchCommand::FSetModuleStaticSwitchCommand(INiagaraService& InNiagaraService)
+    : NiagaraService(InNiagaraService)
+{
+}
+
+FString FSetModuleStaticSwitchCommand::Execute(const FString& Parameters)
+{
+    FNiagaraModuleStaticSwitchParams Params;
+    FString Error;
+
+    if (!ParseParameters(Parameters, Params, Error))
+    {
+        return CreateErrorResponse(Error);
+    }
+
+    if (!NiagaraService.SetModuleStaticSwitch(Params, Error))
+    {
+        return CreateErrorResponse(Error);
+    }
+
+    return CreateSuccessResponse(Params.SwitchName, Params.Value);
+}
+
+FString FSetModuleStaticSwitchCommand::GetCommandName() const
+{
+    return TEXT("set_module_static_switch");
+}
+
+bool FSetModuleStaticSwitchCommand::ValidateParams(const FString& Parameters) const
+{
+    FNiagaraModuleStaticSwitchParams Params;
+    FString Error;
+    return ParseParameters(Parameters, Params, Error);
+}
+
+bool FSetModuleStaticSwitchCommand::ParseParameters(const FString& JsonString, FNiagaraModuleStaticSwitchParams& OutParams, FString& OutError) const
+{
+    TSharedPtr<FJsonObject> JsonObject;
+    TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(JsonString);
+
+    if (!FJsonSerializer::Deserialize(Reader, JsonObject) || !JsonObject.IsValid())
+    {
+        OutError = TEXT("Invalid JSON parameters");
+        return false;
+    }
+
+    if (!JsonObject->TryGetStringField(TEXT("system_path"), OutParams.SystemPath))
+    {
+        OutError = TEXT("Missing 'system_path' parameter");
+        return false;
+    }
+
+    if (!JsonObject->TryGetStringField(TEXT("emitter_name"), OutParams.EmitterName))
+    {
+        OutError = TEXT("Missing 'emitter_name' parameter");
+        return false;
+    }
+
+    if (!JsonObject->TryGetStringField(TEXT("module_name"), OutParams.ModuleName))
+    {
+        OutError = TEXT("Missing 'module_name' parameter");
+        return false;
+    }
+
+    if (!JsonObject->TryGetStringField(TEXT("stage"), OutParams.Stage))
+    {
+        OutError = TEXT("Missing 'stage' parameter");
+        return false;
+    }
+
+    if (!JsonObject->TryGetStringField(TEXT("switch_name"), OutParams.SwitchName))
+    {
+        OutError = TEXT("Missing 'switch_name' parameter");
+        return false;
+    }
+
+    if (!JsonObject->TryGetStringField(TEXT("value"), OutParams.Value))
+    {
+        OutError = TEXT("Missing 'value' parameter");
+        return false;
+    }
+
+    return OutParams.IsValid(OutError);
+}
+
+FString FSetModuleStaticSwitchCommand::CreateSuccessResponse(const FString& SwitchName, const FString& Value) const
+{
+    TSharedPtr<FJsonObject> ResponseObj = MakeShared<FJsonObject>();
+    ResponseObj->SetBoolField(TEXT("success"), true);
+    ResponseObj->SetStringField(TEXT("switch_name"), SwitchName);
+    ResponseObj->SetStringField(TEXT("value"), Value);
+    ResponseObj->SetStringField(TEXT("message"), TEXT("Static switch set successfully"));
+
+    FString OutputString;
+    TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&OutputString);
+    FJsonSerializer::Serialize(ResponseObj.ToSharedRef(), Writer);
+
+    return OutputString;
+}
+
+FString FSetModuleStaticSwitchCommand::CreateErrorResponse(const FString& ErrorMessage) const
+{
+    TSharedPtr<FJsonObject> ErrorObj = MakeShared<FJsonObject>();
+    ErrorObj->SetBoolField(TEXT("success"), false);
+    ErrorObj->SetStringField(TEXT("error"), ErrorMessage);
+
+    FString OutputString;
+    TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&OutputString);
+    FJsonSerializer::Serialize(ErrorObj.ToSharedRef(), Writer);
+
+    return OutputString;
+}

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/NiagaraCommandRegistration.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/NiagaraCommandRegistration.cpp
@@ -22,6 +22,8 @@
 #include "Commands/Niagara/SetModuleCurveInputCommand.h"
 #include "Commands/Niagara/SetModuleColorCurveInputCommand.h"
 #include "Commands/Niagara/SetModuleRandomInputCommand.h"
+#include "Commands/Niagara/SetModuleLinkedInputCommand.h"
+#include "Commands/Niagara/SetModuleStaticSwitchCommand.h"
 #include "Commands/Niagara/GetModuleInputsCommand.h"
 #include "Commands/Niagara/GetEmitterModulesCommand.h"
 #include "Commands/Niagara/RemoveModuleFromEmitterCommand.h"
@@ -79,6 +81,8 @@ void FNiagaraCommandRegistration::RegisterAllCommands()
     RegisterAndTrackCommand(MakeShared<FSetModuleCurveInputCommand>(NiagaraService));
     RegisterAndTrackCommand(MakeShared<FSetModuleColorCurveInputCommand>(NiagaraService));
     RegisterAndTrackCommand(MakeShared<FSetModuleRandomInputCommand>(NiagaraService));
+    RegisterAndTrackCommand(MakeShared<FSetModuleLinkedInputCommand>(NiagaraService));
+    RegisterAndTrackCommand(MakeShared<FSetModuleStaticSwitchCommand>(NiagaraService));
     RegisterAndTrackCommand(MakeShared<FGetModuleInputsCommand>(NiagaraService));
     RegisterAndTrackCommand(MakeShared<FGetEmitterModulesCommand>(NiagaraService));
     RegisterAndTrackCommand(MakeShared<FRemoveModuleFromEmitterCommand>(NiagaraService));

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Niagara/NiagaraCurveInputService.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Niagara/NiagaraCurveInputService.cpp
@@ -30,6 +30,8 @@ static UNiagaraNodeFunctionCall* FindModuleNodeByName(
     const FString& ModuleName)
 {
     FString NormalizedSearchName = ModuleName.Replace(TEXT(" "), TEXT(""));
+    UNiagaraNodeFunctionCall* PartialMatchNode = nullptr;
+
     for (UEdGraphNode* Node : Graph->Nodes)
     {
         UNiagaraNodeFunctionCall* FunctionNode = Cast<UNiagaraNodeFunctionCall>(Node);
@@ -37,14 +39,20 @@ static UNiagaraNodeFunctionCall* FindModuleNodeByName(
         {
             FString NodeName = FunctionNode->GetFunctionName();
             FString NormalizedNodeName = NodeName.Replace(TEXT(" "), TEXT(""));
-            if (NormalizedNodeName.Contains(NormalizedSearchName, ESearchCase::IgnoreCase) ||
-                NormalizedSearchName.Contains(NormalizedNodeName, ESearchCase::IgnoreCase))
+
+            // Exact match takes priority
+            if (NormalizedNodeName.Equals(NormalizedSearchName, ESearchCase::IgnoreCase))
             {
                 return FunctionNode;
             }
+            // Track partial match as fallback
+            if (!PartialMatchNode && NormalizedNodeName.Contains(NormalizedSearchName, ESearchCase::IgnoreCase))
+            {
+                PartialMatchNode = FunctionNode;
+            }
         }
     }
-    return nullptr;
+    return PartialMatchNode;
 }
 
 // ============================================================================

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Niagara/NiagaraLinkedInputService.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Niagara/NiagaraLinkedInputService.cpp
@@ -1,0 +1,300 @@
+// NiagaraLinkedInputService.cpp - Linked Input Support for Niagara Modules
+// SetModuleLinkedInput - binds module inputs to particle attributes
+
+#include "Services/NiagaraService.h"
+
+#include "NiagaraSystem.h"
+#include "NiagaraEmitter.h"
+#include "NiagaraScript.h"
+#include "NiagaraGraph.h"
+#include "NiagaraNodeOutput.h"
+#include "NiagaraNodeFunctionCall.h"
+#include "NiagaraScriptSource.h"
+#include "NiagaraTypes.h"
+#include "NiagaraCommon.h"
+#include "EdGraphSchema_Niagara.h"
+#include "ViewModels/Stack/NiagaraStackGraphUtilities.h"
+#include "ViewModels/Stack/NiagaraParameterHandle.h"
+
+// ============================================================================
+// Helper to find module node by name
+// ============================================================================
+
+static UNiagaraNodeFunctionCall* FindModuleNodeByNameForLinked(
+    UNiagaraGraph* Graph,
+    const FString& ModuleName)
+{
+    FString NormalizedSearchName = ModuleName.Replace(TEXT(" "), TEXT(""));
+    UNiagaraNodeFunctionCall* PartialMatchNode = nullptr;
+
+    for (UEdGraphNode* Node : Graph->Nodes)
+    {
+        UNiagaraNodeFunctionCall* FunctionNode = Cast<UNiagaraNodeFunctionCall>(Node);
+        if (FunctionNode)
+        {
+            FString NodeName = FunctionNode->GetFunctionName();
+            FString NormalizedNodeName = NodeName.Replace(TEXT(" "), TEXT(""));
+
+            // Exact match takes priority
+            if (NormalizedNodeName.Equals(NormalizedSearchName, ESearchCase::IgnoreCase))
+            {
+                return FunctionNode;
+            }
+            // Track partial match as fallback
+            if (!PartialMatchNode && NormalizedNodeName.Contains(NormalizedSearchName, ESearchCase::IgnoreCase))
+            {
+                PartialMatchNode = FunctionNode;
+            }
+        }
+    }
+    return PartialMatchNode;
+}
+
+// ============================================================================
+// Set Module Linked Input - bind input to a particle attribute
+// ============================================================================
+
+// Helper to get the type definition for a linked parameter name
+static FNiagaraTypeDefinition GetLinkedParameterType(const FString& LinkedValue)
+{
+    // Common particle attributes and their types
+    static TMap<FString, FNiagaraTypeDefinition> ParticleAttributeTypes = {
+        {TEXT("Particles.NormalizedAge"), FNiagaraTypeDefinition::GetFloatDef()},
+        {TEXT("Particles.Age"), FNiagaraTypeDefinition::GetFloatDef()},
+        {TEXT("Particles.Lifetime"), FNiagaraTypeDefinition::GetFloatDef()},
+        {TEXT("Particles.Mass"), FNiagaraTypeDefinition::GetFloatDef()},
+        {TEXT("Particles.SpriteRotation"), FNiagaraTypeDefinition::GetFloatDef()},
+        {TEXT("Particles.Position"), FNiagaraTypeDefinition::GetVec3Def()},
+        {TEXT("Particles.Velocity"), FNiagaraTypeDefinition::GetVec3Def()},
+        {TEXT("Particles.Color"), FNiagaraTypeDefinition::GetColorDef()},
+        {TEXT("Particles.SpriteSize"), FNiagaraTypeDefinition::GetVec2Def()},
+    };
+
+    if (const FNiagaraTypeDefinition* FoundType = ParticleAttributeTypes.Find(LinkedValue))
+    {
+        return *FoundType;
+    }
+
+    // Default to float for unknown attributes
+    return FNiagaraTypeDefinition::GetFloatDef();
+}
+
+bool FNiagaraService::SetModuleLinkedInput(const FNiagaraModuleLinkedInputParams& Params, FString& OutError)
+{
+    // Validate params
+    if (!Params.IsValid(OutError))
+    {
+        return false;
+    }
+
+    // Find the system
+    UNiagaraSystem* System = FindSystem(Params.SystemPath);
+    if (!System)
+    {
+        OutError = FString::Printf(TEXT("System not found: %s"), *Params.SystemPath);
+        return false;
+    }
+
+    // Find the emitter handle by name
+    int32 EmitterIndex = FindEmitterHandleIndex(System, Params.EmitterName);
+    if (EmitterIndex == INDEX_NONE)
+    {
+        OutError = FString::Printf(TEXT("Emitter '%s' not found in system '%s'"), *Params.EmitterName, *Params.SystemPath);
+        return false;
+    }
+
+    const FNiagaraEmitterHandle& EmitterHandle = System->GetEmitterHandle(EmitterIndex);
+    FVersionedNiagaraEmitterData* EmitterData = EmitterHandle.GetEmitterData();
+    if (!EmitterData)
+    {
+        OutError = FString::Printf(TEXT("Could not get emitter data for '%s'"), *Params.EmitterName);
+        return false;
+    }
+
+    // Convert stage to script usage
+    uint8 UsageValue;
+    if (!GetScriptUsageFromStage(Params.Stage, UsageValue, OutError))
+    {
+        return false;
+    }
+    ENiagaraScriptUsage ScriptUsage = static_cast<ENiagaraScriptUsage>(UsageValue);
+
+    // Get the script for this stage
+    UNiagaraScript* Script = nullptr;
+    switch (ScriptUsage)
+    {
+    case ENiagaraScriptUsage::ParticleSpawnScript:
+        Script = EmitterData->SpawnScriptProps.Script;
+        break;
+    case ENiagaraScriptUsage::ParticleUpdateScript:
+        Script = EmitterData->UpdateScriptProps.Script;
+        break;
+    case ENiagaraScriptUsage::EmitterSpawnScript:
+        Script = EmitterData->EmitterSpawnScriptProps.Script;
+        break;
+    case ENiagaraScriptUsage::EmitterUpdateScript:
+        Script = EmitterData->EmitterUpdateScriptProps.Script;
+        break;
+    default:
+        OutError = FString::Printf(TEXT("Unsupported script usage for stage '%s'"), *Params.Stage);
+        return false;
+    }
+
+    if (!Script)
+    {
+        OutError = FString::Printf(TEXT("Script not found for stage '%s' in emitter '%s'"), *Params.Stage, *Params.EmitterName);
+        return false;
+    }
+
+    // Get the script source and graph
+    UNiagaraScriptSource* ScriptSource = Cast<UNiagaraScriptSource>(Script->GetLatestSource());
+    if (!ScriptSource)
+    {
+        OutError = TEXT("Could not get script source");
+        return false;
+    }
+
+    UNiagaraGraph* Graph = ScriptSource->NodeGraph;
+    if (!Graph)
+    {
+        OutError = TEXT("Could not get script graph");
+        return false;
+    }
+
+    // Find the module node
+    UNiagaraNodeFunctionCall* ModuleNode = FindModuleNodeByNameForLinked(Graph, Params.ModuleName);
+    if (!ModuleNode)
+    {
+        OutError = FString::Printf(TEXT("Module '%s' not found in stage '%s'"), *Params.ModuleName, *Params.Stage);
+        return false;
+    }
+
+    // Get module inputs using the Stack API
+    FCompileConstantResolver ConstantResolver(System, ScriptUsage);
+    TArray<FNiagaraVariable> ModuleInputs;
+    FNiagaraStackGraphUtilities::GetStackFunctionInputs(
+        *ModuleNode,
+        ModuleInputs,
+        ConstantResolver,
+        FNiagaraStackGraphUtilities::ENiagaraGetStackFunctionInputPinsOptions::ModuleInputsOnly
+    );
+
+    // Find the input by name
+    FNiagaraVariable* FoundInput = nullptr;
+    for (FNiagaraVariable& Input : ModuleInputs)
+    {
+        FString InputNameStr = Input.GetName().ToString();
+
+        // Try exact full name match first
+        if (InputNameStr.Equals(Params.InputName, ESearchCase::IgnoreCase))
+        {
+            FoundInput = &Input;
+            break;
+        }
+
+        // Try suffix match
+        if (InputNameStr.EndsWith(Params.InputName, ESearchCase::IgnoreCase))
+        {
+            int32 MatchPos = InputNameStr.Len() - Params.InputName.Len();
+            if (MatchPos == 0 || (MatchPos > 0 && InputNameStr[MatchPos - 1] == '.'))
+            {
+                FoundInput = &Input;
+                break;
+            }
+        }
+
+        // Try simple name match
+        FString SimpleName = InputNameStr;
+        int32 DotIndex = INDEX_NONE;
+        if (InputNameStr.FindLastChar('.', DotIndex))
+        {
+            SimpleName = InputNameStr.RightChop(DotIndex + 1);
+        }
+
+        if (SimpleName.Equals(Params.InputName, ESearchCase::IgnoreCase))
+        {
+            FoundInput = &Input;
+            break;
+        }
+    }
+
+    if (!FoundInput)
+    {
+        TArray<FString> AvailableInputs;
+        for (const FNiagaraVariable& Input : ModuleInputs)
+        {
+            AvailableInputs.Add(Input.GetName().ToString());
+        }
+        OutError = FString::Printf(TEXT("Input '%s' not found on module '%s'. Available inputs: %s"),
+            *Params.InputName, *Params.ModuleName, *FString::Join(AvailableInputs, TEXT(", ")));
+        return false;
+    }
+
+    FNiagaraTypeDefinition InputType = FoundInput->GetType();
+
+    // Mark system for modification
+    System->Modify();
+    Graph->Modify();
+
+    // Create the aliased module parameter handle
+    FNiagaraParameterHandle AliasedHandle = FNiagaraParameterHandle::CreateAliasedModuleParameterHandle(
+        FoundInput->GetName(),
+        FName(*ModuleNode->GetFunctionName())
+    );
+
+    // Get or create the override pin for this input
+    UEdGraphPin& OverridePin = FNiagaraStackGraphUtilities::GetOrCreateStackFunctionInputOverridePin(
+        *ModuleNode,
+        AliasedHandle,
+        InputType,
+        FGuid(),
+        FGuid()
+    );
+
+    // Clear any existing connections on the override pin
+    if (OverridePin.LinkedTo.Num() > 0)
+    {
+        OverridePin.BreakAllPinLinks(true);
+    }
+
+    // Create the linked parameter variable with the CORRECT type for the particle attribute
+    // (NOT the input type - that was a bug causing crashes)
+    FNiagaraTypeDefinition LinkedParamType = GetLinkedParameterType(Params.LinkedValue);
+    FNiagaraVariableBase LinkedParameter(LinkedParamType, FName(*Params.LinkedValue));
+
+    // Build the set of known parameters - these must match the types in GetLinkedParameterType
+    TSet<FNiagaraVariableBase> KnownParameters;
+    KnownParameters.Add(FNiagaraVariableBase(FNiagaraTypeDefinition::GetFloatDef(), FName("Particles.NormalizedAge")));
+    KnownParameters.Add(FNiagaraVariableBase(FNiagaraTypeDefinition::GetFloatDef(), FName("Particles.Age")));
+    KnownParameters.Add(FNiagaraVariableBase(FNiagaraTypeDefinition::GetFloatDef(), FName("Particles.Lifetime")));
+    KnownParameters.Add(FNiagaraVariableBase(FNiagaraTypeDefinition::GetVec3Def(), FName("Particles.Position")));
+    KnownParameters.Add(FNiagaraVariableBase(FNiagaraTypeDefinition::GetVec3Def(), FName("Particles.Velocity")));
+    KnownParameters.Add(FNiagaraVariableBase(FNiagaraTypeDefinition::GetColorDef(), FName("Particles.Color")));
+    KnownParameters.Add(FNiagaraVariableBase(FNiagaraTypeDefinition::GetFloatDef(), FName("Particles.Mass")));
+    KnownParameters.Add(FNiagaraVariableBase(FNiagaraTypeDefinition::GetVec2Def(), FName("Particles.SpriteSize")));
+    KnownParameters.Add(FNiagaraVariableBase(FNiagaraTypeDefinition::GetFloatDef(), FName("Particles.SpriteRotation")));
+
+    // Use the exported SetLinkedParameterValueForFunctionInput
+    // This function handles all the internal node creation and linking
+    FNiagaraStackGraphUtilities::SetLinkedParameterValueForFunctionInput(
+        OverridePin,
+        LinkedParameter,
+        KnownParameters,
+        ENiagaraDefaultMode::FailIfPreviouslyNotSet,
+        FGuid()
+    );
+
+    // Mark system dirty
+    MarkSystemDirty(System);
+
+    // Notify graph of changes
+    Graph->NotifyGraphChanged();
+
+    // Refresh editors
+    RefreshEditors(System);
+
+    UE_LOG(LogNiagaraService, Log, TEXT("Set linked input '%s' on module '%s' to '%s'"),
+        *Params.InputName, *Params.ModuleName, *Params.LinkedValue);
+
+    return true;
+}

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Niagara/NiagaraMetadataService.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Niagara/NiagaraMetadataService.cpp
@@ -9,12 +9,281 @@
 #include "NiagaraGraph.h"
 #include "NiagaraNodeFunctionCall.h"
 #include "NiagaraNodeOutput.h"
+#include "NiagaraNodeInput.h"
+#include "NiagaraNodeStaticSwitch.h"
+#include "NiagaraNodeParameterMapSet.h"
+#include "NiagaraScriptVariable.h"
 #include "NiagaraScriptSource.h"
 #include "NiagaraTypes.h"
 #include "NiagaraCommon.h"
+#include "NiagaraDataInterfaceCurve.h"
+#include "NiagaraDataInterfaceColorCurve.h"
+#include "Curves/RichCurve.h"
 #include "ViewModels/Stack/NiagaraStackGraphUtilities.h"
 #include "ViewModels/Stack/NiagaraParameterHandle.h"
 #include "EdGraphSchema_Niagara.h"
+
+// Helper to find UNiagaraNodeStaticSwitch in module graph by parameter name
+static UNiagaraNodeStaticSwitch* FindStaticSwitchNodeByName(UNiagaraGraph* Graph, const FName& ParameterName)
+{
+    if (!Graph)
+    {
+        return nullptr;
+    }
+
+    TArray<UNiagaraNodeStaticSwitch*> StaticSwitchNodes;
+    Graph->GetNodesOfClass<UNiagaraNodeStaticSwitch>(StaticSwitchNodes);
+
+    for (UNiagaraNodeStaticSwitch* SwitchNode : StaticSwitchNodes)
+    {
+        if (SwitchNode && SwitchNode->InputParameterName == ParameterName)
+        {
+            return SwitchNode;
+        }
+    }
+
+    return nullptr;
+}
+
+// Helper to add enum options to JSON object from a static switch node
+static void AddStaticSwitchEnumOptions(TSharedPtr<FJsonObject>& InputObj, UNiagaraNodeStaticSwitch* SwitchNode, const FString& CurrentValue)
+{
+    if (!SwitchNode)
+    {
+        return;
+    }
+
+    // Access SwitchTypeData - it's a public member
+    const FStaticSwitchTypeData& SwitchTypeData = SwitchNode->SwitchTypeData;
+
+    if (SwitchTypeData.SwitchType == ENiagaraStaticSwitchType::Enum && SwitchTypeData.Enum)
+    {
+        UEnum* EnumType = SwitchTypeData.Enum;
+
+        // Store raw value
+        InputObj->SetStringField(TEXT("raw_value"), CurrentValue);
+
+        // Try to resolve display name from numeric value
+        if (CurrentValue.IsNumeric())
+        {
+            int32 Index = FCString::Atoi(*CurrentValue);
+            if (Index >= 0 && Index < EnumType->NumEnums() - 1)
+            {
+                FText DisplayNameText = EnumType->GetDisplayNameTextByIndex(Index);
+                if (!DisplayNameText.IsEmpty())
+                {
+                    InputObj->SetStringField(TEXT("value"), DisplayNameText.ToString());
+                }
+            }
+        }
+
+        // Add available options
+        TArray<TSharedPtr<FJsonValue>> OptionsArray;
+        for (int32 i = 0; i < EnumType->NumEnums() - 1; ++i) // -1 to skip MAX
+        {
+            TSharedPtr<FJsonObject> OptionObj = MakeShared<FJsonObject>();
+            OptionObj->SetNumberField(TEXT("index"), i);
+
+            FText DisplayText = EnumType->GetDisplayNameTextByIndex(i);
+            OptionObj->SetStringField(TEXT("display_name"), DisplayText.ToString());
+
+            FString InternalName = EnumType->GetNameStringByIndex(i);
+            OptionObj->SetStringField(TEXT("internal_name"), InternalName);
+
+            OptionsArray.Add(MakeShared<FJsonValueObject>(OptionObj));
+        }
+        InputObj->SetArrayField(TEXT("options"), OptionsArray);
+        InputObj->SetStringField(TEXT("input_type"), TEXT("enum"));
+    }
+    else if (SwitchTypeData.SwitchType == ENiagaraStaticSwitchType::Bool)
+    {
+        InputObj->SetStringField(TEXT("input_type"), TEXT("bool"));
+    }
+    else if (SwitchTypeData.SwitchType == ENiagaraStaticSwitchType::Integer)
+    {
+        InputObj->SetStringField(TEXT("input_type"), TEXT("integer"));
+
+        // For integer switches, try to get custom display names from ScriptVariable metadata
+        // Uses the exported GetScriptVariable(FName) overload from NiagaraGraph.h
+        UNiagaraGraph* ModuleGraph = SwitchNode->GetNiagaraGraph();
+        UNiagaraScriptVariable* ScriptVar = nullptr;
+        bool bHasEnumStyleNames = false;
+
+        if (ModuleGraph && !ModuleGraph->IsCompilationCopy())
+        {
+            // Use the simpler overload that takes just the parameter name (NIAGARAEDITOR_API exported)
+            ScriptVar = ModuleGraph->GetScriptVariable(SwitchNode->InputParameterName);
+            if (ScriptVar && ScriptVar->Metadata.WidgetCustomization.WidgetType == ENiagaraInputWidgetType::EnumStyle)
+            {
+                bHasEnumStyleNames = ScriptVar->Metadata.WidgetCustomization.EnumStyleDropdownValues.Num() > 0;
+            }
+        }
+
+        // Get option values
+        TArray<int32> OptionValues = SwitchNode->GetOptionValues();
+        if (OptionValues.Num() > 0)
+        {
+            TArray<TSharedPtr<FJsonValue>> OptionsArray;
+            for (int32 i = 0; i < OptionValues.Num(); ++i)
+            {
+                TSharedPtr<FJsonObject> OptionObj = MakeShared<FJsonObject>();
+                OptionObj->SetNumberField(TEXT("index"), i);
+                OptionObj->SetNumberField(TEXT("value"), OptionValues[i]);
+
+                // Try to get custom display name from EnumStyleDropdownValues
+                FString DisplayName;
+                if (bHasEnumStyleNames && ScriptVar->Metadata.WidgetCustomization.EnumStyleDropdownValues.IsValidIndex(i))
+                {
+                    DisplayName = ScriptVar->Metadata.WidgetCustomization.EnumStyleDropdownValues[i].DisplayName.ToString();
+                }
+
+                // Fallback to "Case N" if no custom name
+                if (DisplayName.IsEmpty())
+                {
+                    DisplayName = FString::Printf(TEXT("Case %d"), OptionValues[i]);
+                }
+                OptionObj->SetStringField(TEXT("display_name"), DisplayName);
+
+                OptionsArray.Add(MakeShared<FJsonValueObject>(OptionObj));
+            }
+            InputObj->SetArrayField(TEXT("options"), OptionsArray);
+
+            // Also resolve current value display name
+            if (bHasEnumStyleNames && CurrentValue.IsNumeric())
+            {
+                int32 CurrentIndex = FCString::Atoi(*CurrentValue);
+                if (ScriptVar->Metadata.WidgetCustomization.EnumStyleDropdownValues.IsValidIndex(CurrentIndex))
+                {
+                    FString ResolvedName = ScriptVar->Metadata.WidgetCustomization.EnumStyleDropdownValues[CurrentIndex].DisplayName.ToString();
+                    if (!ResolvedName.IsEmpty())
+                    {
+                        InputObj->SetStringField(TEXT("raw_value"), CurrentValue);
+                        InputObj->SetStringField(TEXT("value"), ResolvedName);
+                    }
+                }
+            }
+        }
+    }
+}
+
+// Helper to extract keyframes from a FRichCurve to JSON array
+static void ExtractCurveKeyframes(const FRichCurve& Curve, TArray<TSharedPtr<FJsonValue>>& OutKeyframes)
+{
+    const TArray<FRichCurveKey>& Keys = Curve.GetConstRefOfKeys();
+    for (const FRichCurveKey& Key : Keys)
+    {
+        TSharedPtr<FJsonObject> KeyObj = MakeShared<FJsonObject>();
+        KeyObj->SetNumberField(TEXT("time"), Key.Time);
+        KeyObj->SetNumberField(TEXT("value"), Key.Value);
+        OutKeyframes.Add(MakeShared<FJsonValueObject>(KeyObj));
+    }
+}
+
+// Helper to find curve DataInterface from a dynamic input function node
+static UNiagaraDataInterface* FindCurveDataInterfaceFromDynamicNode(UNiagaraNodeFunctionCall* DynamicNode)
+{
+    if (!DynamicNode)
+    {
+        return nullptr;
+    }
+
+    // Look through the dynamic node's input pins for a DataInterface connection
+    for (UEdGraphPin* Pin : DynamicNode->Pins)
+    {
+        if (Pin->Direction != EGPD_Input)
+        {
+            continue;
+        }
+
+        // Check if this pin is connected to a NiagaraNodeInput
+        if (Pin->LinkedTo.Num() > 0 && Pin->LinkedTo[0])
+        {
+            UEdGraphNode* ConnectedNode = Pin->LinkedTo[0]->GetOwningNode();
+            if (UNiagaraNodeInput* InputNode = Cast<UNiagaraNodeInput>(ConnectedNode))
+            {
+                // Check if this is a DataInterface
+                if (InputNode->Input.IsDataInterface())
+                {
+                    // Access the private DataInterface UPROPERTY via reflection
+                    FProperty* DIProperty = UNiagaraNodeInput::StaticClass()->FindPropertyByName(TEXT("DataInterface"));
+                    if (DIProperty)
+                    {
+                        FObjectPropertyBase* ObjProp = CastField<FObjectPropertyBase>(DIProperty);
+                        if (ObjProp)
+                        {
+                            UNiagaraDataInterface* DI = Cast<UNiagaraDataInterface>(ObjProp->GetObjectPropertyValue_InContainer(InputNode));
+                            // Check if it's a curve type
+                            if (DI && (DI->IsA<UNiagaraDataInterfaceCurve>() || DI->IsA<UNiagaraDataInterfaceColorCurve>()))
+                            {
+                                return DI;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    return nullptr;
+}
+
+// Helper to add curve data from a DataInterface to a JSON object
+static void AddCurveDataToJson(TSharedPtr<FJsonObject>& InputObj, UNiagaraDataInterface* DataInterface)
+{
+    if (!DataInterface)
+    {
+        return;
+    }
+
+    // Check for float curve
+    if (UNiagaraDataInterfaceCurve* FloatCurveDI = Cast<UNiagaraDataInterfaceCurve>(DataInterface))
+    {
+        InputObj->SetStringField(TEXT("curve_type"), TEXT("Float"));
+        TArray<TSharedPtr<FJsonValue>> Keyframes;
+        ExtractCurveKeyframes(FloatCurveDI->Curve, Keyframes);
+        if (Keyframes.Num() > 0)
+        {
+            InputObj->SetArrayField(TEXT("keyframes"), Keyframes);
+        }
+        return;
+    }
+
+    // Check for color curve
+    if (UNiagaraDataInterfaceColorCurve* ColorCurveDI = Cast<UNiagaraDataInterfaceColorCurve>(DataInterface))
+    {
+        InputObj->SetStringField(TEXT("curve_type"), TEXT("Color"));
+
+        TArray<TSharedPtr<FJsonValue>> ColorKeyframes;
+
+        // Get all unique time values across all channels
+        TSet<float> TimeValues;
+        for (const FRichCurveKey& Key : ColorCurveDI->RedCurve.GetConstRefOfKeys()) TimeValues.Add(Key.Time);
+        for (const FRichCurveKey& Key : ColorCurveDI->GreenCurve.GetConstRefOfKeys()) TimeValues.Add(Key.Time);
+        for (const FRichCurveKey& Key : ColorCurveDI->BlueCurve.GetConstRefOfKeys()) TimeValues.Add(Key.Time);
+        for (const FRichCurveKey& Key : ColorCurveDI->AlphaCurve.GetConstRefOfKeys()) TimeValues.Add(Key.Time);
+
+        // Sort and create combined keyframes
+        TArray<float> SortedTimes = TimeValues.Array();
+        SortedTimes.Sort();
+
+        for (float Time : SortedTimes)
+        {
+            TSharedPtr<FJsonObject> KeyObj = MakeShared<FJsonObject>();
+            KeyObj->SetNumberField(TEXT("time"), Time);
+            KeyObj->SetNumberField(TEXT("r"), ColorCurveDI->RedCurve.Eval(Time));
+            KeyObj->SetNumberField(TEXT("g"), ColorCurveDI->GreenCurve.Eval(Time));
+            KeyObj->SetNumberField(TEXT("b"), ColorCurveDI->BlueCurve.Eval(Time));
+            KeyObj->SetNumberField(TEXT("a"), ColorCurveDI->AlphaCurve.Eval(Time));
+            ColorKeyframes.Add(MakeShared<FJsonValueObject>(KeyObj));
+        }
+
+        if (ColorKeyframes.Num() > 0)
+        {
+            InputObj->SetArrayField(TEXT("keyframes"), ColorKeyframes);
+        }
+        return;
+    }
+}
 
 bool FNiagaraService::GetMetadata(const FString& AssetPath, const TArray<FString>* Fields, TSharedPtr<FJsonObject>& OutMetadata, const FString& EmitterName, const FString& Stage)
 {
@@ -101,6 +370,12 @@ bool FNiagaraService::GetModuleInputs(const FString& SystemPath, const FString& 
     case ENiagaraScriptUsage::ParticleUpdateScript:
         Script = EmitterData->UpdateScriptProps.Script;
         break;
+    case ENiagaraScriptUsage::EmitterSpawnScript:
+        Script = EmitterData->EmitterSpawnScriptProps.Script;
+        break;
+    case ENiagaraScriptUsage::EmitterUpdateScript:
+        Script = EmitterData->EmitterUpdateScriptProps.Script;
+        break;
     default:
         OutInputs->SetBoolField(TEXT("success"), false);
         OutInputs->SetStringField(TEXT("error"), FString::Printf(TEXT("Unsupported stage '%s'"), *Stage));
@@ -131,8 +406,9 @@ bool FNiagaraService::GetModuleInputs(const FString& SystemPath, const FString& 
         return false;
     }
 
-    // Find the module node by name
+    // Find the module node by name - prioritize exact matches
     UNiagaraNodeFunctionCall* ModuleNode = nullptr;
+    UNiagaraNodeFunctionCall* PartialMatchNode = nullptr;
     FString NormalizedSearchName = ModuleName.Replace(TEXT(" "), TEXT(""));
     for (UEdGraphNode* Node : Graph->Nodes)
     {
@@ -141,13 +417,24 @@ bool FNiagaraService::GetModuleInputs(const FString& SystemPath, const FString& 
         {
             FString NodeName = FunctionNode->GetFunctionName();
             FString NormalizedNodeName = NodeName.Replace(TEXT(" "), TEXT(""));
-            if (NormalizedNodeName.Contains(NormalizedSearchName, ESearchCase::IgnoreCase) ||
-                NormalizedSearchName.Contains(NormalizedNodeName, ESearchCase::IgnoreCase))
+
+            // Exact match takes priority
+            if (NormalizedNodeName.Equals(NormalizedSearchName, ESearchCase::IgnoreCase))
             {
                 ModuleNode = FunctionNode;
                 break;
             }
+            // Track partial match as fallback (only if search name contains node name, not vice versa)
+            if (!PartialMatchNode && NormalizedNodeName.Contains(NormalizedSearchName, ESearchCase::IgnoreCase))
+            {
+                PartialMatchNode = FunctionNode;
+            }
         }
+    }
+    // Use partial match only if no exact match found
+    if (!ModuleNode && PartialMatchNode)
+    {
+        ModuleNode = PartialMatchNode;
     }
 
     if (!ModuleNode)
@@ -197,230 +484,446 @@ bool FNiagaraService::GetModuleInputs(const FString& SystemPath, const FString& 
         FNiagaraTypeDefinition InputType = Input.GetType();
         InputObj->SetStringField(TEXT("type"), InputType.GetName());
 
-        // Try to read the actual value from RapidIterationParameters
         FString ValueStr = TEXT("[Unknown]");
         bool bFoundValue = false;
+        UNiagaraDataInterface* FoundDataInterface = nullptr;  // For curve extraction
+        FString ValueMode = TEXT("Local");
 
-        // Create the aliased handle and rapid iteration variable name
-        FNiagaraParameterHandle AliasedHandle = FNiagaraParameterHandle::CreateAliasedModuleParameterHandle(
-            Input.GetName(),
-            FName(*ModuleNode->GetFunctionName())
-        );
-
-        FNiagaraVariable InputVariable(InputType, FName(*AliasedHandle.GetParameterHandleString().ToString()));
-        FNiagaraVariable RapidIterationVariable = FNiagaraUtilities::ConvertVariableToRapidIterationConstantName(
-            InputVariable,
-            *UniqueEmitterName,
-            ScriptUsage
-        );
-
-        // Try to get the value from the script's RapidIterationParameters using safe FNiagaraVariable::SetData
-        const uint8* ParameterData = Script->RapidIterationParameters.GetParameterData(RapidIterationVariable);
-
-        if (ParameterData)
+        // FIRST: Check if this input's pin is connected to something
+        // This takes priority over RapidIterationParameters because connections override local values
+        UEdGraphPin* MatchingPin = nullptr;
+        for (UEdGraphPin* Pin : ModuleNode->Pins)
         {
-            // Use FNiagaraVariable's safe SetData method, then read from the variable
-            FNiagaraVariable TempVar(InputType, RapidIterationVariable.GetName());
-            TempVar.SetData(ParameterData);
-
-            // Now read from the variable's safely allocated data
-            const uint8* SafeData = TempVar.GetData();
-            if (SafeData)
+            if (Pin->Direction != EGPD_Input)
             {
-                if (InputType == FNiagaraTypeDefinition::GetFloatDef())
+                continue;
+            }
+
+            // Match pin by name (handle both "Module.X" and "X" formats)
+            FString PinNameStr = Pin->PinName.ToString();
+            if (PinNameStr.Contains(SimpleName, ESearchCase::IgnoreCase) ||
+                SimpleName.Contains(PinNameStr, ESearchCase::IgnoreCase))
+            {
+                MatchingPin = Pin;
+                break;
+            }
+        }
+
+        // Check if the pin is connected to something
+        if (MatchingPin && MatchingPin->LinkedTo.Num() > 0 && MatchingPin->LinkedTo[0] && MatchingPin->LinkedTo[0]->GetOwningNode())
+        {
+            // Pin is linked - determine the value mode from the linked node
+            UEdGraphNode* LinkedNode = MatchingPin->LinkedTo[0]->GetOwningNode();
+            FString LinkedClassName = LinkedNode->GetClass()->GetName();
+
+            if (UNiagaraNodeFunctionCall* DynamicNode = Cast<UNiagaraNodeFunctionCall>(LinkedNode))
+            {
+                // Dynamic input (curve, random range, etc.)
+                ValueMode = TEXT("Dynamic");
+                ValueStr = FString::Printf(TEXT("[Dynamic: %s]"), *DynamicNode->GetFunctionName());
+                bFoundValue = true;
+
+                // Check if this dynamic input has a curve DataInterface
+                UNiagaraDataInterface* CurveDI = FindCurveDataInterfaceFromDynamicNode(DynamicNode);
+                if (CurveDI)
                 {
-                    float FloatValue = TempVar.GetValue<float>();
-                    ValueStr = FString::Printf(TEXT("%.4f"), FloatValue);
-                    bFoundValue = true;
+                    FoundDataInterface = CurveDI;
                 }
-                else if (InputType == FNiagaraTypeDefinition::GetIntDef())
+            }
+            else if (LinkedClassName.Contains(TEXT("ParameterMapGet")))
+            {
+                // Linked to another parameter
+                ValueMode = TEXT("Linked");
+                FNiagaraVariable LinkedVar = UEdGraphSchema_Niagara::PinToNiagaraVariable(MatchingPin->LinkedTo[0]);
+                ValueStr = FString::Printf(TEXT("[Linked: %s]"), *LinkedVar.GetName().ToString());
+                bFoundValue = true;
+            }
+            else if (LinkedClassName.Contains(TEXT("CustomHlsl")))
+            {
+                // Custom expression
+                ValueMode = TEXT("Expression");
+                ValueStr = TEXT("[Expression]");
+                bFoundValue = true;
+            }
+            else if (LinkedClassName.Contains(TEXT("NiagaraNodeInput")))
+            {
+                // Data interface or object asset
+                ValueMode = TEXT("DataInterface");
+                if (UNiagaraNodeInput* InputNode = Cast<UNiagaraNodeInput>(LinkedNode))
                 {
-                    int32 IntValue = TempVar.GetValue<int32>();
-                    ValueStr = FString::Printf(TEXT("%d"), IntValue);
-                    bFoundValue = true;
-                }
-                else if (InputType == FNiagaraTypeDefinition::GetBoolDef())
-                {
-                    FNiagaraBool BoolValue = TempVar.GetValue<FNiagaraBool>();
-                    ValueStr = BoolValue.IsValid() && BoolValue.GetValue() ? TEXT("true") : TEXT("false");
-                    bFoundValue = true;
-                }
-                else if (InputType == FNiagaraTypeDefinition::GetVec2Def())
-                {
-                    FVector2f Vec = TempVar.GetValue<FVector2f>();
-                    ValueStr = FString::Printf(TEXT("(%.4f, %.4f)"), Vec.X, Vec.Y);
-                    bFoundValue = true;
-                }
-                else if (InputType == FNiagaraTypeDefinition::GetVec3Def())
-                {
-                    FVector3f Vec = TempVar.GetValue<FVector3f>();
-                    ValueStr = FString::Printf(TEXT("(%.4f, %.4f, %.4f)"), Vec.X, Vec.Y, Vec.Z);
-                    bFoundValue = true;
-                }
-                else if (InputType == FNiagaraTypeDefinition::GetVec4Def())
-                {
-                    FVector4f Vec = TempVar.GetValue<FVector4f>();
-                    ValueStr = FString::Printf(TEXT("(%.4f, %.4f, %.4f, %.4f)"), Vec.X, Vec.Y, Vec.Z, Vec.W);
-                    bFoundValue = true;
-                }
-                else if (InputType == FNiagaraTypeDefinition::GetColorDef())
-                {
-                    FLinearColor Color = TempVar.GetValue<FLinearColor>();
-                    ValueStr = FString::Printf(TEXT("(R=%.4f, G=%.4f, B=%.4f, A=%.4f)"), Color.R, Color.G, Color.B, Color.A);
-                    bFoundValue = true;
-                }
-                else if (InputType == FNiagaraTypeDefinition::GetQuatDef())
-                {
-                    FQuat4f Quat = TempVar.GetValue<FQuat4f>();
-                    ValueStr = FString::Printf(TEXT("(X=%.4f, Y=%.4f, Z=%.4f, W=%.4f)"), Quat.X, Quat.Y, Quat.Z, Quat.W);
-                    bFoundValue = true;
+                    // Use FNiagaraVariable::IsDataInterface() which is exported from Niagara runtime
+                    if (InputNode->Input.IsDataInterface())
+                    {
+                        // Access the private DataInterface UPROPERTY via reflection
+                        FProperty* DIProperty = UNiagaraNodeInput::StaticClass()->FindPropertyByName(TEXT("DataInterface"));
+                        if (DIProperty)
+                        {
+                            FObjectPropertyBase* ObjProp = CastField<FObjectPropertyBase>(DIProperty);
+                            if (ObjProp)
+                            {
+                                FoundDataInterface = Cast<UNiagaraDataInterface>(ObjProp->GetObjectPropertyValue_InContainer(InputNode));
+                            }
+                        }
+
+                        if (FoundDataInterface)
+                        {
+                            ValueStr = FString::Printf(TEXT("[DataInterface: %s]"), *FoundDataInterface->GetClass()->GetName());
+                        }
+                        else
+                        {
+                            ValueStr = TEXT("[DataInterface: Unset]");
+                        }
+                    }
+                    else
+                    {
+                        ValueStr = FString::Printf(TEXT("[Input: %s]"), *InputNode->Input.GetName().ToString());
+                    }
                 }
                 else
                 {
-                    // Report the type name for complex/unknown types
-                    ValueStr = FString::Printf(TEXT("[RapidIter: %s]"), *InputType.GetName());
-                    bFoundValue = true;
+                    ValueStr = FString::Printf(TEXT("[%s]"), *LinkedClassName);
+                }
+                bFoundValue = true;
+            }
+            else
+            {
+                ValueMode = TEXT("Linked");
+                ValueStr = FString::Printf(TEXT("[Linked: %s]"), *LinkedClassName);
+                bFoundValue = true;
+            }
+        }
+
+        // CHECK OVERRIDE PINS: If no value found yet, check for override pins via parameter map nodes
+        // Override pins are created in a NiagaraNodeParameterMapSet node connected to the module
+        if (!bFoundValue)
+        {
+            FNiagaraParameterHandle AliasedHandle = FNiagaraParameterHandle::CreateAliasedModuleParameterHandle(
+                Input.GetName(),
+                FName(*ModuleNode->GetFunctionName())
+            );
+            FString AliasedHandleStr = AliasedHandle.GetParameterHandleString().ToString();
+
+            // Find parameter map set nodes in the graph that might have override pins for this module
+            for (UEdGraphNode* Node : Graph->Nodes)
+            {
+                UNiagaraNodeParameterMapSet* MapSetNode = Cast<UNiagaraNodeParameterMapSet>(Node);
+                if (!MapSetNode)
+                {
+                    continue;
+                }
+
+                // Check if this map set node is connected to our module (via parameter map output)
+                bool bConnectedToModule = false;
+                for (UEdGraphPin* Pin : MapSetNode->Pins)
+                {
+                    if (Pin->Direction == EGPD_Output && Pin->LinkedTo.Num() > 0)
+                    {
+                        for (UEdGraphPin* LinkedPin : Pin->LinkedTo)
+                        {
+                            if (LinkedPin && LinkedPin->GetOwningNode() == ModuleNode)
+                            {
+                                bConnectedToModule = true;
+                                break;
+                            }
+                        }
+                    }
+                    if (bConnectedToModule)
+                    {
+                        break;
+                    }
+                }
+
+                if (!bConnectedToModule)
+                {
+                    continue;
+                }
+
+                // Look through this map set node's input pins for one matching our aliased handle
+                for (UEdGraphPin* Pin : MapSetNode->Pins)
+                {
+                    if (Pin->Direction != EGPD_Input)
+                    {
+                        continue;
+                    }
+
+                    FString PinName = Pin->PinName.ToString();
+                    // Check if this pin matches our aliased handle (e.g., "ScaleSpriteSize.Uniform Curve Sprite Scale")
+                    if (PinName.Contains(AliasedHandleStr, ESearchCase::IgnoreCase) ||
+                        AliasedHandleStr.Contains(PinName, ESearchCase::IgnoreCase) ||
+                        PinName.EndsWith(SimpleName, ESearchCase::IgnoreCase))
+                    {
+                        if (Pin->LinkedTo.Num() > 0 && Pin->LinkedTo[0])
+                        {
+                            UEdGraphNode* LinkedNode = Pin->LinkedTo[0]->GetOwningNode();
+                            if (UNiagaraNodeInput* InputNode = Cast<UNiagaraNodeInput>(LinkedNode))
+                            {
+                                if (InputNode->Input.IsDataInterface())
+                                {
+                                    ValueMode = TEXT("DataInterface");
+                                    FProperty* DIProperty = UNiagaraNodeInput::StaticClass()->FindPropertyByName(TEXT("DataInterface"));
+                                    if (DIProperty)
+                                    {
+                                        FObjectPropertyBase* ObjProp = CastField<FObjectPropertyBase>(DIProperty);
+                                        if (ObjProp)
+                                        {
+                                            FoundDataInterface = Cast<UNiagaraDataInterface>(ObjProp->GetObjectPropertyValue_InContainer(InputNode));
+                                        }
+                                    }
+
+                                    if (FoundDataInterface)
+                                    {
+                                        ValueStr = FString::Printf(TEXT("[DataInterface: %s]"), *FoundDataInterface->GetClass()->GetName());
+                                        bFoundValue = true;
+                                    }
+                                }
+                            }
+                            else if (UNiagaraNodeFunctionCall* DynamicNode = Cast<UNiagaraNodeFunctionCall>(LinkedNode))
+                            {
+                                ValueMode = TEXT("Dynamic");
+                                ValueStr = FString::Printf(TEXT("[Dynamic: %s]"), *DynamicNode->GetFunctionName());
+                                bFoundValue = true;
+
+                                UNiagaraDataInterface* CurveDI = FindCurveDataInterfaceFromDynamicNode(DynamicNode);
+                                if (CurveDI)
+                                {
+                                    FoundDataInterface = CurveDI;
+                                }
+                            }
+                        }
+                        if (bFoundValue)
+                        {
+                            break;
+                        }
+                    }
+                }
+                if (bFoundValue)
+                {
+                    break;
                 }
             }
         }
 
-        // If not found in rapid iteration params, check module pins directly
-        FString ValueMode = TEXT("Local");
+        // SECOND: If pin is NOT connected, try RapidIterationParameters for local values
         if (!bFoundValue)
         {
-            // Search for matching input pin on the module node
-            for (UEdGraphPin* Pin : ModuleNode->Pins)
+            // Create the aliased handle and rapid iteration variable name
+            FNiagaraParameterHandle AliasedHandle = FNiagaraParameterHandle::CreateAliasedModuleParameterHandle(
+                Input.GetName(),
+                FName(*ModuleNode->GetFunctionName())
+            );
+
+            FNiagaraVariable InputVariable(InputType, FName(*AliasedHandle.GetParameterHandleString().ToString()));
+            FNiagaraVariable RapidIterationVariable = FNiagaraUtilities::ConvertVariableToRapidIterationConstantName(
+                InputVariable,
+                *UniqueEmitterName,
+                ScriptUsage
+            );
+
+            // Try to get the value from the script's RapidIterationParameters
+            const uint8* ParameterData = Script->RapidIterationParameters.GetParameterData(RapidIterationVariable);
+
+            if (ParameterData)
             {
-                if (Pin->Direction != EGPD_Input)
-                {
-                    continue;
-                }
+                // Use FNiagaraVariable's safe SetData method, then read from the variable
+                FNiagaraVariable TempVar(InputType, RapidIterationVariable.GetName());
+                TempVar.SetData(ParameterData);
 
-                // Match pin by name (handle both "Module.X" and "X" formats)
-                FString PinNameStr = Pin->PinName.ToString();
-                if (!PinNameStr.Contains(SimpleName, ESearchCase::IgnoreCase) &&
-                    !SimpleName.Contains(PinNameStr, ESearchCase::IgnoreCase))
+                // Now read from the variable's safely allocated data
+                const uint8* SafeData = TempVar.GetData();
+                if (SafeData)
                 {
-                    continue;
-                }
-
-                if (Pin->LinkedTo.Num() > 0 && Pin->LinkedTo[0] && Pin->LinkedTo[0]->GetOwningNode())
-                {
-                    // Pin is linked - determine the value mode from the linked node
-                    UEdGraphNode* LinkedNode = Pin->LinkedTo[0]->GetOwningNode();
-                    FString LinkedClassName = LinkedNode->GetClass()->GetName();
-
-                    if (UNiagaraNodeFunctionCall* DynamicNode = Cast<UNiagaraNodeFunctionCall>(LinkedNode))
+                    if (InputType == FNiagaraTypeDefinition::GetFloatDef())
                     {
-                        // Dynamic input (curve, random range, etc.)
-                        ValueMode = TEXT("Dynamic");
-                        ValueStr = FString::Printf(TEXT("[Dynamic: %s]"), *DynamicNode->GetFunctionName());
+                        float FloatValue = TempVar.GetValue<float>();
+                        ValueStr = FString::Printf(TEXT("%.4f"), FloatValue);
                         bFoundValue = true;
                     }
-                    else if (LinkedClassName.Contains(TEXT("ParameterMapGet")))
+                    else if (InputType == FNiagaraTypeDefinition::GetIntDef())
                     {
-                        // Linked to another parameter
-                        ValueMode = TEXT("Linked");
-                        FNiagaraVariable LinkedVar = UEdGraphSchema_Niagara::PinToNiagaraVariable(Pin->LinkedTo[0]);
-                        ValueStr = FString::Printf(TEXT("[Linked: %s]"), *LinkedVar.GetName().ToString());
+                        int32 IntValue = TempVar.GetValue<int32>();
+                        ValueStr = FString::Printf(TEXT("%d"), IntValue);
                         bFoundValue = true;
                     }
-                    else if (LinkedClassName.Contains(TEXT("CustomHlsl")))
+                    else if (InputType == FNiagaraTypeDefinition::GetBoolDef())
                     {
-                        // Custom expression
-                        ValueMode = TEXT("Expression");
-                        ValueStr = TEXT("[Expression]");
+                        FNiagaraBool BoolValue = TempVar.GetValue<FNiagaraBool>();
+                        ValueStr = BoolValue.IsValid() && BoolValue.GetValue() ? TEXT("true") : TEXT("false");
                         bFoundValue = true;
                     }
-                    else if (LinkedClassName.Contains(TEXT("NiagaraNodeInput")))
+                    else if (InputType == FNiagaraTypeDefinition::GetVec2Def())
                     {
-                        // Data interface or object asset
-                        ValueMode = TEXT("DataInterface");
-                        ValueStr = FString::Printf(TEXT("[%s]"), *LinkedClassName);
+                        FVector2f Vec = TempVar.GetValue<FVector2f>();
+                        ValueStr = FString::Printf(TEXT("(%.4f, %.4f)"), Vec.X, Vec.Y);
+                        bFoundValue = true;
+                    }
+                    else if (InputType == FNiagaraTypeDefinition::GetVec3Def())
+                    {
+                        FVector3f Vec = TempVar.GetValue<FVector3f>();
+                        ValueStr = FString::Printf(TEXT("(%.4f, %.4f, %.4f)"), Vec.X, Vec.Y, Vec.Z);
+                        bFoundValue = true;
+                    }
+                    else if (InputType == FNiagaraTypeDefinition::GetVec4Def())
+                    {
+                        FVector4f Vec = TempVar.GetValue<FVector4f>();
+                        ValueStr = FString::Printf(TEXT("(%.4f, %.4f, %.4f, %.4f)"), Vec.X, Vec.Y, Vec.Z, Vec.W);
+                        bFoundValue = true;
+                    }
+                    else if (InputType == FNiagaraTypeDefinition::GetColorDef())
+                    {
+                        FLinearColor Color = TempVar.GetValue<FLinearColor>();
+                        ValueStr = FString::Printf(TEXT("(R=%.4f, G=%.4f, B=%.4f, A=%.4f)"), Color.R, Color.G, Color.B, Color.A);
+                        bFoundValue = true;
+                    }
+                    else if (InputType == FNiagaraTypeDefinition::GetQuatDef())
+                    {
+                        FQuat4f Quat = TempVar.GetValue<FQuat4f>();
+                        ValueStr = FString::Printf(TEXT("(X=%.4f, Y=%.4f, Z=%.4f, W=%.4f)"), Quat.X, Quat.Y, Quat.Z, Quat.W);
                         bFoundValue = true;
                     }
                     else
                     {
-                        ValueMode = TEXT("Linked");
-                        ValueStr = FString::Printf(TEXT("[Linked: %s]"), *LinkedClassName);
+                        // Report the type name for complex/unknown types
+                        ValueStr = FString::Printf(TEXT("[RapidIter: %s]"), *InputType.GetName());
                         bFoundValue = true;
                     }
                 }
-                else if (!Pin->DefaultValue.IsEmpty())
+            }
+        }
+
+        // THIRD: If still not found, check pin default values (pin connections already handled above)
+        if (!bFoundValue && MatchingPin)
+        {
+            if (!MatchingPin->DefaultValue.IsEmpty())
+            {
+                // Local value - try to read properly using PinToNiagaraVariable
+                const UEdGraphSchema_Niagara* NiagaraSchema = GetDefault<UEdGraphSchema_Niagara>();
+                FNiagaraVariable ValueVariable = NiagaraSchema->PinToNiagaraVariable(MatchingPin, false);
+
+                if (ValueVariable.IsDataAllocated())
                 {
-                    // Local value - try to read properly using PinToNiagaraVariable
-                    const UEdGraphSchema_Niagara* NiagaraSchema = GetDefault<UEdGraphSchema_Niagara>();
-                    FNiagaraVariable ValueVariable = NiagaraSchema->PinToNiagaraVariable(Pin, false);
+                    // Use the actual variable type, not InputType (they may differ)
+                    FNiagaraTypeDefinition ActualType = ValueVariable.GetType();
 
-                    if (ValueVariable.IsDataAllocated())
+                    // Read the value from the variable using its actual type
+                    if (ActualType == FNiagaraTypeDefinition::GetFloatDef())
                     {
-                        // Use the actual variable type, not InputType (they may differ)
-                        FNiagaraTypeDefinition ActualType = ValueVariable.GetType();
+                        float FloatValue = ValueVariable.GetValue<float>();
+                        ValueStr = FString::Printf(TEXT("%.4f"), FloatValue);
+                        bFoundValue = true;
+                    }
+                    else if (ActualType == FNiagaraTypeDefinition::GetIntDef())
+                    {
+                        int32 IntValue = ValueVariable.GetValue<int32>();
+                        ValueStr = FString::Printf(TEXT("%d"), IntValue);
+                        bFoundValue = true;
+                    }
+                    else if (ActualType == FNiagaraTypeDefinition::GetBoolDef())
+                    {
+                        FNiagaraBool BoolValue = ValueVariable.GetValue<FNiagaraBool>();
+                        ValueStr = BoolValue.IsValid() && BoolValue.GetValue() ? TEXT("true") : TEXT("false");
+                        bFoundValue = true;
+                    }
+                    else if (ActualType == FNiagaraTypeDefinition::GetVec2Def())
+                    {
+                        FVector2f Vec = ValueVariable.GetValue<FVector2f>();
+                        ValueStr = FString::Printf(TEXT("(%.4f, %.4f)"), Vec.X, Vec.Y);
+                        bFoundValue = true;
+                    }
+                    else if (ActualType == FNiagaraTypeDefinition::GetVec3Def())
+                    {
+                        FVector3f Vec = ValueVariable.GetValue<FVector3f>();
+                        ValueStr = FString::Printf(TEXT("(%.4f, %.4f, %.4f)"), Vec.X, Vec.Y, Vec.Z);
+                        bFoundValue = true;
+                    }
+                    else if (ActualType == FNiagaraTypeDefinition::GetColorDef())
+                    {
+                        FLinearColor Color = ValueVariable.GetValue<FLinearColor>();
+                        ValueStr = FString::Printf(TEXT("(R=%.4f, G=%.4f, B=%.4f, A=%.4f)"), Color.R, Color.G, Color.B, Color.A);
+                        bFoundValue = true;
+                    }
+                }
 
-                        // Read the value from the variable using its actual type
-                        if (ActualType == FNiagaraTypeDefinition::GetFloatDef())
+                if (!bFoundValue)
+                {
+                    // Fall back to pin default value string, resolve enum names
+                    ValueStr = MatchingPin->DefaultValue;
+
+                    // Try to resolve enum display names
+                    bool bEnumResolved = false;
+                    if (UEnum* EnumType = Cast<UEnum>(MatchingPin->PinType.PinSubCategoryObject.Get()))
+                    {
+                        int64 EnumValue = INDEX_NONE;
+
+                        // First try to parse as numeric index (common for static switches)
+                        if (ValueStr.IsNumeric())
                         {
-                            float FloatValue = ValueVariable.GetValue<float>();
-                            ValueStr = FString::Printf(TEXT("%.4f"), FloatValue);
-                            bFoundValue = true;
+                            int32 Index = FCString::Atoi(*ValueStr);
+                            if (Index >= 0 && Index < EnumType->NumEnums() - 1) // -1 to skip MAX value
+                            {
+                                EnumValue = Index;
+                            }
                         }
-                        else if (ActualType == FNiagaraTypeDefinition::GetIntDef())
+
+                        // If not numeric, try to find by name
+                        if (EnumValue == INDEX_NONE)
                         {
-                            int32 IntValue = ValueVariable.GetValue<int32>();
-                            ValueStr = FString::Printf(TEXT("%d"), IntValue);
-                            bFoundValue = true;
+                            EnumValue = EnumType->GetValueByNameString(ValueStr);
                         }
-                        else if (ActualType == FNiagaraTypeDefinition::GetBoolDef())
+
+                        // Get display name if we found a valid value
+                        if (EnumValue != INDEX_NONE)
                         {
-                            FNiagaraBool BoolValue = ValueVariable.GetValue<FNiagaraBool>();
-                            ValueStr = BoolValue.IsValid() && BoolValue.GetValue() ? TEXT("true") : TEXT("false");
-                            bFoundValue = true;
+                            FText DisplayNameText = EnumType->GetDisplayNameTextByValue(EnumValue);
+                            if (!DisplayNameText.IsEmpty())
+                            {
+                                // Store raw value for debugging
+                                InputObj->SetStringField(TEXT("raw_value"), ValueStr);
+                                ValueStr = DisplayNameText.ToString();
+                            }
                         }
-                        else if (ActualType == FNiagaraTypeDefinition::GetVec2Def())
+
+                        // Add available options for enum types
+                        TArray<TSharedPtr<FJsonValue>> OptionsArray;
+                        for (int32 i = 0; i < EnumType->NumEnums() - 1; ++i) // -1 to skip MAX value
                         {
-                            FVector2f Vec = ValueVariable.GetValue<FVector2f>();
-                            ValueStr = FString::Printf(TEXT("(%.4f, %.4f)"), Vec.X, Vec.Y);
-                            bFoundValue = true;
+                            TSharedPtr<FJsonObject> OptionObj = MakeShared<FJsonObject>();
+                            OptionObj->SetNumberField(TEXT("index"), i);
+
+                            FText DisplayText = EnumType->GetDisplayNameTextByIndex(i);
+                            OptionObj->SetStringField(TEXT("display_name"), DisplayText.ToString());
+
+                            FString InternalName = EnumType->GetNameStringByIndex(i);
+                            OptionObj->SetStringField(TEXT("internal_name"), InternalName);
+
+                            OptionsArray.Add(MakeShared<FJsonValueObject>(OptionObj));
                         }
-                        else if (ActualType == FNiagaraTypeDefinition::GetVec3Def())
-                        {
-                            FVector3f Vec = ValueVariable.GetValue<FVector3f>();
-                            ValueStr = FString::Printf(TEXT("(%.4f, %.4f, %.4f)"), Vec.X, Vec.Y, Vec.Z);
-                            bFoundValue = true;
-                        }
-                        else if (ActualType == FNiagaraTypeDefinition::GetColorDef())
-                        {
-                            FLinearColor Color = ValueVariable.GetValue<FLinearColor>();
-                            ValueStr = FString::Printf(TEXT("(R=%.4f, G=%.4f, B=%.4f, A=%.4f)"), Color.R, Color.G, Color.B, Color.A);
-                            bFoundValue = true;
-                        }
+                        InputObj->SetArrayField(TEXT("options"), OptionsArray);
+                        InputObj->SetStringField(TEXT("input_type"), TEXT("enum"));
+                        bEnumResolved = true;
                     }
 
-                    if (!bFoundValue)
+                    // Fallback for Niagara static switches - check module's internal graph
+                    if (!bEnumResolved && MatchingPin->PinType.PinCategory.ToString() == TEXT("Type"))
                     {
-                        // Fall back to pin default value string, resolve enum names
-                        ValueStr = Pin->DefaultValue;
-
-                        // Try to resolve enum display names
-                        if (UEnum* EnumType = Cast<UEnum>(Pin->PinType.PinSubCategoryObject.Get()))
+                        // Get the module's internal graph to find static switch nodes
+                        UNiagaraGraph* ModuleGraph = ModuleNode->GetCalledGraph();
+                        if (ModuleGraph)
                         {
-                            int64 EnumValue = EnumType->GetValueByNameString(ValueStr);
-                            if (EnumValue != INDEX_NONE)
+                            // Find static switch by pin name
+                            UNiagaraNodeStaticSwitch* SwitchNode = FindStaticSwitchNodeByName(ModuleGraph, MatchingPin->PinName);
+                            if (SwitchNode)
                             {
-                                FText DisplayNameText = EnumType->GetDisplayNameTextByValue(EnumValue);
-                                if (!DisplayNameText.IsEmpty())
+                                // Use helper to add enum options from the static switch node
+                                AddStaticSwitchEnumOptions(InputObj, SwitchNode, ValueStr);
+                                // Update ValueStr if helper resolved it
+                                if (InputObj->HasField(TEXT("value")))
                                 {
-                                    ValueStr = DisplayNameText.ToString();
+                                    ValueStr = InputObj->GetStringField(TEXT("value"));
                                 }
                             }
                         }
-                        bFoundValue = true;
                     }
-                }
-
-                if (bFoundValue)
-                {
-                    break;
+                    bFoundValue = true;
                 }
             }
         }
@@ -432,6 +935,13 @@ bool FNiagaraService::GetModuleInputs(const FString& SystemPath, const FString& 
 
         InputObj->SetStringField(TEXT("value"), ValueStr);
         InputObj->SetStringField(TEXT("value_mode"), ValueMode);
+
+        // Extract curve keyframes if we found a curve DataInterface
+        if (FoundDataInterface)
+        {
+            AddCurveDataToJson(InputObj, FoundDataInterface);
+        }
+
         InputsArray.Add(MakeShared<FJsonValueObject>(InputObj));
     }
 
@@ -492,16 +1002,78 @@ bool FNiagaraService::GetModuleInputs(const FString& SystemPath, const FString& 
 
                 // Resolve enum display names for better readability
                 // Enum pins have PinSubCategoryObject set to the UEnum*
+                bool bEnumResolved = false;
                 if (UEnum* EnumType = Cast<UEnum>(Pin->PinType.PinSubCategoryObject.Get()))
                 {
-                    // Try to find the enum value by name and get its display name
-                    int64 EnumValue = EnumType->GetValueByNameString(Value);
+                    int64 EnumValue = INDEX_NONE;
+
+                    // First try to parse as numeric index (common for static switches)
+                    if (Value.IsNumeric())
+                    {
+                        int32 Index = FCString::Atoi(*Value);
+                        if (Index >= 0 && Index < EnumType->NumEnums() - 1) // -1 to skip MAX value
+                        {
+                            EnumValue = Index;
+                        }
+                    }
+
+                    // If not numeric, try to find by name
+                    if (EnumValue == INDEX_NONE)
+                    {
+                        EnumValue = EnumType->GetValueByNameString(Value);
+                    }
+
+                    // Get display name if we found a valid value
                     if (EnumValue != INDEX_NONE)
                     {
                         FText DisplayNameText = EnumType->GetDisplayNameTextByValue(EnumValue);
                         if (!DisplayNameText.IsEmpty())
                         {
+                            // Store both raw and display value
+                            InputObj->SetStringField(TEXT("raw_value"), Value);
                             Value = DisplayNameText.ToString();
+                        }
+                    }
+
+                    // Add available options for enum types
+                    TArray<TSharedPtr<FJsonValue>> OptionsArray;
+                    for (int32 i = 0; i < EnumType->NumEnums() - 1; ++i) // -1 to skip MAX value
+                    {
+                        TSharedPtr<FJsonObject> OptionObj = MakeShared<FJsonObject>();
+                        OptionObj->SetNumberField(TEXT("index"), i);
+
+                        FText DisplayText = EnumType->GetDisplayNameTextByIndex(i);
+                        OptionObj->SetStringField(TEXT("display_name"), DisplayText.ToString());
+
+                        FString InternalName = EnumType->GetNameStringByIndex(i);
+                        OptionObj->SetStringField(TEXT("internal_name"), InternalName);
+
+                        OptionsArray.Add(MakeShared<FJsonValueObject>(OptionObj));
+                    }
+                    InputObj->SetArrayField(TEXT("options"), OptionsArray);
+                    InputObj->SetStringField(TEXT("input_type"), TEXT("enum"));
+                    bEnumResolved = true;
+                }
+
+                // Fallback for Niagara static switches - check module's internal graph
+                // Static switches in Niagara don't expose UEnum via PinSubCategoryObject
+                if (!bEnumResolved && Pin->PinType.PinCategory.ToString() == TEXT("Type"))
+                {
+                    // Get the module's internal graph to find static switch nodes
+                    UNiagaraGraph* ModuleGraph = ModuleNode->GetCalledGraph();
+                    if (ModuleGraph)
+                    {
+                        // Find static switch by pin name
+                        UNiagaraNodeStaticSwitch* SwitchNode = FindStaticSwitchNodeByName(ModuleGraph, Pin->PinName);
+                        if (SwitchNode)
+                        {
+                            // Use helper to add enum options from the static switch node
+                            AddStaticSwitchEnumOptions(InputObj, SwitchNode, Value);
+                            // Update Value if helper resolved it
+                            if (InputObj->HasField(TEXT("value")))
+                            {
+                                Value = InputObj->GetStringField(TEXT("value"));
+                            }
                         }
                     }
                 }
@@ -660,6 +1232,20 @@ bool FNiagaraService::GetEmitterModules(const FString& SystemPath, const FString
     // Build the stages object
     TSharedPtr<FJsonObject> StagesObj = MakeShared<FJsonObject>();
 
+    // Get Emitter Spawn modules (emitter-level initialization)
+    TArray<TSharedPtr<FJsonValue>> EmitterSpawnModules = ExtractModulesFromScript(
+        EmitterData->EmitterSpawnScriptProps.Script,
+        ENiagaraScriptUsage::EmitterSpawnScript
+    );
+    StagesObj->SetArrayField(TEXT("EmitterSpawn"), EmitterSpawnModules);
+
+    // Get Emitter Update modules (spawn rate, spawn burst, etc.)
+    TArray<TSharedPtr<FJsonValue>> EmitterUpdateModules = ExtractModulesFromScript(
+        EmitterData->EmitterUpdateScriptProps.Script,
+        ENiagaraScriptUsage::EmitterUpdateScript
+    );
+    StagesObj->SetArrayField(TEXT("EmitterUpdate"), EmitterUpdateModules);
+
     // Get Particle Spawn modules
     TArray<TSharedPtr<FJsonValue>> SpawnModules = ExtractModulesFromScript(
         EmitterData->SpawnScriptProps.Script,
@@ -699,8 +1285,10 @@ bool FNiagaraService::GetEmitterModules(const FString& SystemPath, const FString
     OutModules->SetObjectField(TEXT("stages"), StagesObj);
 
     // Add summary counts
-    int32 TotalModules = SpawnModules.Num() + UpdateModules.Num() + EventModulesArray.Num();
+    int32 TotalModules = EmitterSpawnModules.Num() + EmitterUpdateModules.Num() + SpawnModules.Num() + UpdateModules.Num() + EventModulesArray.Num();
     OutModules->SetNumberField(TEXT("total_module_count"), TotalModules);
+    OutModules->SetNumberField(TEXT("emitter_spawn_count"), EmitterSpawnModules.Num());
+    OutModules->SetNumberField(TEXT("emitter_update_count"), EmitterUpdateModules.Num());
     OutModules->SetNumberField(TEXT("spawn_count"), SpawnModules.Num());
     OutModules->SetNumberField(TEXT("update_count"), UpdateModules.Num());
     if (EventModulesArray.Num() > 0)

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Niagara/NiagaraRandomInputService.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Niagara/NiagaraRandomInputService.cpp
@@ -25,6 +25,8 @@ static UNiagaraNodeFunctionCall* FindModuleNodeByNameForRandom(
     const FString& ModuleName)
 {
     FString NormalizedSearchName = ModuleName.Replace(TEXT(" "), TEXT(""));
+    UNiagaraNodeFunctionCall* PartialMatchNode = nullptr;
+
     for (UEdGraphNode* Node : Graph->Nodes)
     {
         UNiagaraNodeFunctionCall* FunctionNode = Cast<UNiagaraNodeFunctionCall>(Node);
@@ -32,14 +34,20 @@ static UNiagaraNodeFunctionCall* FindModuleNodeByNameForRandom(
         {
             FString NodeName = FunctionNode->GetFunctionName();
             FString NormalizedNodeName = NodeName.Replace(TEXT(" "), TEXT(""));
-            if (NormalizedNodeName.Contains(NormalizedSearchName, ESearchCase::IgnoreCase) ||
-                NormalizedSearchName.Contains(NormalizedNodeName, ESearchCase::IgnoreCase))
+
+            // Exact match takes priority
+            if (NormalizedNodeName.Equals(NormalizedSearchName, ESearchCase::IgnoreCase))
             {
                 return FunctionNode;
             }
+            // Track partial match as fallback
+            if (!PartialMatchNode && NormalizedNodeName.Contains(NormalizedSearchName, ESearchCase::IgnoreCase))
+            {
+                PartialMatchNode = FunctionNode;
+            }
         }
     }
-    return nullptr;
+    return PartialMatchNode;
 }
 
 // ============================================================================

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Niagara/NiagaraServiceHelpers.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Niagara/NiagaraServiceHelpers.cpp
@@ -172,23 +172,38 @@ void FNiagaraService::RefreshEditors(UObject* Asset)
 
 bool FNiagaraService::GetScriptUsageFromStage(const FString& Stage, uint8& OutUsage, FString& OutError) const
 {
-    if (Stage.Equals(TEXT("Spawn"), ESearchCase::IgnoreCase))
+    // Particle stages
+    if (Stage.Equals(TEXT("Spawn"), ESearchCase::IgnoreCase) ||
+        Stage.Equals(TEXT("ParticleSpawn"), ESearchCase::IgnoreCase))
     {
         OutUsage = static_cast<uint8>(ENiagaraScriptUsage::ParticleSpawnScript);
         return true;
     }
-    else if (Stage.Equals(TEXT("Update"), ESearchCase::IgnoreCase))
+    else if (Stage.Equals(TEXT("Update"), ESearchCase::IgnoreCase) ||
+             Stage.Equals(TEXT("ParticleUpdate"), ESearchCase::IgnoreCase))
     {
         OutUsage = static_cast<uint8>(ENiagaraScriptUsage::ParticleUpdateScript);
         return true;
     }
-    else if (Stage.Equals(TEXT("Event"), ESearchCase::IgnoreCase))
+    else if (Stage.Equals(TEXT("Event"), ESearchCase::IgnoreCase) ||
+             Stage.Equals(TEXT("ParticleEvent"), ESearchCase::IgnoreCase))
     {
         OutUsage = static_cast<uint8>(ENiagaraScriptUsage::ParticleEventScript);
         return true;
     }
+    // Emitter stages
+    else if (Stage.Equals(TEXT("EmitterSpawn"), ESearchCase::IgnoreCase))
+    {
+        OutUsage = static_cast<uint8>(ENiagaraScriptUsage::EmitterSpawnScript);
+        return true;
+    }
+    else if (Stage.Equals(TEXT("EmitterUpdate"), ESearchCase::IgnoreCase))
+    {
+        OutUsage = static_cast<uint8>(ENiagaraScriptUsage::EmitterUpdateScript);
+        return true;
+    }
 
-    OutError = FString::Printf(TEXT("Invalid stage '%s'. Must be 'Spawn', 'Update', or 'Event'"), *Stage);
+    OutError = FString::Printf(TEXT("Invalid stage '%s'. Valid stages: 'Spawn', 'Update', 'Event', 'EmitterSpawn', 'EmitterUpdate'"), *Stage);
     return false;
 }
 
@@ -197,11 +212,15 @@ FString FNiagaraService::GetStageFromScriptUsage(uint8 Usage) const
     switch (static_cast<ENiagaraScriptUsage>(Usage))
     {
     case ENiagaraScriptUsage::ParticleSpawnScript:
-        return TEXT("Spawn");
+        return TEXT("ParticleSpawn");
     case ENiagaraScriptUsage::ParticleUpdateScript:
-        return TEXT("Update");
+        return TEXT("ParticleUpdate");
     case ENiagaraScriptUsage::ParticleEventScript:
         return TEXT("Event");
+    case ENiagaraScriptUsage::EmitterSpawnScript:
+        return TEXT("EmitterSpawn");
+    case ENiagaraScriptUsage::EmitterUpdateScript:
+        return TEXT("EmitterUpdate");
     default:
         return TEXT("Unknown");
     }

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Niagara/NiagaraStaticSwitchService.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Niagara/NiagaraStaticSwitchService.cpp
@@ -1,0 +1,306 @@
+// NiagaraStaticSwitchService.cpp - Static Switch Module Operations
+
+#include "Services/NiagaraService.h"
+
+#include "NiagaraSystem.h"
+#include "NiagaraEmitter.h"
+#include "NiagaraScript.h"
+#include "NiagaraGraph.h"
+#include "NiagaraNodeFunctionCall.h"
+#include "NiagaraScriptSource.h"
+#include "ViewModels/Stack/NiagaraStackGraphUtilities.h"
+
+bool FNiagaraService::SetModuleStaticSwitch(const FNiagaraModuleStaticSwitchParams& Params, FString& OutError)
+{
+    // Validate params
+    if (!Params.IsValid(OutError))
+    {
+        return false;
+    }
+
+    // Find the system
+    UNiagaraSystem* System = FindSystem(Params.SystemPath);
+    if (!System)
+    {
+        OutError = FString::Printf(TEXT("System not found: %s"), *Params.SystemPath);
+        return false;
+    }
+
+    // Find the emitter handle by name
+    int32 EmitterIndex = FindEmitterHandleIndex(System, Params.EmitterName);
+    if (EmitterIndex == INDEX_NONE)
+    {
+        OutError = FString::Printf(TEXT("Emitter '%s' not found in system '%s'"), *Params.EmitterName, *Params.SystemPath);
+        return false;
+    }
+
+    const FNiagaraEmitterHandle& EmitterHandle = System->GetEmitterHandle(EmitterIndex);
+    FVersionedNiagaraEmitterData* EmitterData = EmitterHandle.GetEmitterData();
+    if (!EmitterData)
+    {
+        OutError = FString::Printf(TEXT("Could not get emitter data for '%s'"), *Params.EmitterName);
+        return false;
+    }
+
+    // Convert stage to script usage
+    uint8 UsageValue;
+    if (!GetScriptUsageFromStage(Params.Stage, UsageValue, OutError))
+    {
+        return false;
+    }
+    ENiagaraScriptUsage ScriptUsage = static_cast<ENiagaraScriptUsage>(UsageValue);
+
+    // Get the script for this stage
+    UNiagaraScript* Script = nullptr;
+    switch (ScriptUsage)
+    {
+    case ENiagaraScriptUsage::ParticleSpawnScript:
+        Script = EmitterData->SpawnScriptProps.Script;
+        break;
+    case ENiagaraScriptUsage::ParticleUpdateScript:
+        Script = EmitterData->UpdateScriptProps.Script;
+        break;
+    case ENiagaraScriptUsage::EmitterSpawnScript:
+        Script = EmitterData->EmitterSpawnScriptProps.Script;
+        break;
+    case ENiagaraScriptUsage::EmitterUpdateScript:
+        Script = EmitterData->EmitterUpdateScriptProps.Script;
+        break;
+    default:
+        OutError = FString::Printf(TEXT("Unsupported script usage for stage '%s'"), *Params.Stage);
+        return false;
+    }
+
+    if (!Script)
+    {
+        OutError = FString::Printf(TEXT("Script not found for stage '%s' in emitter '%s'"), *Params.Stage, *Params.EmitterName);
+        return false;
+    }
+
+    // Get the script source and graph
+    UNiagaraScriptSource* ScriptSource = Cast<UNiagaraScriptSource>(Script->GetLatestSource());
+    if (!ScriptSource)
+    {
+        OutError = TEXT("Could not get script source");
+        return false;
+    }
+
+    UNiagaraGraph* Graph = ScriptSource->NodeGraph;
+    if (!Graph)
+    {
+        OutError = TEXT("Could not get script graph");
+        return false;
+    }
+
+    // Find the module node by name - prioritize exact matches
+    UNiagaraNodeFunctionCall* ModuleNode = nullptr;
+    UNiagaraNodeFunctionCall* PartialMatchNode = nullptr;
+    FString NormalizedSearchName = Params.ModuleName.Replace(TEXT(" "), TEXT(""));
+
+    for (UEdGraphNode* Node : Graph->Nodes)
+    {
+        UNiagaraNodeFunctionCall* FunctionNode = Cast<UNiagaraNodeFunctionCall>(Node);
+        if (FunctionNode)
+        {
+            FString NodeName = FunctionNode->GetFunctionName();
+            FString NormalizedNodeName = NodeName.Replace(TEXT(" "), TEXT(""));
+
+            // Exact match takes priority
+            if (NormalizedNodeName.Equals(NormalizedSearchName, ESearchCase::IgnoreCase))
+            {
+                ModuleNode = FunctionNode;
+                break;
+            }
+            // Track partial match as fallback
+            if (!PartialMatchNode && NormalizedNodeName.Contains(NormalizedSearchName, ESearchCase::IgnoreCase))
+            {
+                PartialMatchNode = FunctionNode;
+            }
+        }
+    }
+
+    // Use partial match only if no exact match found
+    if (!ModuleNode && PartialMatchNode)
+    {
+        ModuleNode = PartialMatchNode;
+    }
+
+    if (!ModuleNode)
+    {
+        OutError = FString::Printf(TEXT("Module '%s' not found in stage '%s'"), *Params.ModuleName, *Params.Stage);
+        return false;
+    }
+
+    // Mark system for modification
+    System->Modify();
+
+    // Find the static switch pin by name using direct pin search
+    // We iterate through module input pins and match by name
+    UEdGraphPin* SwitchPin = nullptr;
+    FString NormalizedSwitchName = Params.SwitchName.Replace(TEXT(" "), TEXT(""));
+
+    for (UEdGraphPin* Pin : ModuleNode->Pins)
+    {
+        if (Pin->Direction != EGPD_Input)
+        {
+            continue;
+        }
+
+        FString PinName = Pin->PinName.ToString();
+        FString NormalizedPinName = PinName.Replace(TEXT(" "), TEXT(""));
+
+        // Try exact match first
+        if (PinName.Equals(Params.SwitchName, ESearchCase::IgnoreCase) ||
+            NormalizedPinName.Equals(NormalizedSwitchName, ESearchCase::IgnoreCase))
+        {
+            SwitchPin = Pin;
+            break;
+        }
+    }
+
+    if (!SwitchPin)
+    {
+        // Build a helpful error message listing available pins
+        TArray<FString> AvailablePins;
+        for (UEdGraphPin* Pin : ModuleNode->Pins)
+        {
+            if (Pin->Direction == EGPD_Input)
+            {
+                AvailablePins.Add(Pin->PinName.ToString());
+            }
+        }
+        OutError = FString::Printf(TEXT("Static switch '%s' not found on module '%s'. Available pins: %s"),
+            *Params.SwitchName, *Params.ModuleName, *FString::Join(AvailablePins, TEXT(", ")));
+        return false;
+    }
+
+    // Determine the pin type and set the value accordingly
+    FString ValueToSet = Params.Value;
+
+    // Handle enum pins - convert display names to internal names
+    if (UEnum* EnumType = Cast<UEnum>(SwitchPin->PinType.PinSubCategoryObject.Get()))
+    {
+        int64 EnumValue = INDEX_NONE;
+        FString InternalName;
+
+        // First try parsing as an index
+        if (Params.Value.IsNumeric())
+        {
+            int32 Index = FCString::Atoi(*Params.Value);
+            if (Index >= 0 && Index < EnumType->NumEnums() - 1) // -1 to skip MAX value
+            {
+                EnumValue = Index;
+                InternalName = EnumType->GetNameStringByIndex(Index);
+            }
+        }
+
+        // If not a valid index, try name matching
+        if (EnumValue == INDEX_NONE)
+        {
+            // Try exact match with internal name (e.g., "NewEnumerator0")
+            EnumValue = EnumType->GetValueByNameString(Params.Value);
+
+            if (EnumValue == INDEX_NONE)
+            {
+                // Try to find by short name or display name
+                for (int32 i = 0; i < EnumType->NumEnums() - 1; ++i)
+                {
+                    FString EnumName = EnumType->GetNameStringByIndex(i);
+                    FString ShortName = EnumName;
+
+                    // Remove enum prefix (e.g., "ESplineCoordinateSpace::World" -> "World")
+                    int32 ColonPos;
+                    if (EnumName.FindLastChar(':', ColonPos))
+                    {
+                        ShortName = EnumName.RightChop(ColonPos + 1);
+                    }
+
+                    // Also get the display name for user-defined enums
+                    FText DisplayNameText = EnumType->GetDisplayNameTextByIndex(i);
+                    FString DisplayName = DisplayNameText.ToString();
+
+                    if (ShortName.Equals(Params.Value, ESearchCase::IgnoreCase) ||
+                        EnumName.Equals(Params.Value, ESearchCase::IgnoreCase) ||
+                        DisplayName.Equals(Params.Value, ESearchCase::IgnoreCase))
+                    {
+                        EnumValue = i;
+                        InternalName = EnumName;
+                        break;
+                    }
+                }
+            }
+            else
+            {
+                InternalName = EnumType->GetNameStringByValue(EnumValue);
+            }
+        }
+
+        if (EnumValue == INDEX_NONE)
+        {
+            // Build list of valid enum values for helpful error message
+            TArray<FString> ValidValues;
+            for (int32 i = 0; i < EnumType->NumEnums() - 1; ++i)
+            {
+                FText DisplayText = EnumType->GetDisplayNameTextByIndex(i);
+                FString InternalEnumName = EnumType->GetNameStringByIndex(i);
+                ValidValues.Add(FString::Printf(TEXT("%d='%s' (internal: %s)"), i, *DisplayText.ToString(), *InternalEnumName));
+            }
+            OutError = FString::Printf(TEXT("Enum value '%s' not found for switch '%s'. Valid values: %s"),
+                *Params.Value, *Params.SwitchName, *FString::Join(ValidValues, TEXT(", ")));
+            return false;
+        }
+
+        if (InternalName.IsEmpty())
+        {
+            InternalName = EnumType->GetNameStringByValue(EnumValue);
+        }
+        ValueToSet = InternalName;
+
+        UE_LOG(LogNiagaraService, Log, TEXT("Set static switch '%s' enum value to '%s' (internal: '%s', index: %lld)"),
+            *Params.SwitchName, *Params.Value, *InternalName, EnumValue);
+    }
+    // Handle bool pins
+    else if (SwitchPin->PinType.PinCategory == UEdGraphSchema_K2::PC_Boolean)
+    {
+        // Normalize bool values
+        if (Params.Value.Equals(TEXT("true"), ESearchCase::IgnoreCase) || Params.Value == TEXT("1"))
+        {
+            ValueToSet = TEXT("true");
+        }
+        else if (Params.Value.Equals(TEXT("false"), ESearchCase::IgnoreCase) || Params.Value == TEXT("0"))
+        {
+            ValueToSet = TEXT("false");
+        }
+        else
+        {
+            OutError = FString::Printf(TEXT("Invalid bool value '%s' for switch '%s'. Use 'true', 'false', '0', or '1'."),
+                *Params.Value, *Params.SwitchName);
+            return false;
+        }
+
+        UE_LOG(LogNiagaraService, Log, TEXT("Set static switch '%s' bool value to '%s'"),
+            *Params.SwitchName, *ValueToSet);
+    }
+    // Handle integer pins
+    else if (Params.Value.IsNumeric())
+    {
+        ValueToSet = Params.Value;
+        UE_LOG(LogNiagaraService, Log, TEXT("Set static switch '%s' integer value to '%s'"),
+            *Params.SwitchName, *ValueToSet);
+    }
+
+    // Set the pin value
+    SwitchPin->DefaultValue = ValueToSet;
+
+    // Mark dirty, notify, and recompile - static switches require recompilation
+    MarkSystemDirty(System);
+    Graph->NotifyGraphChanged();
+    System->RequestCompile(false);
+    System->WaitForCompilationComplete();
+    RefreshEditors(System);
+
+    UE_LOG(LogNiagaraService, Log, TEXT("Successfully set static switch '%s' on module '%s' to '%s'"),
+        *Params.SwitchName, *Params.ModuleName, *ValueToSet);
+
+    return true;
+}

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Niagara/SetModuleLinkedInputCommand.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Niagara/SetModuleLinkedInputCommand.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Commands/IUnrealMCPCommand.h"
+#include "Services/INiagaraService.h"
+
+/**
+ * Command for setting a linked input on a Niagara module
+ * Allows binding module inputs to particle attributes like Particles.NormalizedAge
+ * for time-based animations like alpha fade over particle lifetime
+ */
+class UNREALMCP_API FSetModuleLinkedInputCommand : public IUnrealMCPCommand
+{
+public:
+    explicit FSetModuleLinkedInputCommand(INiagaraService& InNiagaraService);
+
+    virtual FString Execute(const FString& Parameters) override;
+    virtual FString GetCommandName() const override;
+    virtual bool ValidateParams(const FString& Parameters) const override;
+
+private:
+    INiagaraService& NiagaraService;
+
+    bool ParseParameters(const FString& JsonString, FNiagaraModuleLinkedInputParams& OutParams, FString& OutError) const;
+    FString CreateSuccessResponse(const FString& ModuleName, const FString& InputName, const FString& LinkedValue) const;
+    FString CreateErrorResponse(const FString& ErrorMessage) const;
+};

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Niagara/SetModuleStaticSwitchCommand.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Niagara/SetModuleStaticSwitchCommand.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Commands/IUnrealMCPCommand.h"
+#include "Services/INiagaraService.h"
+
+/**
+ * Command for setting a static switch on a Niagara module
+ * Static switches control compile-time branching in modules, enabling different behavior modes
+ */
+class UNREALMCP_API FSetModuleStaticSwitchCommand : public IUnrealMCPCommand
+{
+public:
+    explicit FSetModuleStaticSwitchCommand(INiagaraService& InNiagaraService);
+
+    virtual FString Execute(const FString& Parameters) override;
+    virtual FString GetCommandName() const override;
+    virtual bool ValidateParams(const FString& Parameters) const override;
+
+private:
+    INiagaraService& NiagaraService;
+
+    bool ParseParameters(const FString& JsonString, FNiagaraModuleStaticSwitchParams& OutParams, FString& OutError) const;
+    FString CreateSuccessResponse(const FString& SwitchName, const FString& Value) const;
+    FString CreateErrorResponse(const FString& ErrorMessage) const;
+};

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Services/INiagaraService.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Services/INiagaraService.h
@@ -98,7 +98,7 @@ struct UNREALMCP_API FNiagaraModuleAddParams
     /** Path to the module script to add */
     FString ModulePath;
 
-    /** Stage to add the module to: "Spawn", "Update", or "Event" */
+    /** Stage to add the module to: "Spawn", "Update", "Event", "EmitterSpawn", or "EmitterUpdate" */
     FString Stage;
 
     /** Index position for the module (-1 for end) */
@@ -135,9 +135,10 @@ struct UNREALMCP_API FNiagaraModuleAddParams
             return false;
         }
         // Validate stage value
-        if (Stage != TEXT("Spawn") && Stage != TEXT("Update") && Stage != TEXT("Event"))
+        if (Stage != TEXT("Spawn") && Stage != TEXT("Update") && Stage != TEXT("Event") &&
+            Stage != TEXT("EmitterSpawn") && Stage != TEXT("EmitterUpdate"))
         {
-            OutError = FString::Printf(TEXT("Invalid stage '%s'. Must be 'Spawn', 'Update', or 'Event'"), *Stage);
+            OutError = FString::Printf(TEXT("Invalid stage '%s'. Valid stages: 'Spawn', 'Update', 'Event', 'EmitterSpawn', 'EmitterUpdate'"), *Stage);
             return false;
         }
         return true;
@@ -192,9 +193,10 @@ struct UNREALMCP_API FNiagaraModuleRemoveParams
             return false;
         }
         // Validate stage value
-        if (Stage != TEXT("Spawn") && Stage != TEXT("Update") && Stage != TEXT("Event"))
+        if (Stage != TEXT("Spawn") && Stage != TEXT("Update") && Stage != TEXT("Event") &&
+            Stage != TEXT("EmitterSpawn") && Stage != TEXT("EmitterUpdate"))
         {
-            OutError = FString::Printf(TEXT("Invalid stage '%s'. Must be 'Spawn', 'Update', or 'Event'"), *Stage);
+            OutError = FString::Printf(TEXT("Invalid stage '%s'. Valid stages: 'Spawn', 'Update', 'Event', 'EmitterSpawn', 'EmitterUpdate'"), *Stage);
             return false;
         }
         return true;
@@ -252,9 +254,10 @@ struct UNREALMCP_API FNiagaraModuleMoveParams
             return false;
         }
         // Validate stage value
-        if (Stage != TEXT("Spawn") && Stage != TEXT("Update") && Stage != TEXT("Event"))
+        if (Stage != TEXT("Spawn") && Stage != TEXT("Update") && Stage != TEXT("Event") &&
+            Stage != TEXT("EmitterSpawn") && Stage != TEXT("EmitterUpdate"))
         {
-            OutError = FString::Printf(TEXT("Invalid stage '%s'. Must be 'Spawn', 'Update', or 'Event'"), *Stage);
+            OutError = FString::Printf(TEXT("Invalid stage '%s'. Valid stages: 'Spawn', 'Update', 'Event', 'EmitterSpawn', 'EmitterUpdate'"), *Stage);
             return false;
         }
         if (NewIndex < 0)
@@ -755,6 +758,73 @@ struct UNREALMCP_API FNiagaraActorSpawnParams
 };
 
 /**
+ * Parameters for setting a linked input on a module (binding to a particle attribute)
+ */
+struct UNREALMCP_API FNiagaraModuleLinkedInputParams
+{
+    /** Path to the system */
+    FString SystemPath;
+
+    /** Name of the emitter */
+    FString EmitterName;
+
+    /** Name of the module */
+    FString ModuleName;
+
+    /** Stage the module is in */
+    FString Stage;
+
+    /** Name of the input to set */
+    FString InputName;
+
+    /** Value to link to (e.g., "Particles.NormalizedAge", "Particles.Velocity") */
+    FString LinkedValue;
+
+    /** Default constructor */
+    FNiagaraModuleLinkedInputParams() = default;
+
+    /**
+     * Validate the parameters
+     * @param OutError - Error message if validation fails
+     * @return true if parameters are valid
+     */
+    bool IsValid(FString& OutError) const
+    {
+        if (SystemPath.IsEmpty())
+        {
+            OutError = TEXT("System path cannot be empty");
+            return false;
+        }
+        if (EmitterName.IsEmpty())
+        {
+            OutError = TEXT("Emitter name cannot be empty");
+            return false;
+        }
+        if (ModuleName.IsEmpty())
+        {
+            OutError = TEXT("Module name cannot be empty");
+            return false;
+        }
+        if (Stage.IsEmpty())
+        {
+            OutError = TEXT("Stage cannot be empty");
+            return false;
+        }
+        if (InputName.IsEmpty())
+        {
+            OutError = TEXT("Input name cannot be empty");
+            return false;
+        }
+        if (LinkedValue.IsEmpty())
+        {
+            OutError = TEXT("Linked value cannot be empty");
+            return false;
+        }
+        return true;
+    }
+};
+
+/**
  * Parameters for setting an emitter property
  */
 struct UNREALMCP_API FNiagaraEmitterPropertyParams
@@ -794,6 +864,73 @@ struct UNREALMCP_API FNiagaraEmitterPropertyParams
         if (PropertyName.IsEmpty())
         {
             OutError = TEXT("Property name cannot be empty");
+            return false;
+        }
+        return true;
+    }
+};
+
+/**
+ * Parameters for setting a static switch on a module
+ */
+struct UNREALMCP_API FNiagaraModuleStaticSwitchParams
+{
+    /** Path to the system containing the emitter */
+    FString SystemPath;
+
+    /** Name of the emitter containing the module */
+    FString EmitterName;
+
+    /** Name of the module */
+    FString ModuleName;
+
+    /** Stage the module is in */
+    FString Stage;
+
+    /** Name of the static switch (e.g., "Scale Color Mode") */
+    FString SwitchName;
+
+    /** Value to set - can be display name, internal name, or index */
+    FString Value;
+
+    /** Default constructor */
+    FNiagaraModuleStaticSwitchParams() = default;
+
+    /**
+     * Validate the parameters
+     * @param OutError - Error message if validation fails
+     * @return true if parameters are valid
+     */
+    bool IsValid(FString& OutError) const
+    {
+        if (SystemPath.IsEmpty())
+        {
+            OutError = TEXT("System path cannot be empty");
+            return false;
+        }
+        if (EmitterName.IsEmpty())
+        {
+            OutError = TEXT("Emitter name cannot be empty");
+            return false;
+        }
+        if (ModuleName.IsEmpty())
+        {
+            OutError = TEXT("Module name cannot be empty");
+            return false;
+        }
+        if (Stage.IsEmpty())
+        {
+            OutError = TEXT("Stage cannot be empty");
+            return false;
+        }
+        if (SwitchName.IsEmpty())
+        {
+            OutError = TEXT("Switch name cannot be empty");
+            return false;
+        }
+        if (Value.IsEmpty())
+        {
+            OutError = TEXT("Value cannot be empty");
             return false;
         }
         return true;
@@ -999,6 +1136,23 @@ public:
      * @return true if random input was set successfully
      */
     virtual bool SetModuleRandomInput(const FNiagaraModuleRandomInputParams& Params, FString& OutError) = 0;
+
+    /**
+     * Set a linked input on a module (binding to a particle attribute like Particles.NormalizedAge)
+     * @param Params - Linked input parameters
+     * @param OutError - Error message if setting fails
+     * @return true if linked input was set successfully
+     */
+    virtual bool SetModuleLinkedInput(const FNiagaraModuleLinkedInputParams& Params, FString& OutError) = 0;
+
+    /**
+     * Set a static switch on a module
+     * Static switches control compile-time branching in modules, enabling different behavior modes
+     * @param Params - Static switch parameters
+     * @param OutError - Error message if setting fails
+     * @return true if static switch was set successfully
+     */
+    virtual bool SetModuleStaticSwitch(const FNiagaraModuleStaticSwitchParams& Params, FString& OutError) = 0;
 
     // ========================================================================
     // Parameters (Feature 3)

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Services/NiagaraService.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Services/NiagaraService.h
@@ -63,6 +63,8 @@ public:
     virtual bool SetModuleCurveInput(const FNiagaraModuleCurveInputParams& Params, FString& OutError) override;
     virtual bool SetModuleColorCurveInput(const FNiagaraModuleColorCurveInputParams& Params, FString& OutError) override;
     virtual bool SetModuleRandomInput(const FNiagaraModuleRandomInputParams& Params, FString& OutError) override;
+    virtual bool SetModuleLinkedInput(const FNiagaraModuleLinkedInputParams& Params, FString& OutError) override;
+    virtual bool SetModuleStaticSwitch(const FNiagaraModuleStaticSwitchParams& Params, FString& OutError) override;
 
     // ========================================================================
     // INiagaraService interface implementation - Parameters

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/UnrealMCP.Build.cs
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/UnrealMCP.Build.cs
@@ -24,6 +24,13 @@ public class UnrealMCP : ModuleRules
 				"Runtime/AdvancedWidgets/Public"
 			}
 		);
+
+		// Add NiagaraEditor private includes for static switch node access
+		string NiagaraEditorPrivatePath = System.IO.Path.GetFullPath(System.IO.Path.Combine(EngineDirectory, "Plugins", "FX", "Niagara", "Source", "NiagaraEditor", "Private"));
+		if (System.IO.Directory.Exists(NiagaraEditorPrivatePath))
+		{
+			PrivateIncludePaths.Add(NiagaraEditorPrivatePath);
+		}
 		
 		PublicDependencyModuleNames.AddRange(
 			new string[]


### PR DESCRIPTION
- Fix get_module_inputs to properly extract curve keyframes from DataInterface nodes by searching NiagaraNodeParameterMapSet override nodes instead of module pins
- Add set_module_linked_input tool for binding inputs to particle attributes
- Add set_module_static_switch tool for controlling compile-time branching
- Improve static switch display names and available options in get_module_inputs
- Add NiagaraLinkedInputService and NiagaraStaticSwitchService for new tools