### PR TITLE
feat: add create_render_target MCP command for TextureRenderTarget2D …

### DIFF
--- a/Docs/BACKLOG.md
+++ b/Docs/BACKLOG.md
@@ -1,0 +1,29 @@
+# MCP Tools — Backlog (Fixes & Improvements)
+
+## Bugs / Fixes
+
+### `add_component_to_blueprint` — no attach_to / socket support
+- **Problem:** Cannot specify parent component or socket when adding a component
+- **Current:** Component always lands under root (Capsule), requires manual drag in editor
+- **Expected:** `attach_to` param (parent component name) + `socket_name` param
+- **Workaround:** Manual drag in Components panel, or set AttachSocketName via modify_blueprint_component_properties (but AttachParent doesn't work as property)
+- **Priority:** High — needed for Scene Capture, widget components, attached meshes
+- **Found:** 2026-02-15 (Portrait Capture setup)
+
+### `create_node_by_action_name` — cannot reference Blueprint components as targets
+- **Problem:** No way to create a component reference node (e.g., drag CharacterMesh0 onto graph) via MCP
+- **Current:** GetSocketTransform needs Target pin connected to mesh component, but no MCP tool creates component getter nodes
+- **Expected:** Either `target` kwarg on create_node resolves component names, or a dedicated tool to create component reference nodes
+- **Workaround:** Manual drag from Components panel onto graph
+- **Priority:** Medium — needed for any component method call
+- **Found:** 2026-02-15 (Portrait Capture setup)
+
+## Improvements / New Tools
+
+### `create_render_target` ✅ (2026-02-15)
+- Created and working in editorMCP
+- Creates TextureRenderTarget2D assets in Content Browser
+
+---
+
+*Add new items at the top of each section. Date everything.*

--- a/Docs/Implementation-Examples/portrait-scene-capture/PLAN.md
+++ b/Docs/Implementation-Examples/portrait-scene-capture/PLAN.md
@@ -1,0 +1,52 @@
+# Portrait Scene Capture — Implementation Plan
+
+## Goal
+SceneCapture2D captures character's head/face → renders to RT_Portrait → displays in HUD portrait circle.
+Must work during movement, jumping, animations.
+
+## Current State (2026-02-15)
+- ✅ SceneCaptureComponent2D "PortraitCapture" added to BP_ThirdPersonCharacter
+- ✅ RT_Portrait (256×256) TextureRenderTarget2D created at /Game/Rendering/RT_Portrait
+- ✅ M_Portrait material (UI domain, TextureSample→EmissiveColor) at /Game/Materials/M_Portrait
+- ✅ M_Portrait applied to Image_PortraitFace Brush in WBP_HUD_PortraitGroup
+- ✅ Static capture works when character stands still
+- ❌ Portrait disappears during movement/jumping (camera attached to Capsule, mesh moves relative to it)
+- ⚠️ Debug BeginPlay nodes exist (GetSocketTransform → PrintString) — REMOVE when done
+
+## Camera Position (current, on Capsule)
+- Location: X=50 (forward), Y=0, Z=75 (head height)
+- Rotation: Pitch=0, Yaw=180, Roll=0 (looking back at character)
+- FOV: 40°
+
+## Head Bone Info (from PrintString debug)
+- World transform at rest: Translation X=401 Y=0.2 Z=161, Rotation P=83.2 Y=-93.3 R=85.6
+- Bone-local axes are heavily rotated — static bone-local offsets are impractical
+
+## Three Approaches (from research)
+
+### Approach 1: FindLookAtRotation on Tick ⭐ RECOMMENDED — simplest
+- Keep camera on Capsule (predictable position)
+- Every Tick: get head socket world location → FindLookAtRotation → set camera rotation
+- Camera always points at head regardless of animation state
+- **Pros:** Minimal code, no coordinate headaches, works with any animation
+- **Cons:** Slight Tick cost (negligible for one component), camera position doesn't follow head lean
+- **Implementation:** ~5 Blueprint nodes in EventGraph
+
+### Approach 2: Runtime AttachToComponent in BeginPlay
+- In BeginPlay: call AttachToComponent(Mesh, "head", SnapToTarget)
+- Set relative location/rotation after attach (runtime attach resolves bone transform correctly)
+- Different from editor static attach — runtime attach applies bone rotation to relative offsets
+- **Pros:** Camera physically follows head, lean/tilt reflected
+- **Cons:** Need to figure out correct relative offset (still bone-local, but runtime may be more predictable)
+- **Implementation:** ~4 Blueprint nodes in BeginPlay + trial-and-error offset tuning
+
+### Approach 3: Separate Portrait Scene (AAA approach)
+- Create separate sub-level or hidden area with copy of character head mesh
+- Dedicated lighting setup for portrait
+- SceneCapture only renders that isolated scene
+- **Pros:** Full lighting control, no background bleed, professional look
+- **Cons:** Duplicate mesh overhead, more complex setup, overkill for current stage
+- **Implementation:** Separate actor + mesh + lights + scene capture actor
+
+## Next Step
+Try Approach 1 (FindLookAtRotation on Tick).

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Editor/CreateRenderTargetCommand.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Editor/CreateRenderTargetCommand.cpp
@@ -1,0 +1,157 @@
+#include "Commands/Editor/CreateRenderTargetCommand.h"
+#include "Engine/TextureRenderTarget2D.h"
+#include "AssetRegistry/AssetRegistryModule.h"
+#include "UObject/SavePackage.h"
+#include "Dom/JsonObject.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonWriter.h"
+
+FCreateRenderTargetCommand::FCreateRenderTargetCommand(IEditorService& InEditorService)
+	: EditorService(InEditorService)
+{
+}
+
+FString FCreateRenderTargetCommand::Execute(const FString& Parameters)
+{
+	FString Name, FolderPath, Error;
+	int32 Width, Height;
+
+	if (!ParseParameters(Parameters, Name, FolderPath, Width, Height, Error))
+	{
+		return CreateErrorResponse(Error);
+	}
+
+	// Build asset path
+	if (FolderPath.IsEmpty())
+	{
+		FolderPath = TEXT("/Game");
+	}
+	// Ensure folder path starts with /Game
+	if (!FolderPath.StartsWith(TEXT("/Game")))
+	{
+		FolderPath = FString::Printf(TEXT("/Game/%s"), *FolderPath);
+	}
+	// Remove trailing slash
+	FolderPath.RemoveFromEnd(TEXT("/"));
+
+	FString PackagePath = FString::Printf(TEXT("%s/%s"), *FolderPath, *Name);
+
+	// Check if asset already exists
+	if (FindObject<UObject>(nullptr, *PackagePath))
+	{
+		return CreateErrorResponse(FString::Printf(TEXT("Asset already exists at: %s"), *PackagePath));
+	}
+
+	// Create package
+	UPackage* Package = CreatePackage(*PackagePath);
+	if (!Package)
+	{
+		return CreateErrorResponse(TEXT("Failed to create package"));
+	}
+
+	// Create the render target
+	UTextureRenderTarget2D* RenderTarget = NewObject<UTextureRenderTarget2D>(
+		Package, *Name, RF_Public | RF_Standalone);
+
+	if (!RenderTarget)
+	{
+		return CreateErrorResponse(TEXT("Failed to create TextureRenderTarget2D"));
+	}
+
+	// Configure
+	RenderTarget->RenderTargetFormat = RTF_RGBA8;
+	RenderTarget->InitAutoFormat(Width, Height);
+	RenderTarget->UpdateResourceImmediate(true);
+
+	// Mark dirty and save
+	RenderTarget->MarkPackageDirty();
+	Package->MarkPackageDirty();
+
+	// Save the asset
+	FString PackageFileName = FPackageName::LongPackageNameToFilename(PackagePath, FPackageName::GetAssetPackageExtension());
+	FSavePackageArgs SaveArgs;
+	SaveArgs.TopLevelFlags = RF_Public | RF_Standalone;
+	bool bSaved = UPackage::SavePackage(Package, RenderTarget, *PackageFileName, SaveArgs);
+
+	if (!bSaved)
+	{
+		UE_LOG(LogTemp, Warning, TEXT("CreateRenderTarget: Asset created but failed to save to disk"));
+	}
+
+	// Notify asset registry
+	FAssetRegistryModule::AssetCreated(RenderTarget);
+
+	UE_LOG(LogTemp, Log, TEXT("Created TextureRenderTarget2D: %s (%dx%d)"), *PackagePath, Width, Height);
+
+	return CreateSuccessResponse(PackagePath, Width, Height);
+}
+
+FString FCreateRenderTargetCommand::GetCommandName() const
+{
+	return TEXT("create_render_target");
+}
+
+bool FCreateRenderTargetCommand::ValidateParams(const FString& Parameters) const
+{
+	FString Name, FolderPath, Error;
+	int32 Width, Height;
+	return ParseParameters(Parameters, Name, FolderPath, Width, Height, Error);
+}
+
+bool FCreateRenderTargetCommand::ParseParameters(const FString& JsonString, FString& OutName,
+	FString& OutFolderPath, int32& OutWidth, int32& OutHeight, FString& OutError) const
+{
+	TSharedPtr<FJsonObject> JsonObject;
+	TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(JsonString);
+
+	if (!FJsonSerializer::Deserialize(Reader, JsonObject) || !JsonObject.IsValid())
+	{
+		OutError = TEXT("Invalid JSON parameters");
+		return false;
+	}
+
+	if (!JsonObject->TryGetStringField(TEXT("name"), OutName) || OutName.IsEmpty())
+	{
+		OutError = TEXT("Missing required 'name' parameter");
+		return false;
+	}
+
+	JsonObject->TryGetStringField(TEXT("folder_path"), OutFolderPath);
+	OutWidth = JsonObject->HasField(TEXT("width")) ? (int32)JsonObject->GetNumberField(TEXT("width")) : 256;
+	OutHeight = JsonObject->HasField(TEXT("height")) ? (int32)JsonObject->GetNumberField(TEXT("height")) : 256;
+
+	if (OutWidth <= 0 || OutHeight <= 0 || OutWidth > 4096 || OutHeight > 4096)
+	{
+		OutError = TEXT("Width and height must be between 1 and 4096");
+		return false;
+	}
+
+	return true;
+}
+
+FString FCreateRenderTargetCommand::CreateSuccessResponse(const FString& AssetPath, int32 Width, int32 Height) const
+{
+	TSharedPtr<FJsonObject> ResponseObj = MakeShared<FJsonObject>();
+	ResponseObj->SetBoolField(TEXT("success"), true);
+	ResponseObj->SetStringField(TEXT("asset_path"), AssetPath);
+	ResponseObj->SetNumberField(TEXT("width"), Width);
+	ResponseObj->SetNumberField(TEXT("height"), Height);
+	ResponseObj->SetStringField(TEXT("type"), TEXT("TextureRenderTarget2D"));
+
+	FString OutputString;
+	TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&OutputString);
+	FJsonSerializer::Serialize(ResponseObj.ToSharedRef(), Writer);
+	return OutputString;
+}
+
+FString FCreateRenderTargetCommand::CreateErrorResponse(const FString& ErrorMessage) const
+{
+	TSharedPtr<FJsonObject> ErrorObj = MakeShared<FJsonObject>();
+	ErrorObj->SetBoolField(TEXT("success"), false);
+	ErrorObj->SetStringField(TEXT("error"), ErrorMessage);
+
+	FString OutputString;
+	TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&OutputString);
+	FJsonSerializer::Serialize(ErrorObj.ToSharedRef(), Writer);
+	return OutputString;
+}

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EditorCommandRegistration.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EditorCommandRegistration.cpp
@@ -13,6 +13,7 @@
 #include "Commands/Editor/GetLevelMetadataCommand.h"
 #include "Commands/Editor/BatchDeleteActorsCommand.h"
 #include "Commands/Editor/BatchSpawnActorsCommand.h"
