### PR TITLE
Add get_niagara_diagnostics tool for system validation

### DIFF
--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Niagara/GetNiagaraDiagnosticsCommand.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Niagara/GetNiagaraDiagnosticsCommand.cpp
@@ -1,0 +1,321 @@
+#include "Commands/Niagara/GetNiagaraDiagnosticsCommand.h"
+#include "Dom/JsonObject.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonWriter.h"
+
+// Niagara includes
+#include "NiagaraSystem.h"
+#include "NiagaraEmitter.h"
+#include "NiagaraValidationRule.h"
+#include "NiagaraScript.h"
+#include "NiagaraScriptSourceBase.h"
+
+// NiagaraEditor includes for validation system
+#include "ViewModels/NiagaraSystemViewModel.h"
+#include "ViewModels/NiagaraEmitterHandleViewModel.h"
+#include "ViewModels/Stack/NiagaraStackViewModel.h"
+#include "ViewModels/Stack/NiagaraStackEntry.h"
+#include "ViewModels/Stack/NiagaraStackErrorItem.h"
+#include "NiagaraValidationRules.h"
+
+// Asset loading
+#include "AssetRegistry/AssetRegistryModule.h"
+#include "UObject/SavePackage.h"
+
+FGetNiagaraDiagnosticsCommand::FGetNiagaraDiagnosticsCommand(INiagaraService& InNiagaraService)
+    : NiagaraService(InNiagaraService)
+{
+}
+
+FString FGetNiagaraDiagnosticsCommand::Execute(const FString& Parameters)
+{
+    TSharedPtr<FJsonObject> JsonObject;
+    TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Parameters);
+
+    if (!FJsonSerializer::Deserialize(Reader, JsonObject) || !JsonObject.IsValid())
+    {
+        return CreateErrorResponse(TEXT("Invalid JSON parameters"));
+    }
+
+    FString SystemPath;
+    if (!JsonObject->TryGetStringField(TEXT("system"), SystemPath))
+    {
+        return CreateErrorResponse(TEXT("Missing 'system' parameter"));
+    }
+
+    // Resolve system path - handle both full paths and short names
+    FString FullPath = SystemPath;
+    if (!FullPath.StartsWith(TEXT("/Game/")))
+    {
+        // Try to find the asset
+        FAssetRegistryModule& AssetRegistryModule = FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry");
+        TArray<FAssetData> AssetList;
+        AssetRegistryModule.Get().GetAssetsByClass(UNiagaraSystem::StaticClass()->GetClassPathName(), AssetList);
+
+        for (const FAssetData& Asset : AssetList)
+        {
+            if (Asset.AssetName.ToString() == SystemPath)
+            {
+                FullPath = Asset.GetObjectPathString();
+                break;
+            }
+        }
+    }
+
+    // Load the Niagara System
+    UNiagaraSystem* NiagaraSystem = LoadObject<UNiagaraSystem>(nullptr, *FullPath);
+    if (!NiagaraSystem)
+    {
+        return CreateErrorResponse(FString::Printf(TEXT("Failed to load Niagara System: %s"), *SystemPath));
+    }
+
+    // Wait for compilation to complete
+    NiagaraSystem->WaitForCompilationComplete();
+
+    // Create view model - NOT data processing only, we need full stack for issues
+    TSharedPtr<FNiagaraSystemViewModel> SystemViewModel = MakeShared<FNiagaraSystemViewModel>();
+    {
+        FNiagaraSystemViewModelOptions SystemOptions;
+        SystemOptions.bCanModifyEmittersFromTimeline = false;
+        SystemOptions.bCanSimulate = false;
+        SystemOptions.bCanAutoCompile = false;
+        SystemOptions.bIsForDataProcessingOnly = false;  // Need full stack for issues
+        SystemOptions.MessageLogGuid = NiagaraSystem->GetAssetGuid();
+        SystemViewModel->Initialize(*NiagaraSystem, SystemOptions);
+    }
+
+    // Collect validation results
+    TArray<TSharedPtr<FJsonValue>> DiagnosticsArray;
+    int32 InfoCount = 0;
+    int32 WarningCount = 0;
+    int32 ErrorCount = 0;
+
+    // Helper lambda to convert EStackIssueSeverity to string
+    auto StackSeverityToString = [](EStackIssueSeverity Severity) -> FString
+    {
+        switch (Severity)
+        {
+        case EStackIssueSeverity::Error: return TEXT("Error");
+        case EStackIssueSeverity::Warning: return TEXT("Warning");
+        case EStackIssueSeverity::Info: return TEXT("Info");
+        default: return TEXT("None");
+        }
+    };
+
+    // Helper lambda to add a stack issue to the diagnostics array
+    auto AddStackIssue = [&](const UNiagaraStackEntry::FStackIssue& Issue, const FString& SourceName)
+    {
+        if (Issue.GetSeverity() == EStackIssueSeverity::None)
+        {
+            return;
+        }
+
+        // Count by severity
+        switch (Issue.GetSeverity())
+        {
+        case EStackIssueSeverity::Info:
+            InfoCount++;
+            break;
+        case EStackIssueSeverity::Warning:
+            WarningCount++;
+            break;
+        case EStackIssueSeverity::Error:
+            ErrorCount++;
+            break;
+        default:
+            break;
+        }
+
+        TSharedPtr<FJsonObject> DiagnosticObj = MakeShared<FJsonObject>();
+        DiagnosticObj->SetStringField(TEXT("severity"), StackSeverityToString(Issue.GetSeverity()));
+        DiagnosticObj->SetStringField(TEXT("summary"), Issue.GetShortDescription().ToString());
+        DiagnosticObj->SetStringField(TEXT("description"), Issue.GetLongDescription().ToString());
+        DiagnosticObj->SetStringField(TEXT("source"), SourceName);
+        DiagnosticObj->SetStringField(TEXT("type"), TEXT("StackIssue"));
+
+        // Add fixes if available
+        const TArray<UNiagaraStackEntry::FStackIssueFix>& Fixes = Issue.GetFixes();
+        if (Fixes.Num() > 0)
+        {
+            TArray<TSharedPtr<FJsonValue>> FixesArray;
+            for (const UNiagaraStackEntry::FStackIssueFix& Fix : Fixes)
+            {
+                FixesArray.Add(MakeShared<FJsonValueString>(Fix.GetDescription().ToString()));
+            }
+            DiagnosticObj->SetArrayField(TEXT("fixes"), FixesArray);
+        }
+
+        DiagnosticsArray.Add(MakeShared<FJsonValueObject>(DiagnosticObj));
+    };
+
+    // Helper to process all entries in a stack view model
+    auto ProcessStackViewModel = [&](UNiagaraStackViewModel* StackViewModel, const FString& StackName)
+    {
+        if (!StackViewModel)
+        {
+            return;
+        }
+
+        UNiagaraStackEntry* RootEntry = StackViewModel->GetRootEntry();
+        if (!RootEntry)
+        {
+            return;
+        }
+
+        // Force refresh the stack to populate children and issues
+        RootEntry->RefreshChildren();
+
+        // Manually traverse ALL entries and collect their issues
+        TArray<UNiagaraStackEntry*> EntriesToProcess;
+        EntriesToProcess.Add(RootEntry);
+
+        while (EntriesToProcess.Num() > 0)
+        {
+            UNiagaraStackEntry* Entry = EntriesToProcess[0];
+            EntriesToProcess.RemoveAt(0);
+
+            if (!Entry)
+            {
+                continue;
+            }
+
+            // Refresh this entry to ensure issues are populated
+            Entry->RefreshChildren();
+
+            // Collect issues from this entry
+            const TArray<UNiagaraStackEntry::FStackIssue>& Issues = Entry->GetIssues();
+            for (const UNiagaraStackEntry::FStackIssue& Issue : Issues)
+            {
+                FString SourceName = Entry->GetDisplayName().ToString();
+                if (!StackName.IsEmpty())
+                {
+                    SourceName = FString::Printf(TEXT("%s - %s"), *StackName, *SourceName);
+                }
+                AddStackIssue(Issue, SourceName);
+            }
+
+            // Add children to process
+            TArray<UNiagaraStackEntry*> Children;
+            Entry->GetUnfilteredChildren(Children);
+            EntriesToProcess.Append(Children);
+        }
+    };
+
+    // Process system stack view model
+    ProcessStackViewModel(SystemViewModel->GetSystemStackViewModel(), TEXT("System"));
+
+    // Process emitter stack view models
+    const TArray<TSharedRef<FNiagaraEmitterHandleViewModel>>& EmitterHandleViewModels = SystemViewModel->GetEmitterHandleViewModels();
+    for (const TSharedRef<FNiagaraEmitterHandleViewModel>& EmitterHandleViewModel : EmitterHandleViewModels)
+    {
+        FString EmitterName = EmitterHandleViewModel->GetName().ToString();
+        UNiagaraStackViewModel* EmitterStackViewModel = EmitterHandleViewModel->GetEmitterStackViewModel();
+        ProcessStackViewModel(EmitterStackViewModel, EmitterName);
+    }
+
+    // Also run system-level validation rules
+    NiagaraValidation::ValidateAllRulesInSystem(
+        SystemViewModel,
+        [&](const FNiagaraValidationResult& Result)
+        {
+            // Count by severity
+            switch (Result.Severity)
+            {
+            case ENiagaraValidationSeverity::Info:
+                InfoCount++;
+                break;
+            case ENiagaraValidationSeverity::Warning:
+                WarningCount++;
+                break;
+            case ENiagaraValidationSeverity::Error:
+                ErrorCount++;
+                break;
+            }
+
+            // Create diagnostic entry
+            TSharedPtr<FJsonObject> DiagnosticObj = MakeShared<FJsonObject>();
+
+            // Severity
+            FString SeverityStr;
+            switch (Result.Severity)
+            {
+            case ENiagaraValidationSeverity::Info:
+                SeverityStr = TEXT("Info");
+                break;
+            case ENiagaraValidationSeverity::Warning:
+                SeverityStr = TEXT("Warning");
+                break;
+            case ENiagaraValidationSeverity::Error:
+                SeverityStr = TEXT("Error");
+                break;
+            }
+            DiagnosticObj->SetStringField(TEXT("severity"), SeverityStr);
+
+            // Summary and description
+            DiagnosticObj->SetStringField(TEXT("summary"), Result.SummaryText.ToString());
+            DiagnosticObj->SetStringField(TEXT("description"), Result.Description.ToString());
+            DiagnosticObj->SetStringField(TEXT("type"), TEXT("ValidationRule"));
+
+            // Source object name (if available)
+            if (Result.SourceObject.IsValid())
+            {
+                DiagnosticObj->SetStringField(TEXT("source"), Result.SourceObject->GetName());
+            }
+
+            // Available fixes
+            if (Result.Fixes.Num() > 0)
+            {
+                TArray<TSharedPtr<FJsonValue>> FixesArray;
+                for (const FNiagaraValidationFix& Fix : Result.Fixes)
+                {
+                    FixesArray.Add(MakeShared<FJsonValueString>(Fix.Description.ToString()));
+                }
+                DiagnosticObj->SetArrayField(TEXT("fixes"), FixesArray);
+            }
+
+            DiagnosticsArray.Add(MakeShared<FJsonValueObject>(DiagnosticObj));
+        }
+    );
+
+    // Build response
+    TSharedPtr<FJsonObject> ResponseObj = MakeShared<FJsonObject>();
+    ResponseObj->SetBoolField(TEXT("success"), true);
+    ResponseObj->SetStringField(TEXT("system"), NiagaraSystem->GetName());
+    ResponseObj->SetStringField(TEXT("path"), FullPath);
+    ResponseObj->SetArrayField(TEXT("diagnostics"), DiagnosticsArray);
+    ResponseObj->SetNumberField(TEXT("info_count"), InfoCount);
+    ResponseObj->SetNumberField(TEXT("warning_count"), WarningCount);
+    ResponseObj->SetNumberField(TEXT("error_count"), ErrorCount);
+    ResponseObj->SetNumberField(TEXT("total_count"), DiagnosticsArray.Num());
+
+    FString OutputString;
+    TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&OutputString);
+    FJsonSerializer::Serialize(ResponseObj.ToSharedRef(), Writer);
+    return OutputString;
+}
+
+bool FGetNiagaraDiagnosticsCommand::ValidateParams(const FString& Parameters) const
+{
+    TSharedPtr<FJsonObject> JsonObject;
+    TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Parameters);
+
+    if (!FJsonSerializer::Deserialize(Reader, JsonObject) || !JsonObject.IsValid())
+    {
+        return false;
+    }
+
+    FString SystemPath;
+    return JsonObject->TryGetStringField(TEXT("system"), SystemPath);
+}
+
+FString FGetNiagaraDiagnosticsCommand::CreateErrorResponse(const FString& ErrorMessage) const
+{
+    TSharedPtr<FJsonObject> ErrorObj = MakeShared<FJsonObject>();
+    ErrorObj->SetBoolField(TEXT("success"), false);
+    ErrorObj->SetStringField(TEXT("error"), ErrorMessage);
+
+    FString OutputString;
+    TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&OutputString);
+    FJsonSerializer::Serialize(ErrorObj.ToSharedRef(), Writer);
+    return OutputString;
+}

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/NiagaraCommandRegistration.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/NiagaraCommandRegistration.cpp
@@ -24,6 +24,7 @@
 #include "Commands/Niagara/SetModuleRandomInputCommand.h"
 #include "Commands/Niagara/SetModuleLinkedInputCommand.h"
 #include "Commands/Niagara/SetModuleStaticSwitchCommand.h"
