### PR TITLE
Improve Niagara, Sound, and Material MCP services

### DIFF
--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/SoundService.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/SoundService.cpp
@@ -299,15 +299,15 @@ USoundAttenuation* FSoundService::CreateSoundAttenuation(const FSoundAttenuation
     FSoundAttenuationSettings& Settings = Attenuation->Attenuation;
 
     // Distance settings
-    Settings.DistanceAlgorithm = static_cast<EAttenuationDistanceModel>(GetAttenuationFunction(Params.DistanceAlgorithm));
-    Settings.AttenuationShape = Params.bUseSpatialization ? EAttenuationShape::Sphere : EAttenuationShape::Capsule;
+    Settings.DistanceAlgorithm = static_cast<EAttenuationDistanceModel>(GetAttenuationFunction(Params.AttenuationFunction));
+    Settings.AttenuationShape = Params.bSpatialize ? EAttenuationShape::Sphere : EAttenuationShape::Capsule;
     Settings.FalloffDistance = Params.FalloffDistance;
 
     // Radius settings
     Settings.AttenuationShapeExtents = FVector(Params.InnerRadius, 0.0f, 0.0f);
 
     // Spatialization
-    Settings.bSpatialize = Params.bUseSpatialization;
+    Settings.bSpatialize = Params.bSpatialize;
 
     if (!SaveAsset(Attenuation, OutError))
     {


### PR DESCRIPTION
Niagara:
- Auto-link SubUVAnimation Sprite Renderer input to emitter's renderer
- Add mesh renderer support for ParticleMesh and OverrideMaterials properties

Sound:
- Fix parameter names in CreateSoundAttenuation (AttenuationFunction, bSpatialize)

Material:
- Add get_material_graph_metadata tool for expression graph inspection
- Add set_material_expression_property tool for modifying expression nodes