### PR TITLE
PropertyService: support UE 5.1+ Getter/Setter properties

### DIFF
--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/UMG/UMGService.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/UMG/UMGService.cpp
@@ -455,6 +455,9 @@ bool FUMGService::SetWidgetProperties(const FString& BlueprintName, const FStrin
     // Save the blueprint if any properties were set
     if (OutSuccessProperties.Num() > 0)
     {
+        // Ensure widget picks up property changes (especially for UE5.1+ getter/setter properties)
+        Widget->SynchronizeProperties();
+        
         WidgetBlueprint->MarkPackageDirty();
         FKismetEditorUtilities::CompileBlueprint(WidgetBlueprint);
         UEditorAssetLibrary::SaveAsset(WidgetBlueprint->GetPathName(), false);


### PR DESCRIPTION
Properties declared with UPROPERTY(Getter, Setter) were silently broken - direct memory writes bypassed the setter, so Slate widgets never picked up changes (e.g. ProgressBar WidgetStyle.BackgroundImage.TintColor).

Fix: detect HasGetter()/HasSetter() on properties and use a copy-modify-setter path: CallGetter() into temp buffer, modify nested field, CallSetter() back. Works for both dot-notation (WidgetStyle.X.Y) and simple property names.

Affects all UMG widgets deprecated in 5.1+: ProgressBar, Button, Slider, SizeBox, CheckBox, etc.