+#include "Commands/Editor/CreateRenderTargetCommand.h"
 
 TArray<TSharedPtr<IUnrealMCPCommand>> FEditorCommandRegistration::RegisteredCommands;
 
@@ -38,6 +39,9 @@ void FEditorCommandRegistration::RegisterAllCommands()
     // Register batch operations
     RegisterAndTrackCommand(MakeShared<FBatchDeleteActorsCommand>(EditorService));
     RegisterAndTrackCommand(MakeShared<FBatchSpawnActorsCommand>(EditorService));
+
+    // Register asset creation commands
+    RegisterAndTrackCommand(MakeShared<FCreateRenderTargetCommand>(EditorService));
 
     // Note: Additional editor commands are handled by legacy command system
     // and will be migrated to the new architecture in future iterations:

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Editor/CreateRenderTargetCommand.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Editor/CreateRenderTargetCommand.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Commands/IUnrealMCPCommand.h"
+#include "Services/IEditorService.h"
+
+/**
+ * Command for creating TextureRenderTarget2D assets.
+ * Creates a persistent render target asset in the Content Browser.
+ */
+class UNREALMCP_API FCreateRenderTargetCommand : public IUnrealMCPCommand
+{
+public:
+	explicit FCreateRenderTargetCommand(IEditorService& InEditorService);
+
+	virtual FString Execute(const FString& Parameters) override;
+	virtual FString GetCommandName() const override;
+	virtual bool ValidateParams(const FString& Parameters) const override;
+
+private:
+	IEditorService& EditorService;
+
+	bool ParseParameters(const FString& JsonString, FString& OutName, FString& OutFolderPath,
+		int32& OutWidth, int32& OutHeight, FString& OutError) const;
+	FString CreateSuccessResponse(const FString& AssetPath, int32 Width, int32 Height) const;
+	FString CreateErrorResponse(const FString& ErrorMessage) const;
+};