+#include "Commands/Niagara/GetNiagaraDiagnosticsCommand.h"
 #include "Commands/Niagara/GetModuleInputsCommand.h"
 #include "Commands/Niagara/GetEmitterModulesCommand.h"
 #include "Commands/Niagara/RemoveModuleFromEmitterCommand.h"
@@ -86,6 +87,7 @@ void FNiagaraCommandRegistration::RegisterAllCommands()
     RegisterAndTrackCommand(MakeShared<FGetModuleInputsCommand>(NiagaraService));
     RegisterAndTrackCommand(MakeShared<FGetEmitterModulesCommand>(NiagaraService));
     RegisterAndTrackCommand(MakeShared<FRemoveModuleFromEmitterCommand>(NiagaraService));
+    RegisterAndTrackCommand(MakeShared<FGetNiagaraDiagnosticsCommand>(NiagaraService));
 
     // Register Feature 3: Parameter commands
     RegisterAndTrackCommand(MakeShared<FAddNiagaraParameterCommand>(NiagaraService));

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Niagara/GetNiagaraDiagnosticsCommand.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Niagara/GetNiagaraDiagnosticsCommand.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Commands/IUnrealMCPCommand.h"
+#include "Services/INiagaraService.h"
+
+/**
+ * Command for getting diagnostics/validation results from a Niagara System.
+ * Uses UE's built-in NiagaraValidation system (ValidateAllRulesInSystem).
+ * Maps to Python MCP's get_niagara_diagnostics
+ */
+class UNREALMCP_API FGetNiagaraDiagnosticsCommand : public IUnrealMCPCommand
+{
+public:
+    explicit FGetNiagaraDiagnosticsCommand(INiagaraService& InNiagaraService);
+
+    virtual FString Execute(const FString& Parameters) override;
+    virtual FString GetCommandName() const override { return TEXT("get_niagara_diagnostics"); }
+    virtual bool ValidateParams(const FString& Parameters) const override;
+
+private:
+    INiagaraService& NiagaraService;
+
+    FString CreateErrorResponse(const FString& ErrorMessage) const;
+};

