### PR TITLE
Fix MaterialMCP expression types and asset persistence issues

### DIFF
--- a/Docs/known-issues.md
+++ b/Docs/known-issues.md
@@ -112,6 +112,23 @@ This file tracks MCP tool limitations discovered during development. When encoun
 
 ## Resolved Issues
 
+- **MaterialMCP Created Assets Don't Persist to Disk** - Fixed 2026-01-11
+  - Issue: Materials created via `create_material` existed in memory but weren't saved to disk. "Save All" didn't persist them.
+  - Root Cause: `CreateMaterial()`, `CreateMaterialInstance()`, and `DuplicateMaterialInstance()` only called `MarkPackageDirty()` but never actually saved the package to disk
+  - Fix: Added explicit `UPackage::SavePackage()` calls after asset creation in MaterialService.cpp
+  - Note: NiagaraMCP already had proper `SaveAsset()` calls - this was MaterialMCP-specific
+
+- **MaterialMCP Several Expression Types Not Recognized (Noise, ParticleRandom, Length)** - Fixed 2026-01-11
+  - Issue: Expression types `Noise`, `ParticleRandom`, and `Length` returned "Unknown expression type" errors
+  - Root Cause: These expression classes were not mapped in `GetExpressionClassFromTypeName()`
+  - Fix: Added includes for `MaterialExpressionNoise.h`, `MaterialExpressionParticleRandom.h`, `MaterialExpressionLength.h` and registered them in the expression type map
+  - Noise expression now supports all configurable properties: Scale, Quality, Levels, OutputMin, OutputMax, LevelScale, Turbulence, Tiling, RepeatSize, NoiseFunction (enum 0-5)
+
+- **MaterialMCP ComponentMask Channel Configuration Not Supported** - Fixed 2026-01-11
+  - Issue: ComponentMask R/G/B/A channel selection wasn't working, causing "component mask 0000" compile errors
+  - Root Cause: Was actually working - the issue was in how properties were being passed from Python side
+  - Verification: Tested with `{"R": true, "G": false, "B": false, "A": false}` - material compiles successfully
+
 - **MaterialMCP RadialGradientExponential Expression Not Supported** - Fixed 2026-01-09
   - Issue: Expression type "RadialGradientExponential" was not recognized
   - Root Cause: RadialGradientExponential is NOT a native expression - it's a Material Function at `/Engine/Functions/Engine_MaterialFunctions01/Gradient/RadialGradientExponential`

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Material/MaterialExpressionCore.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Material/MaterialExpressionCore.cpp
@@ -39,6 +39,10 @@
 #include "Materials/MaterialExpressionParticleColor.h"
 #include "Materials/MaterialExpressionVertexColor.h"
 #include "Materials/MaterialExpressionSphereMask.h"
+#include "Materials/MaterialExpressionParticleRandom.h"
+// Noise and math expressions
+#include "Materials/MaterialExpressionNoise.h"
+#include "Materials/MaterialExpressionLength.h"
 #include "Materials/MaterialExpressionDotProduct.h"
 #include "Materials/MaterialExpressionDistance.h"
 #include "Materials/MaterialExpressionNormalize.h"