--- a/Python/editor_tools/editor_tools.py
+++ b/Python/editor_tools/editor_tools.py
@@ -11,6 +11,7 @@ from utils.editor.editor_operations import (
     spawn_actor as spawn_actor_impl,
     delete_actor as delete_actor_impl,
     delete_asset as delete_asset_impl,
+    create_render_target as create_render_target_impl,
     set_actor_transform as set_actor_transform_impl,
     get_actor_properties as get_actor_properties_impl,
     set_actor_property as set_actor_property_impl,
@@ -657,10 +658,42 @@ def register_editor_tools(mcp: FastMCP):
         """
         return delete_asset_impl(ctx, asset_path)
 
+    @mcp.tool()
+    def create_render_target(
+        ctx: Context,
+        name: str,
+        folder_path: str = "/Game",
+        width: int = 256,
+        height: int = 256
+    ) -> Dict[str, Any]:
+        """
+        Create a TextureRenderTarget2D asset in the Content Browser.
+
+        Used for Scene Capture, runtime rendering to texture, minimap cameras, portrait captures, etc.
+
+        Args:
+            name: Name of the render target asset (e.g., "RT_Portrait")
+            folder_path: Folder path in Content Browser (default: "/Game")
+            width: Texture width in pixels (1-4096, default: 256)
+            height: Texture height in pixels (1-4096, default: 256)
+
+        Returns:
+            Dict containing:
+            - success: Whether creation was successful
+            - asset_path: Full path to the created asset
+            - width/height: Dimensions
+
+        Examples:
+            create_render_target(name="RT_Portrait", folder_path="/Game/Rendering", width=256, height=256)
+            create_render_target(name="RT_Minimap", folder_path="/Game/Rendering", width=512, height=512)
+        """
+        return create_render_target_impl(ctx, name, folder_path, width, height)
+
     # Register all tools with the help system
     _help_registry.register(spawn_actor, category="actors")
     _help_registry.register(delete_actor, category="actors")
     _help_registry.register(delete_asset, category="assets")
+    _help_registry.register(create_render_target, category="assets")
     _help_registry.register(set_actor_transform, category="actors")
     _help_registry.register(get_actor_properties, category="actors")
     _help_registry.register(set_actor_property, category="actors")

--- a/Python/utils/editor/editor_operations.py
+++ b/Python/utils/editor/editor_operations.py
@@ -221,6 +221,11 @@ def delete_asset(ctx: Context, asset_path: str) -> Dict[str, Any]:
     params = {"asset_path": asset_path}
     return send_unreal_command("delete_asset", params)
 
+def create_render_target(ctx: Context, name: str, folder_path: str = "/Game", width: int = 256, height: int = 256) -> Dict[str, Any]:
+    """Implementation for creating a TextureRenderTarget2D asset."""
+    params = {"name": name, "folder_path": folder_path, "width": width, "height": height}
+    return send_unreal_command("create_render_target", params)
+
 def create_folder(ctx: Context, folder_path: str) -> Dict[str, Any]:
     """Implementation for creating a new folder in the Content Browser."""
     params = {"folder_path": folder_path}


### PR DESCRIPTION
…assets

- New C++ command CreateRenderTargetCommand (editorMCP)
- Creates persistent TextureRenderTarget2D assets in Content Browser
- Parameters: name, folder_path, width, height (1-4096, default 256)
- Python tool + registration in editor_tools
- Added BACKLOG.md for tracking MCP tool fixes/improvements
- Added portrait scene capture implementation plan