--- a/Python/niagara_mcp_server.py
+++ b/Python/niagara_mcp_server.py
@@ -1614,6 +1614,76 @@ async def get_emitter_modules(
     return await send_tcp_command("get_emitter_modules", params)
 
 
+# ============================================================================
+# Diagnostics
+# ============================================================================
+
+@app.tool()
+async def get_niagara_diagnostics(
+    system: str
+) -> Dict[str, Any]:
+    """
+    Get diagnostics and validation results from a Niagara System.
+
+    Uses Unreal Engine's built-in NiagaraValidation system to run all validation
+    rules against the system and report any issues. This includes checks for:
+    - GPU simulation bounds requirements
+    - Banned/deprecated modules
+    - Material compatibility
+    - Large World Coordinates (LWC) issues
+    - Missing or invalid bindings
+    - Performance warnings
+    - And 20+ other built-in validation rules
+
+    Args:
+        system: Path or name of the Niagara System to validate
+
+    Returns:
+        Dictionary containing:
+        - success: Whether validation ran successfully
+        - system: Name of the system
+        - path: Full asset path
+        - diagnostics: Array of diagnostic results, each with:
+            - severity: "Info", "Warning", or "Error"
+            - summary: Short description of the issue
+            - description: Detailed explanation
+            - source: Name of the source object (if applicable)
+            - fixes: Array of suggested fix descriptions (if available)
+        - info_count: Number of info-level diagnostics
+        - warning_count: Number of warning-level diagnostics
+        - error_count: Number of error-level diagnostics
+        - total_count: Total number of diagnostics
+
+    Example:
+        get_niagara_diagnostics(system="NS_FireExplosion")
+        # Returns:
+        # {
+        #   "success": true,
+        #   "system": "NS_FireExplosion",
+        #   "path": "/Game/Effects/NS_FireExplosion",
+        #   "diagnostics": [
+        #     {
+        #       "severity": "Warning",
+        #       "summary": "GPU simulation without fixed bounds",
+        #       "description": "GPU emitters require fixed bounds for culling...",
+        #       "source": "NE_Sparks",
+        #       "fixes": ["Set CalculateBoundsMode to Fixed"]
+        #     }
+        #   ],
+        #   "info_count": 0,
+        #   "warning_count": 1,
+        #   "error_count": 0,
+        #   "total_count": 1
+        # }
+    """
+    params = {"system": system}
+    return await send_tcp_command("get_niagara_diagnostics", params)
+
+
+# ============================================================================
+# Renderer Operations
+# ============================================================================
+
 @app.tool()
 async def set_renderer_property(
     system_path: str,


### PR DESCRIPTION
Uses UE's built-in NiagaraValidation system to detect:
- GPU simulation without fixed bounds warnings
- Deprecated module warnings with upgrade suggestions
- Compile errors (e.g., GPU-only modules on CPU emitters)
- Module usage notes and info messages

Leverages both Stack Issue system (per-module) and ValidationRules system (system-wide) for comprehensive diagnostics.