@@ -125,6 +129,13 @@ UClass* FMaterialExpressionService::GetExpressionClassFromTypeName(const FString
         ExpressionTypeMap.Add(TEXT("ParticleColor"), UMaterialExpressionParticleColor::StaticClass());
         ExpressionTypeMap.Add(TEXT("VertexColor"), UMaterialExpressionVertexColor::StaticClass());
         ExpressionTypeMap.Add(TEXT("SphereMask"), UMaterialExpressionSphereMask::StaticClass());
+        ExpressionTypeMap.Add(TEXT("ParticleRandom"), UMaterialExpressionParticleRandom::StaticClass());
+
+        // Noise expression - procedural noise generation
+        ExpressionTypeMap.Add(TEXT("Noise"), UMaterialExpressionNoise::StaticClass());
+
+        // Length expression - vector magnitude
+        ExpressionTypeMap.Add(TEXT("Length"), UMaterialExpressionLength::StaticClass());
 
         // Material Function Call - allows using any Material Function by path
         ExpressionTypeMap.Add(TEXT("MaterialFunctionCall"), UMaterialExpressionMaterialFunctionCall::StaticClass());

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Material/MaterialExpressionCreation.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Material/MaterialExpressionCreation.cpp
@@ -21,6 +21,8 @@
 // Material Function support
 #include "Materials/MaterialExpressionMaterialFunctionCall.h"
 #include "Materials/MaterialFunctionInterface.h"
+// Noise expression
+#include "Materials/MaterialExpressionNoise.h"
 #include "Dom/JsonValue.h"
 #include "Engine/Texture.h"
 
@@ -246,6 +248,72 @@ bool FMaterialExpressionService::ApplyExpressionProperties(UMaterialExpression* 
             MaskExpr->A = Properties->HasField(TEXT("A"))
                 ? Properties->GetBoolField(TEXT("A"))
                 : Properties->GetBoolField(TEXT("a"));
+        }
+    }
+    // Handle Noise expression
+    else if (UMaterialExpressionNoise* NoiseExpr = Cast<UMaterialExpressionNoise>(Expression))
+    {
+        if (Properties->HasField(TEXT("Scale")) || Properties->HasField(TEXT("scale")))
+        {
+            NoiseExpr->Scale = Properties->HasField(TEXT("Scale"))
+                ? Properties->GetNumberField(TEXT("Scale"))
+                : Properties->GetNumberField(TEXT("scale"));
+        }
+        if (Properties->HasField(TEXT("Quality")) || Properties->HasField(TEXT("quality")))
+        {
+            NoiseExpr->Quality = Properties->HasField(TEXT("Quality"))
+                ? (int32)Properties->GetNumberField(TEXT("Quality"))
+                : (int32)Properties->GetNumberField(TEXT("quality"));
+        }
+        if (Properties->HasField(TEXT("Levels")) || Properties->HasField(TEXT("levels")))
+        {
+            NoiseExpr->Levels = Properties->HasField(TEXT("Levels"))
+                ? (int32)Properties->GetNumberField(TEXT("Levels"))
+                : (int32)Properties->GetNumberField(TEXT("levels"));
+        }
+        if (Properties->HasField(TEXT("OutputMin")) || Properties->HasField(TEXT("output_min")))
+        {
+            NoiseExpr->OutputMin = Properties->HasField(TEXT("OutputMin"))
+                ? Properties->GetNumberField(TEXT("OutputMin"))
+                : Properties->GetNumberField(TEXT("output_min"));
+        }
+        if (Properties->HasField(TEXT("OutputMax")) || Properties->HasField(TEXT("output_max")))
+        {
+            NoiseExpr->OutputMax = Properties->HasField(TEXT("OutputMax"))
+                ? Properties->GetNumberField(TEXT("OutputMax"))
+                : Properties->GetNumberField(TEXT("output_max"));
+        }
+        if (Properties->HasField(TEXT("LevelScale")) || Properties->HasField(TEXT("level_scale")))
+        {
+            NoiseExpr->LevelScale = Properties->HasField(TEXT("LevelScale"))
+                ? Properties->GetNumberField(TEXT("LevelScale"))
+                : Properties->GetNumberField(TEXT("level_scale"));
+        }
+        if (Properties->HasField(TEXT("Turbulence")) || Properties->HasField(TEXT("turbulence")))
+        {
+            NoiseExpr->bTurbulence = Properties->HasField(TEXT("Turbulence"))
+                ? Properties->GetBoolField(TEXT("Turbulence"))
+                : Properties->GetBoolField(TEXT("turbulence"));
+        }
+        if (Properties->HasField(TEXT("Tiling")) || Properties->HasField(TEXT("tiling")))
+        {
+            NoiseExpr->bTiling = Properties->HasField(TEXT("Tiling"))
+                ? Properties->GetBoolField(TEXT("Tiling"))
+                : Properties->GetBoolField(TEXT("tiling"));
+        }
+        if (Properties->HasField(TEXT("RepeatSize")) || Properties->HasField(TEXT("repeat_size")))
+        {
+            NoiseExpr->RepeatSize = Properties->HasField(TEXT("RepeatSize"))
+                ? (uint32)Properties->GetNumberField(TEXT("RepeatSize"))
+                : (uint32)Properties->GetNumberField(TEXT("repeat_size"));
+        }
+        // NoiseFunction enum: 0=SimplexTex, 1=GradientTex, 2=GradientTex3D, 3=GradientALU, 4=ValueALU, 5=Voronoi
+        if (Properties->HasField(TEXT("NoiseFunction")) || Properties->HasField(TEXT("noise_function")))
+        {
+            int32 FuncValue = Properties->HasField(TEXT("NoiseFunction"))
+                ? (int32)Properties->GetNumberField(TEXT("NoiseFunction"))
+                : (int32)Properties->GetNumberField(TEXT("noise_function"));
+            NoiseExpr->NoiseFunction = (ENoiseFunction)FuncValue;
         }
     }
     // Handle MaterialFunctionCall - load function by path and set it

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/MaterialService.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/MaterialService.cpp
@@ -100,6 +100,20 @@ UMaterial* FMaterialService::CreateMaterial(const FMaterialCreationParams& Param
     Package->MarkPackageDirty();
     FAssetRegistryModule::AssetCreated(NewMaterial);
 
+    // Save the package to disk
+    FString PackageFileName = FPackageName::LongPackageNameToFilename(PackageName, FPackageName::GetAssetPackageExtension());
+    FSavePackageArgs SaveArgs;
+    SaveArgs.TopLevelFlags = RF_Public | RF_Standalone;
+    bool bSaved = UPackage::SavePackage(Package, NewMaterial, *PackageFileName, SaveArgs);
+    if (!bSaved)
+    {
+        UE_LOG(LogTemp, Warning, TEXT("Failed to save material package to disk: %s"), *PackageFileName);
+    }
+    else
+    {
+        UE_LOG(LogTemp, Log, TEXT("Saved material package to disk: %s"), *PackageFileName);
+    }
+
     // Build output path
     OutMaterialPath = PackagePath;
 
@@ -180,6 +194,20 @@ UMaterialInterface* FMaterialService::CreateMaterialInstance(const FMaterialInst
 
         Package->MarkPackageDirty();
         FAssetRegistryModule::AssetCreated(MIC);
+
+        // Save the package to disk
+        FString PackageFileName = FPackageName::LongPackageNameToFilename(PackageName, FPackageName::GetAssetPackageExtension());
+        FSavePackageArgs SaveArgs;
+        SaveArgs.TopLevelFlags = RF_Public | RF_Standalone;
+        bool bSaved = UPackage::SavePackage(Package, MIC, *PackageFileName, SaveArgs);
+        if (!bSaved)
+        {
+            UE_LOG(LogTemp, Warning, TEXT("Failed to save material instance package to disk: %s"), *PackageFileName);
+        }
+        else
+        {
+            UE_LOG(LogTemp, Log, TEXT("Saved material instance package to disk: %s"), *PackageFileName);
+        }
 
         OutInstancePath = PackagePath;
         UE_LOG(LogTemp, Log, TEXT("Successfully created material instance constant: %s"), *OutInstancePath);
@@ -720,6 +748,20 @@ bool FMaterialService::DuplicateMaterialInstance(const FString& SourcePath, cons
     // Mark package dirty and register
     Package->MarkPackageDirty();
     FAssetRegistryModule::AssetCreated(NewMIC);
+
+    // Save the package to disk
+    FString PackageFileName = FPackageName::LongPackageNameToFilename(PackageName, FPackageName::GetAssetPackageExtension());
+    FSavePackageArgs SaveArgs;
+    SaveArgs.TopLevelFlags = RF_Public | RF_Standalone;
+    bool bSaved = UPackage::SavePackage(Package, NewMIC, *PackageFileName, SaveArgs);
+    if (!bSaved)
+    {
+        UE_LOG(LogTemp, Warning, TEXT("Failed to save duplicated material instance to disk: %s"), *PackageFileName);
+    }
+    else
+    {
+        UE_LOG(LogTemp, Log, TEXT("Saved duplicated material instance to disk: %s"), *PackageFileName);
+    }
 
     // Set output values
     OutAssetPath = PackagePath;

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Niagara/NiagaraAssetService.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Niagara/NiagaraAssetService.cpp
@@ -252,39 +252,23 @@ bool FNiagaraService::DuplicateSystem(const FString& SourcePath, const FString& 
         return false;
     }
 
-    // Use Asset Tools to duplicate
+    // Use Asset Tools to duplicate with proper name
     IAssetTools& AssetTools = FModuleManager::LoadModuleChecked<FAssetToolsModule>("AssetTools").Get();
 
-    TArray<UObject*> ObjectsToDuplicate;
-    ObjectsToDuplicate.Add(SourceSystem);
+    // DuplicateAsset creates a properly named copy
+    UObject* DuplicatedObject = AssetTools.DuplicateAsset(NewName, DestFolder, SourceSystem);
 
-    TArray<FAssetRenameData> RenameData;
-    FAssetRenameData& Data = RenameData.AddDefaulted_GetRef();
-    Data.Asset = SourceSystem;
-    Data.NewPackagePath = DestFolder;
-    Data.NewName = NewName;
-
-    // Duplicate the asset
-    TArray<UObject*> DuplicatedObjects;
-    ObjectTools::DuplicateObjects(ObjectsToDuplicate, TEXT(""), DestFolder, false, &DuplicatedObjects);
-
-    if (DuplicatedObjects.Num() == 0)
+    if (!DuplicatedObject)
     {
         OutError = TEXT("Failed to duplicate system");
         return false;
     }
 
-    UNiagaraSystem* NewSystem = Cast<UNiagaraSystem>(DuplicatedObjects[0]);
+    UNiagaraSystem* NewSystem = Cast<UNiagaraSystem>(DuplicatedObject);
     if (!NewSystem)
     {
         OutError = TEXT("Duplicated object is not a Niagara System");
         return false;
-    }
-
-    // Rename to desired name if not already correct
-    if (NewSystem->GetName() != NewName)
-    {
-        NewSystem->Rename(*NewName, NewSystem->GetOuter());
     }
 
     // Save the new asset


### PR DESCRIPTION
- Add Noise, ParticleRandom, Length expression types to MaterialMCP
- Add Noise expression property support (Scale, Quality, Levels, etc.)
- Fix Material/MaterialInstance assets not persisting to disk by adding SavePackage calls after creation
- Fix Niagara system duplication using wrong name by switching from ObjectTools::DuplicateObjects to AssetTools.DuplicateAsset
- Update known-issues.md with resolved issues