### PR TITLE
feat(material): MaterialFunction, MPC creation + material_function_pa…

### DIFF
--- a/MCPGameProject/Config/DefaultGame.ini
+++ b/MCPGameProject/Config/DefaultGame.ini
@@ -1,3 +1,7 @@
 
 [/Script/EngineSettings.GeneralProjectSettings]
 ProjectID=79D0CA614129AD37FDB3F391CCE0F640
+
+[/Script/CommonInput.CommonInputSettings]
+bEnableEnhancedInputSupport=True
+InputData=(DefaultInputType=MouseAndKeyboard,DefaultGamepadName="Generic")

--- a/MCPGameProject/MCPGameProject.uproject
+++ b/MCPGameProject/MCPGameProject.uproject
@@ -17,6 +17,10 @@
 			"TargetAllowList": [
 				"Editor"
 			]
+		},
+		{
+			"Name": "CommonUI",
+			"Enabled": true
 		}
 	]
 }

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Editor/ImportTextureCommand.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Editor/ImportTextureCommand.cpp
@@ -1,0 +1,255 @@
+#include "Commands/Editor/ImportTextureCommand.h"
+#include "Engine/Texture2D.h"
+#include "Factories/TextureFactory.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonSerializer.h"
+#include "Dom/JsonObject.h"
+#include "Misc/Paths.h"
+#include "Misc/FileHelper.h"
+#include "UObject/Package.h"
+#include "AssetRegistry/AssetRegistryModule.h"
+
+FString FImportTextureCommand::GetCommandName() const
+{
+	return TEXT("import_texture");
+}
+
+bool FImportTextureCommand::ValidateParams(const FString& Parameters) const
+{
+	FString SourceFilePath, AssetName, FolderPath, CompressionSettings, Error;
+	bool bSRGB, bPreserveAlpha;
+	return ParseParameters(Parameters, SourceFilePath, AssetName, FolderPath, CompressionSettings, bSRGB, bPreserveAlpha, Error);
+}
+
+FString FImportTextureCommand::Execute(const FString& Parameters)
+{
+	FString SourceFilePath, AssetName, FolderPath, CompressionSettings, Error;
+	bool bSRGB, bPreserveAlpha;
+	if (!ParseParameters(Parameters, SourceFilePath, AssetName, FolderPath, CompressionSettings, bSRGB, bPreserveAlpha, Error))
+	{
+		return CreateErrorResponse(Error);
+	}
+
+	// Validate source file exists
+	if (!FPaths::FileExists(SourceFilePath))
+	{
+		return CreateErrorResponse(FString::Printf(TEXT("Source file does not exist: %s"), *SourceFilePath));
+	}
+
+	// Validate file extension
+	FString Extension = FPaths::GetExtension(SourceFilePath).ToLower();
+	TArray<FString> SupportedExtensions = { TEXT("png"), TEXT("tga"), TEXT("tif"), TEXT("tiff"), TEXT("jpg"), TEXT("jpeg"), TEXT("exr"), TEXT("hdr"), TEXT("bmp") };
+	if (!SupportedExtensions.Contains(Extension))
+	{
+		return CreateErrorResponse(FString::Printf(TEXT("Unsupported texture format: %s. Supported: png, tga, tif, jpg, jpeg, exr, hdr, bmp"), *Extension));
+	}
+
+	// Normalize destination path
+	FString DestinationPath = FolderPath;
+	if (!DestinationPath.StartsWith(TEXT("/Game")))
+	{
+		if (DestinationPath.StartsWith(TEXT("/")))
+		{
+			DestinationPath = TEXT("/Game") + DestinationPath;
+		}
+		else
+		{
+			DestinationPath = TEXT("/Game/") + DestinationPath;
+		}
+	}
+
+	// Create package for the asset
+	FString PackagePath = DestinationPath / AssetName;
+	UPackage* Package = CreatePackage(*PackagePath);
+	if (!Package)
+	{
+		return CreateErrorResponse(FString::Printf(TEXT("Failed to create package: %s"), *PackagePath));
+	}
+	Package->FullyLoad();
+
+	// Create and configure the texture factory
+	UTextureFactory* TextureFactory = NewObject<UTextureFactory>();
+	TextureFactory->AddToRoot();
+
+	// Configure for automated import (suppress dialogs)
+	TextureFactory->SuppressImportOverwriteDialog();
+	TextureFactory->NoAlpha = !bPreserveAlpha;
+
+	// Parse compression settings
+	TextureCompressionSettings CompressionEnum = TC_Default;
+	if (CompressionSettings == TEXT("Normalmap"))
+	{
+		CompressionEnum = TC_Normalmap;
+	}
+	else if (CompressionSettings == TEXT("Masks"))
+	{
+		CompressionEnum = TC_Masks;
+	}
+	else if (CompressionSettings == TEXT("Grayscale"))
+	{
+		CompressionEnum = TC_Grayscale;
+	}
+	else if (CompressionSettings == TEXT("HDR"))
+	{
+		CompressionEnum = TC_HDR;
+	}
+	else if (CompressionSettings == TEXT("Alpha"))
+	{
+		CompressionEnum = TC_Alpha;
+	}
+	// else TC_Default
+
+	// Read file data into memory
+	TArray<uint8> FileData;
+	if (!FFileHelper::LoadFileToArray(FileData, *SourceFilePath))
+	{
+		TextureFactory->RemoveFromRoot();
+		return CreateErrorResponse(FString::Printf(TEXT("Failed to read source file: %s"), *SourceFilePath));
+	}
+
+	// Import using FactoryCreateBinary (no bCancelled param in UE 5.7)
+	const uint8* DataPtr = FileData.GetData();
+
+	UObject* ImportedObject = TextureFactory->FactoryCreateBinary(
+		UTexture2D::StaticClass(),
+		Package,
+		FName(*AssetName),
+		RF_Public | RF_Standalone,
+		nullptr,    // Context
+		*Extension, // Type (file extension)
+		DataPtr,
+		DataPtr + FileData.Num(),
+		GWarn
+	);
+
+	TextureFactory->RemoveFromRoot();
+
+	if (!ImportedObject)
+	{
+		return CreateErrorResponse(FString::Printf(TEXT("Failed to import texture file: %s"), *SourceFilePath));
+	}
+
+	// Apply post-import settings
+	UTexture2D* ImportedTexture = Cast<UTexture2D>(ImportedObject);
+	if (ImportedTexture)
+	{
+		ImportedTexture->CompressionSettings = CompressionEnum;
+		ImportedTexture->SRGB = bSRGB;
+
+		// For normalmap compression, always disable sRGB
+		if (CompressionEnum == TC_Normalmap || CompressionEnum == TC_Masks || CompressionEnum == TC_Grayscale)
+		{
+			ImportedTexture->SRGB = false;
+		}
+
+		ImportedTexture->UpdateResource();
+		ImportedTexture->PostEditChange();
+	}
+
+	// Notify asset registry
+	FAssetRegistryModule::AssetCreated(ImportedObject);
+	Package->MarkPackageDirty();
+
+	// Get texture info
+	int32 SizeX = 0;
+	int32 SizeY = 0;
+	bool bHasAlpha = false;
+
+	if (ImportedTexture)
+	{
+		SizeX = ImportedTexture->GetSizeX();
+		SizeY = ImportedTexture->GetSizeY();
+		bHasAlpha = ImportedTexture->HasAlphaChannel();
+
+		UE_LOG(LogTemp, Log, TEXT("Imported texture '%s' from '%s' (%dx%d, Alpha: %s, sRGB: %s, Compression: %s)"),
+			*PackagePath, *SourceFilePath, SizeX, SizeY,
+			bHasAlpha ? TEXT("Yes") : TEXT("No"),
+			ImportedTexture->SRGB ? TEXT("Yes") : TEXT("No"),
+			*CompressionSettings);
+	}
+
+	return CreateSuccessResponse(PackagePath, AssetName, SizeX, SizeY, bHasAlpha);
+}
+
+bool FImportTextureCommand::ParseParameters(
+	const FString& JsonString,
+	FString& OutSourceFilePath,
+	FString& OutAssetName,
+	FString& OutFolderPath,
+	FString& OutCompressionSettings,
+	bool& OutSRGB,
+	bool& OutPreserveAlpha,
+	FString& OutError) const
+{
+	TSharedPtr<FJsonObject> JsonObject;
+	TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(JsonString);
+
+	if (!FJsonSerializer::Deserialize(Reader, JsonObject) || !JsonObject.IsValid())
+	{
+		OutError = TEXT("Failed to parse JSON parameters");
+		return false;
+	}
+
+	if (!JsonObject->TryGetStringField(TEXT("source_file_path"), OutSourceFilePath) || OutSourceFilePath.IsEmpty())
+	{
+		OutError = TEXT("Missing required parameter: source_file_path");
+		return false;
+	}
+
+	if (!JsonObject->TryGetStringField(TEXT("asset_name"), OutAssetName) || OutAssetName.IsEmpty())
+	{
+		OutError = TEXT("Missing required parameter: asset_name");
+		return false;
+	}
+
+	if (!JsonObject->TryGetStringField(TEXT("folder_path"), OutFolderPath) || OutFolderPath.IsEmpty())
+	{
+		OutFolderPath = TEXT("/Game/Textures");
+	}
+
+	if (!JsonObject->TryGetStringField(TEXT("compression_settings"), OutCompressionSettings) || OutCompressionSettings.IsEmpty())
+	{
+		OutCompressionSettings = TEXT("Default");
+	}
+
+	if (!JsonObject->TryGetBoolField(TEXT("srgb"), OutSRGB))
+	{
+		OutSRGB = true;
+	}
+
+	if (!JsonObject->TryGetBoolField(TEXT("preserve_alpha"), OutPreserveAlpha))
+	{
+		OutPreserveAlpha = true;
+	}
+
+	return true;
+}
+
+FString FImportTextureCommand::CreateSuccessResponse(const FString& AssetPath, const FString& AssetName, int32 SizeX, int32 SizeY, bool bHasAlpha) const
+{
+	TSharedPtr<FJsonObject> Response = MakeShared<FJsonObject>();
+	Response->SetBoolField(TEXT("success"), true);
+	Response->SetStringField(TEXT("path"), AssetPath);
+	Response->SetStringField(TEXT("name"), AssetName);
+	Response->SetNumberField(TEXT("size_x"), SizeX);
+	Response->SetNumberField(TEXT("size_y"), SizeY);
+	Response->SetBoolField(TEXT("has_alpha"), bHasAlpha);
+	Response->SetStringField(TEXT("message"), FString::Printf(TEXT("Successfully imported texture as: %s (%dx%d, Alpha: %s)"), *AssetPath, SizeX, SizeY, bHasAlpha ? TEXT("Yes") : TEXT("No")));
+
+	FString OutputString;
+	TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&OutputString);
+	FJsonSerializer::Serialize(Response.ToSharedRef(), Writer);
+	return OutputString;
+}
+
+FString FImportTextureCommand::CreateErrorResponse(const FString& ErrorMessage) const
+{
+	TSharedPtr<FJsonObject> Response = MakeShared<FJsonObject>();
+	Response->SetBoolField(TEXT("success"), false);
+	Response->SetStringField(TEXT("error"), ErrorMessage);
+
+	FString OutputString;
+	TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&OutputString);
+	FJsonSerializer::Serialize(Response.ToSharedRef(), Writer);
+	return OutputString;
+}

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EditorCommandRegistration.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EditorCommandRegistration.cpp
@@ -15,6 +15,7 @@
 #include "Commands/Editor/BatchSpawnActorsCommand.h"
 #include "Commands/Editor/CreateRenderTargetCommand.h"
 #include "Commands/Editor/ImportStaticMeshCommand.h"
+#include "Commands/Editor/ImportTextureCommand.h"
 
 TArray<TSharedPtr<IUnrealMCPCommand>> FEditorCommandRegistration::RegisteredCommands;
 
@@ -46,6 +47,7 @@ void FEditorCommandRegistration::RegisterAllCommands()
 
     // Register asset import commands
     RegisterAndTrackCommand(MakeShared<FImportStaticMeshCommand>());
+    RegisterAndTrackCommand(MakeShared<FImportTextureCommand>());
 
     // Note: Additional editor commands are handled by legacy command system
     // and will be migrated to the new architecture in future iterations:

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Material/AddMaterialExpressionCommand.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Material/AddMaterialExpressionCommand.cpp
@@ -56,9 +56,13 @@ bool FAddMaterialExpressionCommand::ParseParameters(const FString& JsonString, F
         return false;
     }
 
-    if (!JsonObject->TryGetStringField(TEXT("material_path"), OutParams.MaterialPath))
+    // Accept either material_path or material_function_path
+    JsonObject->TryGetStringField(TEXT("material_path"), OutParams.MaterialPath);
+    JsonObject->TryGetStringField(TEXT("material_function_path"), OutParams.MaterialFunctionPath);
+
+    if (OutParams.MaterialPath.IsEmpty() && OutParams.MaterialFunctionPath.IsEmpty())
     {
-        OutError = TEXT("Missing 'material_path' parameter");
+        OutError = TEXT("Missing 'material_path' or 'material_function_path' parameter");
         return false;
     }
 

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Material/ConnectMaterialExpressionsCommand.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Material/ConnectMaterialExpressionsCommand.cpp
@@ -19,9 +19,13 @@ FString FConnectMaterialExpressionsCommand::Execute(const FString& Parameters)
     }
 
     FString MaterialPath;
-    if (!JsonObject->TryGetStringField(TEXT("material_path"), MaterialPath))
+    FString MaterialFunctionPath;
+    JsonObject->TryGetStringField(TEXT("material_path"), MaterialPath);
+    JsonObject->TryGetStringField(TEXT("material_function_path"), MaterialFunctionPath);
+
+    if (MaterialPath.IsEmpty() && MaterialFunctionPath.IsEmpty())
     {
-        return CreateErrorResponse(TEXT("Missing 'material_path' parameter"));
+        return CreateErrorResponse(TEXT("Missing 'material_path' or 'material_function_path' parameter"));
     }
 
     // Check for batch mode (connections array)
@@ -40,6 +44,7 @@ FString FConnectMaterialExpressionsCommand::Execute(const FString& Parameters)
 
             FMaterialExpressionConnectionParams Params;
             Params.MaterialPath = MaterialPath;
+            Params.MaterialFunctionPath = MaterialFunctionPath;
 
             FString SourceIdStr;
             if (!(*ConnObj)->TryGetStringField(TEXT("source_expression_id"), SourceIdStr))
@@ -112,9 +117,11 @@ bool FConnectMaterialExpressionsCommand::ValidateParams(const FString& Parameter
         return false;
     }
 
-    // Must have material_path
-    FString MaterialPath;
-    if (!JsonObject->TryGetStringField(TEXT("material_path"), MaterialPath))
+    // Must have material_path or material_function_path
+    FString MaterialPath, MaterialFunctionPath;
+    JsonObject->TryGetStringField(TEXT("material_path"), MaterialPath);
+    JsonObject->TryGetStringField(TEXT("material_function_path"), MaterialFunctionPath);
+    if (MaterialPath.IsEmpty() && MaterialFunctionPath.IsEmpty())
     {
         return false;
     }
@@ -143,9 +150,13 @@ bool FConnectMaterialExpressionsCommand::ParseParameters(const FString& JsonStri
         return false;
     }
 
-    if (!JsonObject->TryGetStringField(TEXT("material_path"), OutParams.MaterialPath))
+    // Accept either material_path or material_function_path
+    JsonObject->TryGetStringField(TEXT("material_path"), OutParams.MaterialPath);
+    JsonObject->TryGetStringField(TEXT("material_function_path"), OutParams.MaterialFunctionPath);
+
+    if (OutParams.MaterialPath.IsEmpty() && OutParams.MaterialFunctionPath.IsEmpty())
     {
-        OutError = TEXT("Missing 'material_path' parameter");
+        OutError = TEXT("Missing 'material_path' or 'material_function_path' parameter");
         return false;
     }
 

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Material/CreateMPCCommand.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Material/CreateMPCCommand.cpp
@@ -1,0 +1,192 @@
+#include "Commands/Material/CreateMPCCommand.h"
+#include "Dom/JsonObject.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonWriter.h"
+#include "Materials/MaterialParameterCollection.h"
+#include "AssetRegistry/AssetRegistryModule.h"
+#include "UObject/SavePackage.h"
+
+FString FCreateMPCCommand::Execute(const FString& Parameters)
+{
+	FString Response;
+	if (!ParseAndExecute(Parameters, Response))
+	{
+		return Response; // already error JSON
+	}
+	return Response;
+}
+
+FString FCreateMPCCommand::GetCommandName() const
+{
+	return TEXT("create_material_parameter_collection");
+}
+
+bool FCreateMPCCommand::ValidateParams(const FString& Parameters) const
+{
+	TSharedPtr<FJsonObject> JsonObject;
+	TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Parameters);
+	if (!FJsonSerializer::Deserialize(Reader, JsonObject) || !JsonObject.IsValid())
+		return false;
+	FString Name;
+	return JsonObject->TryGetStringField(TEXT("name"), Name) && !Name.IsEmpty();
+}
+
+bool FCreateMPCCommand::ParseAndExecute(const FString& JsonString, FString& OutResponse)
+{
+	TSharedPtr<FJsonObject> JsonObject;
+	TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(JsonString);
+
+	if (!FJsonSerializer::Deserialize(Reader, JsonObject) || !JsonObject.IsValid())
+	{
+		OutResponse = CreateErrorResponse(TEXT("Invalid JSON parameters"));
+		return false;
+	}
+
+	FString Name;
+	if (!JsonObject->TryGetStringField(TEXT("name"), Name))
+	{
+		OutResponse = CreateErrorResponse(TEXT("Missing 'name' parameter"));
+		return false;
+	}
+
+	FString Path = TEXT("/Game/Materials");
+	JsonObject->TryGetStringField(TEXT("path"), Path);
+
+	// Build package path
+	FString PackagePath = Path / Name;
+	FString PackageName = FPackageName::ObjectPathToPackageName(PackagePath);
+
+	// Check existing
+	UPackage* ExistingPackage = FindPackage(nullptr, *PackageName);
+	if (ExistingPackage)
+	{
+		ExistingPackage->FullyLoad();
+		UMaterialParameterCollection* Existing = FindObject<UMaterialParameterCollection>(ExistingPackage, *Name);
+		if (Existing)
+		{
+			// Return existing
+			TSharedPtr<FJsonObject> Resp = MakeShared<FJsonObject>();
+			Resp->SetBoolField(TEXT("success"), true);
+			Resp->SetStringField(TEXT("mpc_path"), PackagePath);
+			Resp->SetStringField(TEXT("message"), TEXT("MPC already exists, returning existing"));
+			FString Out;
+			TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&Out);
+			FJsonSerializer::Serialize(Resp.ToSharedRef(), Writer);
+			OutResponse = Out;
+			return true;
+		}
+	}
+
+	// Create package
+	UPackage* Package = CreatePackage(*PackageName);
+	if (!Package)
+	{
+		OutResponse = CreateErrorResponse(FString::Printf(TEXT("Failed to create package: %s"), *PackageName));
+		return false;
+	}
+	Package->FullyLoad();
+
+	// Create MPC asset
+	UMaterialParameterCollection* MPC = NewObject<UMaterialParameterCollection>(
+		Package, FName(*Name), RF_Public | RF_Standalone);
+
+	if (!MPC)
+	{
+		OutResponse = CreateErrorResponse(TEXT("Failed to create MPC asset"));
+		return false;
+	}
+
+	// Add scalar parameters
+	const TArray<TSharedPtr<FJsonValue>>* ScalarParams;
+	if (JsonObject->TryGetArrayField(TEXT("scalar_params"), ScalarParams))
+	{
+		for (const auto& ParamVal : *ScalarParams)
+		{
+			const TSharedPtr<FJsonObject>* ParamObj;
+			if (ParamVal->TryGetObject(ParamObj))
+			{
+				FCollectionScalarParameter Param;
+				FString ParamName;
+				if ((*ParamObj)->TryGetStringField(TEXT("name"), ParamName))
+				{
+					Param.ParameterName = FName(*ParamName);
+					double DefaultVal = 0.0;
+					(*ParamObj)->TryGetNumberField(TEXT("default_value"), DefaultVal);
+					Param.DefaultValue = (float)DefaultVal;
+					MPC->ScalarParameters.Add(Param);
+				}
+			}
+		}
+	}
+
+	// Add vector parameters
+	const TArray<TSharedPtr<FJsonValue>>* VectorParams;
+	if (JsonObject->TryGetArrayField(TEXT("vector_params"), VectorParams))
+	{
+		for (const auto& ParamVal : *VectorParams)
+		{
+			const TSharedPtr<FJsonObject>* ParamObj;
+			if (ParamVal->TryGetObject(ParamObj))
+			{
+				FCollectionVectorParameter Param;
+				FString ParamName;
+				if ((*ParamObj)->TryGetStringField(TEXT("name"), ParamName))
+				{
+					Param.ParameterName = FName(*ParamName);
+
+					// Parse default value as R,G,B,A
+					double R = 0, G = 0, B = 0, A = 1;
+					(*ParamObj)->TryGetNumberField(TEXT("r"), R);
+					(*ParamObj)->TryGetNumberField(TEXT("g"), G);
+					(*ParamObj)->TryGetNumberField(TEXT("b"), B);
+					(*ParamObj)->TryGetNumberField(TEXT("a"), A);
+					Param.DefaultValue = FLinearColor((float)R, (float)G, (float)B, (float)A);
+					MPC->VectorParameters.Add(Param);
+				}
+			}
+		}
+	}
+
+	// Register with worlds
+	MPC->SetupWorldParameterCollectionInstances();
+
+	// Register and save
+	Package->MarkPackageDirty();
+	FAssetRegistryModule::AssetCreated(MPC);
+
+	FString PackageFileName = FPackageName::LongPackageNameToFilename(PackageName, FPackageName::GetAssetPackageExtension());
+	FSavePackageArgs SaveArgs;
+	SaveArgs.TopLevelFlags = RF_Public | RF_Standalone;
+	UPackage::SavePackage(Package, MPC, *PackageFileName, SaveArgs);
+
+	UE_LOG(LogTemp, Log, TEXT("Created MPC: %s (%d scalar, %d vector params)"),
+		*PackagePath, MPC->ScalarParameters.Num(), MPC->VectorParameters.Num());
+
+	// Build response
+	TSharedPtr<FJsonObject> Resp = MakeShared<FJsonObject>();
+	Resp->SetBoolField(TEXT("success"), true);
+	Resp->SetStringField(TEXT("mpc_path"), PackagePath);
+	Resp->SetNumberField(TEXT("scalar_count"), MPC->ScalarParameters.Num());
+	Resp->SetNumberField(TEXT("vector_count"), MPC->VectorParameters.Num());
+	Resp->SetStringField(TEXT("message"),
+		FString::Printf(TEXT("MPC created at %s (%d scalar, %d vector params)"),
+			*PackagePath, MPC->ScalarParameters.Num(), MPC->VectorParameters.Num()));
+
+	FString Out;
+	TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&Out);
+	FJsonSerializer::Serialize(Resp.ToSharedRef(), Writer);
+	OutResponse = Out;
+	return true;
+}
+
+FString FCreateMPCCommand::CreateErrorResponse(const FString& ErrorMessage) const
+{
+	TSharedPtr<FJsonObject> ErrorObj = MakeShared<FJsonObject>();
+	ErrorObj->SetBoolField(TEXT("success"), false);
+	ErrorObj->SetStringField(TEXT("error"), ErrorMessage);
+
+	FString OutputString;
+	TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&OutputString);
+	FJsonSerializer::Serialize(ErrorObj.ToSharedRef(), Writer);
+	return OutputString;
+}

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Material/CreateMaterialFunctionCommand.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Material/CreateMaterialFunctionCommand.cpp
@@ -1,0 +1,157 @@
+#include "Commands/Material/CreateMaterialFunctionCommand.h"
+#include "Dom/JsonObject.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonWriter.h"
+#include "Materials/MaterialFunction.h"
+#include "Factories/MaterialFunctionFactoryNew.h"
+#include "AssetRegistry/AssetRegistryModule.h"
+#include "UObject/SavePackage.h"
+
+FString FCreateMaterialFunctionCommand::Execute(const FString& Parameters)
+{
+	FParams Params;
+	FString Error;
+
+	if (!ParseParameters(Parameters, Params, Error))
+	{
+		return CreateErrorResponse(Error);
+	}
+
+	// Build full path
+	FString PackagePath = Params.Path / Params.Name;
+	FString PackageName = FPackageName::ObjectPathToPackageName(PackagePath);
+
+	// Check if already exists
+	UPackage* ExistingPackage = FindPackage(nullptr, *PackageName);
+	if (ExistingPackage)
+	{
+		ExistingPackage->FullyLoad();
+		UMaterialFunction* Existing = FindObject<UMaterialFunction>(ExistingPackage, *Params.Name);
+		if (Existing)
+		{
+			return CreateSuccessResponse(PackagePath);
+		}
+	}
+
+	// Create package
+	UPackage* Package = CreatePackage(*PackageName);
+	if (!Package)
+	{
+		return CreateErrorResponse(FString::Printf(TEXT("Failed to create package: %s"), *PackageName));
+	}
+	Package->FullyLoad();
+
+	// Create via factory
+	UMaterialFunctionFactoryNew* Factory = NewObject<UMaterialFunctionFactoryNew>();
+	UMaterialFunction* MatFunc = Cast<UMaterialFunction>(Factory->FactoryCreateNew(
+		UMaterialFunction::StaticClass(),
+		Package,
+		*Params.Name,
+		RF_Public | RF_Standalone,
+		nullptr,
+		GWarn
+	));
+
+	if (!MatFunc)
+	{
+		return CreateErrorResponse(TEXT("Failed to create MaterialFunction asset"));
+	}
+
+	// Set metadata
+	MatFunc->Description = Params.Description;
+	MatFunc->bExposeToLibrary = Params.bExposeToLibrary;
+
+	for (const FString& Category : Params.LibraryCategories)
+	{
+		MatFunc->LibraryCategoriesText.Add(FText::FromString(Category));
+	}
+
+	// If no categories specified, add a default
+	if (MatFunc->LibraryCategoriesText.Num() == 0 && Params.bExposeToLibrary)
+	{
+		MatFunc->LibraryCategoriesText.Add(FText::FromString(TEXT("Custom")));
+	}
+
+	// Register and save
+	Package->MarkPackageDirty();
+	FAssetRegistryModule::AssetCreated(MatFunc);
+
+	FString PackageFileName = FPackageName::LongPackageNameToFilename(PackageName, FPackageName::GetAssetPackageExtension());
+	FSavePackageArgs SaveArgs;
+	SaveArgs.TopLevelFlags = RF_Public | RF_Standalone;
+	UPackage::SavePackage(Package, MatFunc, *PackageFileName, SaveArgs);
+
+	UE_LOG(LogTemp, Log, TEXT("Created MaterialFunction: %s"), *PackagePath);
+
+	return CreateSuccessResponse(PackagePath);
+}
+
+FString FCreateMaterialFunctionCommand::GetCommandName() const
+{
+	return TEXT("create_material_function");
+}
+
+bool FCreateMaterialFunctionCommand::ValidateParams(const FString& Parameters) const
+{
+	FParams Params;
+	FString Error;
+	return ParseParameters(Parameters, Params, Error);
+}
+
+bool FCreateMaterialFunctionCommand::ParseParameters(const FString& JsonString, FParams& OutParams, FString& OutError) const
+{
+	TSharedPtr<FJsonObject> JsonObject;
+	TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(JsonString);
+
+	if (!FJsonSerializer::Deserialize(Reader, JsonObject) || !JsonObject.IsValid())
+	{
+		OutError = TEXT("Invalid JSON parameters");
+		return false;
+	}
+
+	if (!JsonObject->TryGetStringField(TEXT("name"), OutParams.Name))
+	{
+		OutError = TEXT("Missing 'name' parameter");
+		return false;
+	}
+
+	JsonObject->TryGetStringField(TEXT("path"), OutParams.Path);
+	JsonObject->TryGetStringField(TEXT("description"), OutParams.Description);
+	JsonObject->TryGetBoolField(TEXT("expose_to_library"), OutParams.bExposeToLibrary);
+
+	const TArray<TSharedPtr<FJsonValue>>* CategoriesArray;
+	if (JsonObject->TryGetArrayField(TEXT("library_categories"), CategoriesArray))
+	{
+		for (const auto& Val : *CategoriesArray)
+		{
+			OutParams.LibraryCategories.Add(Val->AsString());
+		}
+	}
+
+	return OutParams.IsValid(OutError);
+}
+
+FString FCreateMaterialFunctionCommand::CreateSuccessResponse(const FString& FunctionPath) const
+{
+	TSharedPtr<FJsonObject> ResponseObj = MakeShared<FJsonObject>();
+	ResponseObj->SetBoolField(TEXT("success"), true);
+	ResponseObj->SetStringField(TEXT("function_path"), FunctionPath);
+	ResponseObj->SetStringField(TEXT("message"), FString::Printf(TEXT("MaterialFunction created at %s"), *FunctionPath));
+
+	FString OutputString;
+	TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&OutputString);
+	FJsonSerializer::Serialize(ResponseObj.ToSharedRef(), Writer);
+	return OutputString;
+}
+
+FString FCreateMaterialFunctionCommand::CreateErrorResponse(const FString& ErrorMessage) const
+{
+	TSharedPtr<FJsonObject> ErrorObj = MakeShared<FJsonObject>();
+	ErrorObj->SetBoolField(TEXT("success"), false);
+	ErrorObj->SetStringField(TEXT("error"), ErrorMessage);
+
+	FString OutputString;
+	TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&OutputString);
+	FJsonSerializer::Serialize(ErrorObj.ToSharedRef(), Writer);
+	return OutputString;
+}

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/MaterialCommandRegistration.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/MaterialCommandRegistration.cpp
@@ -29,6 +29,8 @@
 #include "Commands/Material/CompileMaterialCommand.h"
 #include "Commands/Material/SearchMaterialPaletteCommand.h"
 #include "Commands/Material/SetMaterialPropertiesCommand.h"
+#include "Commands/Material/CreateMaterialFunctionCommand.h"
+#include "Commands/Material/CreateMPCCommand.h"
 
 TArray<TSharedPtr<IUnrealMCPCommand>> FMaterialCommandRegistration::RegisteredCommands;
 
@@ -66,6 +68,8 @@ void FMaterialCommandRegistration::RegisterAllCommands()
     RegisterAndTrackCommand(MakeShared<FCompileMaterialCommand>());
     RegisterAndTrackCommand(MakeShared<FSearchMaterialPaletteCommand>());
     RegisterAndTrackCommand(MakeShared<FSetMaterialPropertiesCommand>());
+    RegisterAndTrackCommand(MakeShared<FCreateMaterialFunctionCommand>());
+    RegisterAndTrackCommand(MakeShared<FCreateMPCCommand>());
 
     UE_LOG(LogTemp, Log, TEXT("Registered %d Material commands"), RegisteredCommands.Num());
 }

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Project/SetIMCMappingSettingsCommand.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Project/SetIMCMappingSettingsCommand.cpp
@@ -1,0 +1,217 @@
+#include "Commands/Project/SetIMCMappingSettingsCommand.h"
+#include "Utils/UnrealMCPCommonUtils.h"
+#include "Dom/JsonObject.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonWriter.h"
+#include "InputMappingContext.h"
+#include "EnhancedActionKeyMapping.h"
+#include "PlayerMappableKeySettings.h"
+#include "InputAction.h"
+#include "EditorAssetLibrary.h"
+#include "UObject/SavePackage.h"
+
+FSetIMCMappingSettingsCommand::FSetIMCMappingSettingsCommand(TSharedPtr<IProjectService> InProjectService)
+	: ProjectService(InProjectService)
+{
+}
+
+FString FSetIMCMappingSettingsCommand::GetCommandName() const
+{
+	return TEXT("set_imc_mapping_settings");
+}
+
+bool FSetIMCMappingSettingsCommand::ValidateParams(const FString& Parameters) const
+{
+	TSharedPtr<FJsonObject> JsonObject;
+	TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Parameters);
+	if (!FJsonSerializer::Deserialize(Reader, JsonObject) || !JsonObject.IsValid())
+	{
+		return false;
+	}
+
+	FString IMCPath;
+	if (!JsonObject->TryGetStringField(TEXT("imc_path"), IMCPath) || IMCPath.IsEmpty())
+	{
+		return false;
+	}
+
+	FString ActionName;
+	if (!JsonObject->TryGetStringField(TEXT("action_name"), ActionName) || ActionName.IsEmpty())
+	{
+		return false;
+	}
+
+	FString Key;
+	if (!JsonObject->TryGetStringField(TEXT("key"), Key) || Key.IsEmpty())
+	{
+		return false;
+	}
+
+	FString MappingName;
+	if (!JsonObject->TryGetStringField(TEXT("mapping_name"), MappingName) || MappingName.IsEmpty())
+	{
+		return false;
+	}
+
+	return true;
+}
+
+static FString SerializeError(const FString& ErrorMessage)
+{
+	TSharedPtr<FJsonObject> Err = FUnrealMCPCommonUtils::CreateErrorResponse(ErrorMessage);
+	FString Out;
+	TSharedRef<TJsonWriter<>> W = TJsonWriterFactory<>::Create(&Out);
+	FJsonSerializer::Serialize(Err.ToSharedRef(), W);
+	return Out;
+}
+
+FString FSetIMCMappingSettingsCommand::Execute(const FString& Parameters)
+{
+	TSharedPtr<FJsonObject> JsonObject;
+	TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Parameters);
+	if (!FJsonSerializer::Deserialize(Reader, JsonObject) || !JsonObject.IsValid())
+	{
+		return SerializeError(TEXT("Invalid JSON parameters"));
+	}
+
+	FString IMCPath = JsonObject->GetStringField(TEXT("imc_path"));
+	FString ActionName = JsonObject->GetStringField(TEXT("action_name"));
+	FString Key = JsonObject->GetStringField(TEXT("key"));
+	FString MappingName = JsonObject->GetStringField(TEXT("mapping_name"));
+
+	FString DisplayName;
+	JsonObject->TryGetStringField(TEXT("display_name"), DisplayName);
+	if (DisplayName.IsEmpty())
+	{
+		DisplayName = MappingName;
+	}
+
+	FString DisplayCategory;
+	JsonObject->TryGetStringField(TEXT("display_category"), DisplayCategory);
+
+	// Load the IMC asset
+	UInputMappingContext* IMC = Cast<UInputMappingContext>(UEditorAssetLibrary::LoadAsset(IMCPath));
+	if (!IMC)
+	{
+		return SerializeError(FString::Printf(TEXT("InputMappingContext not found: %s"), *IMCPath));
+	}
+
+	// Find the FKey from the string
+	FKey TargetKey(*Key);
+	if (!TargetKey.IsValid())
+	{
+		return SerializeError(FString::Printf(TEXT("Invalid key: %s"), *Key));
+	}
+
+	// Find the matching mapping by action name + key
+	const TArray<FEnhancedActionKeyMapping>& Mappings = IMC->GetMappings();
+	int32 FoundIndex = INDEX_NONE;
+
+	for (int32 i = 0; i < Mappings.Num(); ++i)
+	{
+		const FEnhancedActionKeyMapping& Mapping = Mappings[i];
+		if (Mapping.Action && Mapping.Action->GetName() == ActionName && Mapping.Key == TargetKey)
+		{
+			FoundIndex = i;
+			break;
+		}
+	}
+
+	if (FoundIndex == INDEX_NONE)
+	{
+		return SerializeError(FString::Printf(
+			TEXT("No mapping found for action '%s' with key '%s' in IMC '%s'"),
+			*ActionName, *Key, *IMCPath));
+	}
+
+	// Get mutable reference to the mapping
+	FEnhancedActionKeyMapping& Mapping = IMC->GetMapping(FoundIndex);
+
+	// Set SettingBehavior to OverrideSettings via reflection (protected property)
+	FEnumProperty* BehaviorProp = CastField<FEnumProperty>(
+		FEnhancedActionKeyMapping::StaticStruct()->FindPropertyByName(TEXT("SettingBehavior")));
+	if (BehaviorProp)
+	{
+		// EPlayerMappableKeySettingBehaviors::OverrideSettings = 1
+		uint8 OverrideValue = 1;
+		BehaviorProp->GetUnderlyingProperty()->SetIntPropertyValue(
+			BehaviorProp->ContainerPtrToValuePtr<void>(&Mapping), static_cast<int64>(OverrideValue));
+	}
+	else
+	{
+		// Fallback: try as a byte property
+		FByteProperty* ByteProp = CastField<FByteProperty>(
+			FEnhancedActionKeyMapping::StaticStruct()->FindPropertyByName(TEXT("SettingBehavior")));
+		if (ByteProp)
+		{
+			ByteProp->SetPropertyValue_InContainer(&Mapping, 1); // OverrideSettings = 1
+		}
+		else
+		{
+			return SerializeError(TEXT("Cannot find SettingBehavior property on FEnhancedActionKeyMapping"));
+		}
+	}
+
+	// Access PlayerMappableKeySettings via reflection (protected property)
+	FObjectProperty* SettingsProp = CastField<FObjectProperty>(
+		FEnhancedActionKeyMapping::StaticStruct()->FindPropertyByName(TEXT("PlayerMappableKeySettings")));
+	if (!SettingsProp)
+	{
+		return SerializeError(TEXT("Cannot find PlayerMappableKeySettings property on FEnhancedActionKeyMapping"));
+	}
+
+	// Create or get the UPlayerMappableKeySettings instance
+	UPlayerMappableKeySettings* KeySettings = Cast<UPlayerMappableKeySettings>(
+		SettingsProp->GetObjectPropertyValue(SettingsProp->ContainerPtrToValuePtr<void>(&Mapping)));
+
+	if (!KeySettings)
+	{
+		KeySettings = NewObject<UPlayerMappableKeySettings>(IMC, UPlayerMappableKeySettings::StaticClass(),
+			NAME_None, RF_Public | RF_Transactional);
+		SettingsProp->SetObjectPropertyValue(
+			SettingsProp->ContainerPtrToValuePtr<void>(&Mapping), KeySettings);
+	}
+
+	// Set the settings
+	KeySettings->Name = FName(*MappingName);
+	KeySettings->DisplayName = FText::FromString(DisplayName);
+	if (!DisplayCategory.IsEmpty())
+	{
+		KeySettings->DisplayCategory = FText::FromString(DisplayCategory);
+	}
+
+	// Mark dirty and save
+	IMC->MarkPackageDirty();
+	UPackage* Package = IMC->GetOutermost();
+	if (Package)
+	{
+		FString PackageFilename;
+		if (FPackageName::DoesPackageExist(Package->GetName(), &PackageFilename))
+		{
+			FSavePackageArgs SaveArgs;
+			SaveArgs.TopLevelFlags = RF_Standalone;
+			UPackage::SavePackage(Package, IMC, *PackageFilename, SaveArgs);
+		}
+	}
+
+	// Build response
+	TSharedPtr<FJsonObject> Response = MakeShared<FJsonObject>();
+	Response->SetBoolField(TEXT("success"), true);
+	Response->SetStringField(TEXT("imc_path"), IMCPath);
+	Response->SetStringField(TEXT("action_name"), ActionName);
+	Response->SetStringField(TEXT("key"), Key);
+	Response->SetStringField(TEXT("mapping_name"), MappingName);
+	Response->SetStringField(TEXT("display_name"), DisplayName);
+	if (!DisplayCategory.IsEmpty())
+	{
+		Response->SetStringField(TEXT("display_category"), DisplayCategory);
+	}
+	Response->SetStringField(TEXT("message"), FString::Printf(
+		TEXT("Per-mapping settings set on %s[%s/%s]: name=%s, behavior=OverrideSettings"),
+		*IMCPath, *ActionName, *Key, *MappingName));
+
+	FString Out;
+	TSharedRef<TJsonWriter<>> W = TJsonWriterFactory<>::Create(&Out);
+	FJsonSerializer::Serialize(Response.ToSharedRef(), W);
+	return Out;
+}

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/ProjectCommandRegistration.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/ProjectCommandRegistration.cpp
@@ -28,6 +28,7 @@
 #include "Commands/Project/SearchAssetsCommand.h"
 #include "Commands/Project/CaptureViewportScreenshotCommand.h"
 #include "Commands/Project/SetInputActionMappableSettingsCommand.h"
+#include "Commands/Project/SetIMCMappingSettingsCommand.h"
 #include "Services/IProjectService.h"
 
 void FProjectCommandRegistration::RegisterCommands(FUnrealMCPCommandRegistry& Registry, TSharedPtr<IProjectService> ProjectService)
@@ -97,8 +98,9 @@ void FProjectCommandRegistration::RegisterCommands(FUnrealMCPCommandRegistry& Re
     Registry.RegisterCommand(MakeShared<FMoveAssetCommand>(ProjectService));
     Registry.RegisterCommand(MakeShared<FSearchAssetsCommand>());
 
-    // Register Enhanced Input settings command
+    // Register Enhanced Input settings commands
     Registry.RegisterCommand(MakeShared<FSetInputActionMappableSettingsCommand>(ProjectService));
+    Registry.RegisterCommand(MakeShared<FSetIMCMappingSettingsCommand>(ProjectService));
 
     UE_LOG(LogTemp, Log, TEXT("Registered project commands successfully"));
 }

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Material/MaterialExpressionConnection.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Material/MaterialExpressionConnection.cpp
@@ -1,7 +1,9 @@
 #include "Services/MaterialExpressionService.h"
+#include "MaterialEditingLibrary.h"
 #include "MaterialGraph/MaterialGraph.h"
 #include "MaterialGraph/MaterialGraphSchema.h"
 #include "Kismet2/BlueprintEditorUtils.h"
+#include "Materials/MaterialFunction.h"
 #include "Misc/PackageName.h"
 #include "UObject/SavePackage.h"
 
@@ -13,6 +15,70 @@ bool FMaterialExpressionService::ConnectExpressions(
     if (!Params.IsValid(OutError))
     {
         return false;
+    }
+
+    // ---- MaterialFunction branch ----
+    if (Params.IsForMaterialFunction())
+    {
+        UMaterialFunction* MatFunc = LoadObject<UMaterialFunction>(nullptr, *Params.MaterialFunctionPath);
+        if (!MatFunc)
+        {
+            OutError = FString::Printf(TEXT("MaterialFunction not found: %s"), *Params.MaterialFunctionPath);
+            return false;
+        }
+
+        UMaterialExpression* SourceExpr = FindExpressionInFunction(MatFunc, Params.SourceExpressionId);
+        UMaterialExpression* TargetExpr = FindExpressionInFunction(MatFunc, Params.TargetExpressionId);
+
+        if (!SourceExpr) { OutError = FString::Printf(TEXT("Source expression not found: %s"), *Params.SourceExpressionId.ToString()); return false; }
+        if (!TargetExpr) { OutError = FString::Printf(TEXT("Target expression not found: %s"), *Params.TargetExpressionId.ToString()); return false; }
+
+        if (Params.SourceOutputIndex < 0 || Params.SourceOutputIndex >= SourceExpr->GetOutputs().Num())
+        {
+            OutError = FString::Printf(TEXT("Invalid source output index: %d"), Params.SourceOutputIndex);
+            return false;
+        }
+
+        // Find target input by name
+        int32 TargetInputIndex = -1;
+        int32 NumInputs = TargetExpr->GetInputsView().Num();
+        for (int32 i = 0; i < NumInputs; ++i)
+        {
+            if (TargetExpr->GetInputName(i).ToString().Equals(Params.TargetInputName, ESearchCase::IgnoreCase))
+            {
+                TargetInputIndex = i;
+                break;
+            }
+        }
+
+        if (TargetInputIndex < 0)
+        {
+            TArray<FString> AvailableInputs;
+            for (int32 i = 0; i < NumInputs; ++i)
+                AvailableInputs.Add(TargetExpr->GetInputName(i).ToString());
+            OutError = FString::Printf(TEXT("Input '%s' not found. Available: %s"),
+                *Params.TargetInputName, *FString::Join(AvailableInputs, TEXT(", ")));
+            return false;
+        }
+
+        FExpressionInput* TargetInput = TargetExpr->GetInput(TargetInputIndex);
+        SourceExpr->Modify();
+        TargetExpr->Modify();
+        SourceExpr->ConnectExpression(TargetInput, Params.SourceOutputIndex);
+
+        UMaterialEditingLibrary::UpdateMaterialFunction(MatFunc, nullptr);
+        MatFunc->MarkPackageDirty();
+
+        // Save
+        UPackage* Package = MatFunc->GetOutermost();
+        FString PackageFilename = FPackageName::LongPackageNameToFilename(
+            Package->GetName(), FPackageName::GetAssetPackageExtension());
+        FSavePackageArgs SaveArgs;
+        SaveArgs.TopLevelFlags = RF_Public | RF_Standalone;
+        UPackage::SavePackage(Package, MatFunc, *PackageFilename, SaveArgs);
+
+        UE_LOG(LogTemp, Log, TEXT("Connected expressions in MaterialFunction %s"), *Params.MaterialFunctionPath);
+        return true;
     }
 
     // Find the working material (editor's transient copy if editor is open)

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Material/MaterialExpressionCreation.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Material/MaterialExpressionCreation.cpp
@@ -21,6 +21,9 @@
 // Material Function support
 #include "Materials/MaterialExpressionMaterialFunctionCall.h"
 #include "Materials/MaterialFunctionInterface.h"
+#include "Materials/MaterialFunction.h"
+#include "Materials/MaterialExpressionFunctionInput.h"
+#include "Materials/MaterialExpressionFunctionOutput.h"
 // Noise expression
 #include "Materials/MaterialExpressionNoise.h"
 // Particle SubUV for flipbook animations
@@ -634,6 +637,12 @@ UMaterialExpression* FMaterialExpressionService::AddExpression(
     if (!Params.IsValid(OutError))
     {
         return nullptr;
+    }
+
+    // ---- MaterialFunction branch ----
+    if (Params.IsForMaterialFunction())
+    {
+        return AddExpressionToFunction(Params, OutExpressionInfo, OutError);
     }
 
     // Find the working material (editor's transient copy if editor is open)

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Material/MaterialFunctionExpressionCreation.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Material/MaterialFunctionExpressionCreation.cpp
@@ -1,0 +1,162 @@
+#include "Services/MaterialExpressionService.h"
+#include "MaterialEditingLibrary.h"
+#include "Materials/MaterialFunction.h"
+#include "Materials/MaterialExpressionFunctionInput.h"
+#include "Materials/MaterialExpressionFunctionOutput.h"
+#include "UObject/SavePackage.h"
+
+UMaterialExpression* FMaterialExpressionService::AddExpressionToFunction(
+    const FMaterialExpressionCreationParams& Params,
+    TSharedPtr<FJsonObject>& OutExpressionInfo,
+    FString& OutError)
+{
+    // Load the MaterialFunction asset
+    UMaterialFunction* MatFunc = LoadObject<UMaterialFunction>(nullptr, *Params.MaterialFunctionPath);
+    if (!MatFunc)
+    {
+        OutError = FString::Printf(TEXT("MaterialFunction not found: %s"), *Params.MaterialFunctionPath);
+        return nullptr;
+    }
+
+    // Get expression class
+    UClass* ExpressionClass = GetExpressionClassFromTypeName(Params.ExpressionType);
+    if (!ExpressionClass)
+    {
+        OutError = FString::Printf(TEXT("Unknown expression type: %s"), *Params.ExpressionType);
+        return nullptr;
+    }
+
+    // Create expression in the MaterialFunction using UE's API
+    UMaterialExpression* NewExpression = UMaterialEditingLibrary::CreateMaterialExpressionInFunction(
+        MatFunc,
+        ExpressionClass,
+        (int32)Params.Position.X,
+        (int32)Params.Position.Y
+    );
+
+    if (!NewExpression)
+    {
+        OutError = FString::Printf(TEXT("Failed to create expression %s in MaterialFunction"), *Params.ExpressionType);
+        return nullptr;
+    }
+
+    // Apply type-specific properties
+    if (Params.Properties.IsValid())
+    {
+        NewExpression->Modify();
+        if (!ApplyExpressionProperties(NewExpression, Params.Properties, OutError))
+        {
+            // Clean up on failure
+            UMaterialEditingLibrary::DeleteMaterialExpressionInFunction(MatFunc, NewExpression);
+            return nullptr;
+        }
+    }
+
+    // Handle FunctionInput-specific properties
+    if (UMaterialExpressionFunctionInput* InputExpr = Cast<UMaterialExpressionFunctionInput>(NewExpression))
+    {
+        if (Params.Properties.IsValid())
+        {
+            FString InputName;
+            if (Params.Properties->TryGetStringField(TEXT("InputName"), InputName) ||
+                Params.Properties->TryGetStringField(TEXT("input_name"), InputName))
+            {
+                InputExpr->InputName = FName(*InputName);
+            }
+
+            FString InputTypeStr;
+            if (Params.Properties->TryGetStringField(TEXT("InputType"), InputTypeStr) ||
+                Params.Properties->TryGetStringField(TEXT("input_type"), InputTypeStr))
+            {
+                if (InputTypeStr == TEXT("Scalar") || InputTypeStr == TEXT("Float"))
+                    InputExpr->InputType = FunctionInput_Scalar;
+                else if (InputTypeStr == TEXT("Vector2"))
+                    InputExpr->InputType = FunctionInput_Vector2;
+                else if (InputTypeStr == TEXT("Vector3"))
+                    InputExpr->InputType = FunctionInput_Vector3;
+                else if (InputTypeStr == TEXT("Vector4"))
+                    InputExpr->InputType = FunctionInput_Vector4;
+                else if (InputTypeStr == TEXT("Texture2D"))
+                    InputExpr->InputType = FunctionInput_Texture2D;
+                else if (InputTypeStr == TEXT("Bool") || InputTypeStr == TEXT("StaticBool"))
+                    InputExpr->InputType = FunctionInput_StaticBool;
+            }
+
+            int32 SortPriority;
+            if (Params.Properties->TryGetNumberField(TEXT("SortPriority"), SortPriority) ||
+                Params.Properties->TryGetNumberField(TEXT("sort_priority"), SortPriority))
+            {
+                InputExpr->SortPriority = SortPriority;
+            }
+        }
+        InputExpr->ConditionallyGenerateId(true);
+    }
+
+    // Handle FunctionOutput-specific properties
+    if (UMaterialExpressionFunctionOutput* OutputExpr = Cast<UMaterialExpressionFunctionOutput>(NewExpression))
+    {
+        if (Params.Properties.IsValid())
+        {
+            FString OutputName;
+            if (Params.Properties->TryGetStringField(TEXT("OutputName"), OutputName) ||
+                Params.Properties->TryGetStringField(TEXT("output_name"), OutputName))
+            {
+                OutputExpr->OutputName = FName(*OutputName);
+            }
+
+            int32 SortPriority;
+            if (Params.Properties->TryGetNumberField(TEXT("SortPriority"), SortPriority) ||
+                Params.Properties->TryGetNumberField(TEXT("sort_priority"), SortPriority))
+            {
+                OutputExpr->SortPriority = SortPriority;
+            }
+        }
+        OutputExpr->ConditionallyGenerateId(true);
+    }
+
+    // Update and save
+    UMaterialEditingLibrary::UpdateMaterialFunction(MatFunc, nullptr);
+    MatFunc->MarkPackageDirty();
+
+    // Save to disk
+    UPackage* Package = MatFunc->GetOutermost();
+    FString PackageFilename = FPackageName::LongPackageNameToFilename(
+        Package->GetName(), FPackageName::GetAssetPackageExtension());
+    FSavePackageArgs SaveArgs;
+    SaveArgs.TopLevelFlags = RF_Public | RF_Standalone;
+    UPackage::SavePackage(Package, MatFunc, *PackageFilename, SaveArgs);
+
+    UE_LOG(LogTemp, Log, TEXT("Added %s to MaterialFunction %s"), *Params.ExpressionType, *Params.MaterialFunctionPath);
+
+    // Build output info
+    OutExpressionInfo = MakeShared<FJsonObject>();
+    OutExpressionInfo->SetBoolField(TEXT("success"), true);
+    OutExpressionInfo->SetStringField(TEXT("expression_id"), NewExpression->MaterialExpressionGuid.ToString());
+    OutExpressionInfo->SetStringField(TEXT("expression_type"), Params.ExpressionType);
+
+    TArray<TSharedPtr<FJsonValue>> PositionArray;
+    PositionArray.Add(MakeShared<FJsonValueNumber>(NewExpression->MaterialExpressionEditorX));
+    PositionArray.Add(MakeShared<FJsonValueNumber>(NewExpression->MaterialExpressionEditorY));
+    OutExpressionInfo->SetArrayField(TEXT("position"), PositionArray);
+    OutExpressionInfo->SetArrayField(TEXT("inputs"), GetInputPinInfo(NewExpression));
+    OutExpressionInfo->SetArrayField(TEXT("outputs"), GetOutputPinInfo(NewExpression));
+    OutExpressionInfo->SetStringField(TEXT("message"),
+        FString::Printf(TEXT("Expression %s added to MaterialFunction %s"), *Params.ExpressionType, *Params.MaterialFunctionPath));
+
+    return NewExpression;
+}
+
+UMaterialExpression* FMaterialExpressionService::FindExpressionInFunction(UMaterialFunction* Function, const FGuid& ExpressionId)
+{
+    if (!Function) return nullptr;
+
+    const TArray<TObjectPtr<UMaterialExpression>>& Expressions = Function->GetExpressionCollection().Expressions;
+    for (UMaterialExpression* Expr : Expressions)
+    {
+        if (Expr && Expr->MaterialExpressionGuid == ExpressionId)
+        {
+            return Expr;
+        }
+    }
+    return nullptr;
+}

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Editor/ImportTextureCommand.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Editor/ImportTextureCommand.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Commands/IUnrealMCPCommand.h"
+
+/**
+ * Command to import a texture file (PNG, TGA, TIF, JPEG, EXR, HDR) from disk into the Unreal project.
+ * Self-contained — uses UTextureFactory directly, no service layer needed.
+ */
+class UNREALMCP_API FImportTextureCommand : public IUnrealMCPCommand
+{
+public:
+	FImportTextureCommand() = default;
+
+	//~ IUnrealMCPCommand interface
+	virtual FString Execute(const FString& Parameters) override;
+	virtual FString GetCommandName() const override;
+	virtual bool ValidateParams(const FString& Parameters) const override;
+	//~ End IUnrealMCPCommand interface
+
+private:
+	bool ParseParameters(
+		const FString& JsonString,
+		FString& OutSourceFilePath,
+		FString& OutAssetName,
+		FString& OutFolderPath,
+		FString& OutCompressionSettings,
+		bool& OutSRGB,
+		bool& OutPreserveAlpha,
+		FString& OutError) const;
+
+	FString CreateSuccessResponse(const FString& AssetPath, const FString& AssetName, int32 SizeX, int32 SizeY, bool bHasAlpha) const;
+	FString CreateErrorResponse(const FString& ErrorMessage) const;
+};

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Material/CreateMPCCommand.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Material/CreateMPCCommand.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Commands/IUnrealMCPCommand.h"
+
+/**
+ * Command for creating Material Parameter Collection (MPC) assets.
+ * MPCs provide global material parameters shared across all materials.
+ */
+class UNREALMCP_API FCreateMPCCommand : public IUnrealMCPCommand
+{
+public:
+	FCreateMPCCommand() = default;
+
+	virtual FString Execute(const FString& Parameters) override;
+	virtual FString GetCommandName() const override;
+	virtual bool ValidateParams(const FString& Parameters) const override;
+
+private:
+	bool ParseAndExecute(const FString& JsonString, FString& OutResponse);
+	FString CreateErrorResponse(const FString& ErrorMessage) const;
+};

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Material/CreateMaterialFunctionCommand.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Material/CreateMaterialFunctionCommand.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Commands/IUnrealMCPCommand.h"
+
+/**
+ * Command for creating new MaterialFunction assets.
+ * MaterialFunctions are reusable node graphs that can be called from materials.
+ */
+class UNREALMCP_API FCreateMaterialFunctionCommand : public IUnrealMCPCommand
+{
+public:
+	FCreateMaterialFunctionCommand() = default;
+
+	virtual FString Execute(const FString& Parameters) override;
+	virtual FString GetCommandName() const override;
+	virtual bool ValidateParams(const FString& Parameters) const override;
+
+private:
+	struct FParams
+	{
+		FString Name;
+		FString Path = TEXT("/Game/Materials/Functions");
+		FString Description;
+		bool bExposeToLibrary = true;
+		TArray<FString> LibraryCategories;
+
+		bool IsValid(FString& OutError) const
+		{
+			if (Name.IsEmpty()) { OutError = TEXT("Missing 'name' parameter"); return false; }
+			return true;
+		}
+	};
+
+	bool ParseParameters(const FString& JsonString, FParams& OutParams, FString& OutError) const;
+	FString CreateSuccessResponse(const FString& FunctionPath) const;
+	FString CreateErrorResponse(const FString& ErrorMessage) const;
+};

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Project/SetIMCMappingSettingsCommand.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Project/SetIMCMappingSettingsCommand.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Commands/IUnrealMCPCommand.h"
+#include "Services/IProjectService.h"
+
+/**
+ * Command to set per-mapping PlayerMappableKeySettings on an IMC key mapping.
+ * Sets SettingBehavior=OverrideSettings and creates a UPlayerMappableKeySettings
+ * with unique Name/DisplayName/DisplayCategory per mapping.
+ * This enables per-key rebinding for multi-key actions like WASD movement.
+ */
+class UNREALMCP_API FSetIMCMappingSettingsCommand : public IUnrealMCPCommand
+{
+public:
+	explicit FSetIMCMappingSettingsCommand(TSharedPtr<IProjectService> InProjectService);
+	virtual ~FSetIMCMappingSettingsCommand() = default;
+
+	virtual FString GetCommandName() const override;
+	virtual FString Execute(const FString& Parameters) override;
+	virtual bool ValidateParams(const FString& Parameters) const override;
+
+private:
+	TSharedPtr<IProjectService> ProjectService;
+};

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Services/MaterialExpressionService.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Services/MaterialExpressionService.h
@@ -10,8 +10,11 @@
  */
 struct UNREALMCP_API FMaterialExpressionCreationParams
 {
-    /** Path to the material to modify */
+    /** Path to the material to modify (mutually exclusive with MaterialFunctionPath) */
     FString MaterialPath;
+
+    /** Path to the material function to modify (mutually exclusive with MaterialPath) */
+    FString MaterialFunctionPath;
 
     /** Type of expression to create (e.g., "Constant3Vector", "Add", "TextureSample") */
     FString ExpressionType;
@@ -25,6 +28,9 @@ struct UNREALMCP_API FMaterialExpressionCreationParams
     /** Default constructor */
     FMaterialExpressionCreationParams() = default;
 
+    /** Returns true if targeting a MaterialFunction rather than a Material */
+    bool IsForMaterialFunction() const { return !MaterialFunctionPath.IsEmpty(); }
+
     /**
      * Validate the parameters
      * @param OutError - Error message if validation fails
@@ -32,9 +38,9 @@ struct UNREALMCP_API FMaterialExpressionCreationParams
      */
     bool IsValid(FString& OutError) const
     {
-        if (MaterialPath.IsEmpty())
+        if (MaterialPath.IsEmpty() && MaterialFunctionPath.IsEmpty())
         {
-            OutError = TEXT("Material path cannot be empty");
+            OutError = TEXT("Either 'material_path' or 'material_function_path' must be provided");
             return false;
         }
         if (ExpressionType.IsEmpty())
@@ -51,8 +57,11 @@ struct UNREALMCP_API FMaterialExpressionCreationParams
  */
 struct UNREALMCP_API FMaterialExpressionConnectionParams
 {
-    /** Path to the material containing the expressions */
+    /** Path to the material containing the expressions (mutually exclusive with MaterialFunctionPath) */
     FString MaterialPath;
+
+    /** Path to the material function containing the expressions (mutually exclusive with MaterialPath) */
+    FString MaterialFunctionPath;
 
     /** GUID of the source expression */
     FGuid SourceExpressionId;
@@ -69,6 +78,9 @@ struct UNREALMCP_API FMaterialExpressionConnectionParams
     /** Default constructor */
     FMaterialExpressionConnectionParams() = default;
 
+    /** Returns true if targeting a MaterialFunction rather than a Material */
+    bool IsForMaterialFunction() const { return !MaterialFunctionPath.IsEmpty(); }
+
     /**
      * Validate the parameters
      * @param OutError - Error message if validation fails
@@ -76,9 +88,9 @@ struct UNREALMCP_API FMaterialExpressionConnectionParams
      */
     bool IsValid(FString& OutError) const
     {
-        if (MaterialPath.IsEmpty())
+        if (MaterialPath.IsEmpty() && MaterialFunctionPath.IsEmpty())
         {
-            OutError = TEXT("Material path cannot be empty");
+            OutError = TEXT("Either 'material_path' or 'material_function_path' must be provided");
             return false;
         }
         if (!SourceExpressionId.IsValid())
@@ -222,6 +234,23 @@ public:
         const FString& MaterialPath,
         TSharedPtr<FJsonObject>& OutResult,
         FString& OutError);
+
+    /**
+     * Add an expression to a MaterialFunction
+     * @param Params - Expression creation parameters (must have MaterialFunctionPath set)
+     * @param OutExpressionInfo - Output JSON with expression details
+     * @param OutError - Error message if creation fails
+     * @return Created expression or nullptr if failed
+     */
+    UMaterialExpression* AddExpressionToFunction(
+        const FMaterialExpressionCreationParams& Params,
+        TSharedPtr<FJsonObject>& OutExpressionInfo,
+        FString& OutError);
+
+    /**
+     * Find an expression by GUID within a MaterialFunction
+     */
+    UMaterialExpression* FindExpressionInFunction(UMaterialFunction* Function, const FGuid& ExpressionId);
 
 private:
     /** Singleton instance */

--- a/MCPGameProject/Plugins/UnrealMCP/UnrealMCP.uplugin
+++ b/MCPGameProject/Plugins/UnrealMCP/UnrealMCP.uplugin
@@ -34,6 +34,22 @@
 		{
 			"Name": "PCG",
 			"Enabled": true
+		},
+		{
+			"Name": "EnhancedInput",
+			"Enabled": true
+		},
+		{
+			"Name": "Metasound",
+			"Enabled": true
+		},
+		{
+			"Name": "StateTree",
+			"Enabled": true
+		},
+		{
+			"Name": "PropertyBindingUtils",
+			"Enabled": true
 		}
 	]
 } 

--- a/MCPGameProject/Source/MCPGameProject/MCPGameProject.Build.cs
+++ b/MCPGameProject/Source/MCPGameProject/MCPGameProject.Build.cs
@@ -14,7 +14,8 @@ public class MCPGameProject : ModuleRules
 			"Engine", 
 			"InputCore", 
 			"EnhancedInput",
-			"UMG"  // Add UMG for Widget Blueprints
+			"UMG",  // Add UMG for Widget Blueprints
+			"CommonInput"  // Input device detection (keyboard/gamepad switching)
 		});
 
 		PrivateDependencyModuleNames.AddRange(new string[] {

--- a/Python/editor_tools/editor_tools.py
+++ b/Python/editor_tools/editor_tools.py
@@ -21,7 +21,8 @@ from utils.editor.editor_operations import (
     get_level_metadata as get_level_metadata_impl,
     batch_delete_actors as batch_delete_actors_impl,
     batch_spawn_actors as batch_spawn_actors_impl,
-    import_static_mesh as import_static_mesh_impl
+    import_static_mesh as import_static_mesh_impl,
+    import_texture as import_texture_impl
 )
 from utils.mcp_help import get_help_registry, get_mcp_help as get_mcp_help_impl
 
@@ -728,6 +729,60 @@ def register_editor_tools(mcp: FastMCP):
         """
         return import_static_mesh_impl(ctx, source_file_path, asset_name, folder_path, import_materials)
 
+    @mcp.tool()
+    def import_texture(
+        ctx: Context,
+        source_file_path: str,
+        asset_name: str,
+        folder_path: str = "/Game/Textures",
+        compression_settings: str = "Default",
+        srgb: bool = True,
+        preserve_alpha: bool = True
+    ) -> Dict[str, Any]:
+        """
+        Import a texture from disk into the Unreal Engine project.
+
+        Supports PNG, TGA, TIF, JPEG, EXR, HDR, BMP formats.
+
+        Args:
+            source_file_path: Absolute path to the texture file on disk
+                (e.g., "E:/textures/T_Grass_Short_01.png")
+            asset_name: Name for the imported Texture asset (e.g., "T_Grass_Short_01")
+            folder_path: Content folder path for the imported asset (default: "/Game/Textures")
+            compression_settings: Texture compression type (default: "Default")
+                - "Default": Standard color texture (BC1/BC3)
+                - "Normalmap": Normal map compression (BC5), forces sRGB off
+                - "Masks": Mask/utility texture, forces sRGB off
+                - "Grayscale": Grayscale texture, forces sRGB off
+                - "HDR": High dynamic range (RGBA16F)
+                - "Alpha": Alpha-only compression
+            srgb: Whether texture uses sRGB color space (default: True).
+                Automatically disabled for Normalmap, Masks, and Grayscale compression.
+            preserve_alpha: Whether to preserve the alpha channel (default: True).
+                Set to False for opaque textures to save memory.
+
+        Returns:
+            Dictionary containing:
+            - success: Whether the import was successful
+            - path: Full asset path of the imported texture
+            - name: Name of the imported asset
+            - size_x: Texture width in pixels
+            - size_y: Texture height in pixels
+            - has_alpha: Whether the texture has an alpha channel
+            - message: Success/error message
+
+        Example:
+            import_texture(
+                source_file_path="E:/project/Content/Environment/GroundCover/T_Grass_Short_01.png",
+                asset_name="T_Grass_Short_01",
+                folder_path="/Game/Environment/GroundCover",
+                compression_settings="Default",
+                srgb=True,
+                preserve_alpha=True
+            )
+        """
+        return import_texture_impl(ctx, source_file_path, asset_name, folder_path, compression_settings, srgb, preserve_alpha)
+
     # Register all tools with the help system
     _help_registry.register(spawn_actor, category="actors")
     _help_registry.register(delete_actor, category="actors")
@@ -743,5 +798,6 @@ def register_editor_tools(mcp: FastMCP):
     _help_registry.register(delete_actors, category="actors")
     _help_registry.register(spawn_actors, category="actors")
     _help_registry.register(import_static_mesh, category="assets")
+    _help_registry.register(import_texture, category="assets")
 
     logger.info("Editor tools registered successfully")

--- a/Python/material_mcp_server.py
+++ b/Python/material_mcp_server.py
@@ -129,6 +129,117 @@ async def create_material(
 
 
 # ============================================================================
+# Material Function Creation
+# ============================================================================
+
+@app.tool()
+async def create_material_function(
+    name: str,
+    path: str = "/Game/Materials/Functions",
+    description: str = "",
+    expose_to_library: bool = True,
+    library_categories: list = None
+) -> Dict[str, Any]:
+    """
+    Create a new MaterialFunction asset.
+
+    MaterialFunctions are reusable node graphs that can be called from multiple materials.
+    Use add_material_expression with material_function_path to add nodes to it.
+
+    Args:
+        name: Name of the function (e.g., "MF_GrassWind")
+        path: Folder path (default: "/Game/Materials/Functions")
+        description: Description text for the function
+        expose_to_library: Whether to show in material editor palette (default: True)
+        library_categories: List of category strings for palette organization (default: ["Custom"])
+
+    Returns:
+        Dictionary containing:
+        - success: Whether creation was successful
+        - function_path: Full path to the created MaterialFunction
+        - message: Success/error message
+
+    Example:
+        create_material_function(
+            name="MF_GrassWind",
+            path="/Game/Environment/Materials/Functions",
+            description="Wind animation for grass cards",
+            library_categories=["Vegetation", "Wind"]
+        )
+    """
+    params = {
+        "name": name,
+        "path": path,
+        "description": description,
+        "expose_to_library": expose_to_library,
+    }
+    if library_categories:
+        params["library_categories"] = library_categories
+
+    return await send_tcp_command("create_material_function", params)
+
+
+# ============================================================================
+# Material Parameter Collection Creation
+# ============================================================================
+
+@app.tool()
+async def create_material_parameter_collection(
+    name: str,
+    path: str = "/Game/Materials",
+    scalar_params: list = None,
+    vector_params: list = None
+) -> Dict[str, Any]:
+    """
+    Create a Material Parameter Collection (MPC) asset.
+
+    MPCs provide global material parameters shared across ALL materials that reference them.
+    Change a value once → every material using this MPC updates instantly.
+    Ideal for: wind, weather, time of day, global tint, interaction systems.
+
+    Args:
+        name: Name of the MPC (e.g., "MPC_Wind")
+        path: Folder path (default: "/Game/Materials")
+        scalar_params: List of scalar parameters, each a dict with:
+            - name: Parameter name (e.g., "WindSpeed")
+            - default_value: Default float value (default: 0.0)
+        vector_params: List of vector parameters, each a dict with:
+            - name: Parameter name (e.g., "WindDirection")
+            - r, g, b, a: Default color/vector components (default: 0,0,0,1)
+
+    Returns:
+        Dictionary containing:
+        - success: Whether creation was successful
+        - mpc_path: Full path to the created MPC
+        - scalar_count: Number of scalar parameters
+        - vector_count: Number of vector parameters
+
+    Example:
+        create_material_parameter_collection(
+            name="MPC_Wind",
+            path="/Game/Environment/Materials",
+            scalar_params=[
+                {"name": "WindSpeed", "default_value": 0.3},
+                {"name": "WindStrength", "default_value": 3.0}
+            ],
+            vector_params=[
+                {"name": "WindDirection", "r": 0.7, "g": 0.7, "b": 0.0, "a": 0.0}
+            ]
+        )
+    """
+    params = {
+        "name": name,
+        "path": path,
+    }
+    if scalar_params:
+        params["scalar_params"] = scalar_params
+    if vector_params:
+        params["vector_params"] = vector_params
+
+    return await send_tcp_command("create_material_parameter_collection", params)
+
+
+# ============================================================================
 # Material Instance Creation
 # ============================================================================
 
@@ -607,35 +718,56 @@ async def set_material_expression_property(
 
 @app.tool()
 async def add_material_expression(
-    material_path: str,
-    expression_type: str,
+    material_path: str = None,
+    expression_type: str = "",
     position: List[int] = None,
-    properties: dict = None
+    properties: dict = None,
+    material_function_path: str = None
 ) -> Dict[str, Any]:
     """
-    Add a material expression node to a material graph.
+    Add a material expression node to a material or material function graph.
+
+    Provide either material_path OR material_function_path (not both).
+    For MaterialFunctions, use FunctionInput/FunctionOutput expression types
+    to define the function's interface.
 
     Args:
         material_path: Path to the material (e.g., "/Game/Materials/M_MyMaterial")
-        expression_type: Type of expression (e.g., "Constant", "Multiply", "ParticleColor",
-                        "RadialGradientExponential", "VertexColor", "TextureCoordinate")
+        expression_type: Type of expression (e.g., "Constant", "Multiply", "FunctionInput",
+                        "FunctionOutput", "VertexColor", "TextureCoordinate")
         position: [X, Y] position in the graph (optional)
-        properties: Dictionary of expression properties (optional)
+        properties: Dictionary of expression properties (optional).
+            For FunctionInput: {"InputName": "UV", "InputType": "Vector2", "SortPriority": 0}
+            For FunctionOutput: {"OutputName": "Result", "SortPriority": 0}
+            InputType options: "Scalar", "Vector2", "Vector3", "Vector4", "Texture2D", "Bool"
+        material_function_path: Path to MaterialFunction instead of material
+            (e.g., "/Game/Materials/Functions/MF_GrassWind")
 
     Returns:
         Dictionary with expression_id, name, and other info
 
-    Example:
+    Examples:
+        # Add to a material
         add_material_expression(
             material_path="/Game/Materials/M_Ember",
             expression_type="Constant",
             properties={"R": 1.0}
         )
+
+        # Add input to a MaterialFunction
+        add_material_expression(
+            material_function_path="/Game/Materials/Functions/MF_Wind",
+            expression_type="FunctionInput",
+            properties={"InputName": "WindSpeed", "InputType": "Scalar"}
+        )
     """
     params = {
-        "material_path": material_path,
         "expression_type": expression_type
     }
+    if material_path:
+        params["material_path"] = material_path
+    if material_function_path:
+        params["material_function_path"] = material_function_path
     if position:
         params["position"] = position
     if properties:
@@ -646,32 +778,39 @@ async def add_material_expression(
 
 @app.tool()
 async def connect_material_expressions(
-    material_path: str,
-    source_expression_id: str,
-    target_expression_id: str,
-    target_input_name: str,
-    source_output_index: int = 0
+    source_expression_id: str = "",
+    target_expression_id: str = "",
+    target_input_name: str = "",
+    source_output_index: int = 0,
+    material_path: str = None,
+    material_function_path: str = None
 ) -> Dict[str, Any]:
     """
-    Connect two material expressions.
+    Connect two material expressions in a material or material function.
+
+    Provide either material_path OR material_function_path (not both).
 
     Args:
-        material_path: Path to the material
         source_expression_id: GUID of the source expression
         target_expression_id: GUID of the target expression
         target_input_name: Name of the input on the target (e.g., "A", "B", "Base")
         source_output_index: Output index on source (default 0)
+        material_path: Path to the material
+        material_function_path: Path to the MaterialFunction
 
     Returns:
         Success/error message
     """
     params = {
-        "material_path": material_path,
         "source_expression_id": source_expression_id,
         "target_expression_id": target_expression_id,
         "target_input_name": target_input_name,
         "source_output_index": source_output_index
     }
+    if material_path:
+        params["material_path"] = material_path
+    if material_function_path:
+        params["material_function_path"] = material_function_path
 
     return await send_tcp_command("connect_material_expressions", params)
 

--- a/Python/project_tools/project_tools.py
+++ b/Python/project_tools/project_tools.py
@@ -1582,4 +1582,68 @@ def register_project_tools(mcp: FastMCP):
         except Exception as e:
             return {"success": False, "message": f"Error: {e}"}
 
+    @mcp.tool()
+    def set_imc_mapping_settings(
+        ctx: Context,
+        imc_path: str,
+        action_name: str,
+        key: str,
+        mapping_name: str,
+        display_name: str = "",
+        display_category: str = ""
+    ) -> Dict[str, Any]:
+        """
+        Set per-mapping PlayerMappableKeySettings on an IMC key mapping.
+
+        Sets SettingBehavior=OverrideSettings and creates unique PlayerMappableKeySettings
+        per mapping. This enables per-key rebinding for multi-key actions like WASD movement,
+        where each key within the same InputAction needs its own MappingName.
+
+        Args:
+            imc_path: Full path to the InputMappingContext (e.g., "/Game/ThirdPerson/Input/IMC_Default")
+            action_name: Name of the InputAction (e.g., "IA_Move")
+            key: The key bound to this mapping (e.g., "W", "S", "A", "D")
+            mapping_name: Unique mapping identifier (e.g., "MoveForward", "MoveBackward")
+            display_name: Localized name shown in UI (defaults to mapping_name)
+            display_category: Grouping category (e.g., "Movement", "Actions")
+
+        Example:
+            set_imc_mapping_settings(
+                imc_path="/Game/ThirdPerson/Input/IMC_Default",
+                action_name="IA_Move",
+                key="W",
+                mapping_name="MoveForward",
+                display_name="Move Forward",
+                display_category="Movement"
+            )
+        """
+        from utils.unreal_connection_utils import get_unreal_engine_connection as get_unreal_connection
+
+        try:
+            unreal = get_unreal_connection()
+            if not unreal:
+                return {"success": False, "message": "Failed to connect to Unreal Engine"}
+
+            params = {
+                "imc_path": imc_path,
+                "action_name": action_name,
+                "key": key,
+                "mapping_name": mapping_name,
+            }
+            if display_name:
+                params["display_name"] = display_name
+            if display_category:
+                params["display_category"] = display_category
+
+            logger.info(f"Setting per-mapping settings on '{imc_path}' [{action_name}/{key}]: name={mapping_name}")
+            response = unreal.send_command("set_imc_mapping_settings", params)
+
+            if not response:
+                return {"success": False, "message": "No response from Unreal Engine"}
+
+            return response
+
+        except Exception as e:
+            return {"success": False, "message": f"Error: {e}"}
+
     logger.info("Project tools registered successfully")

--- a/Python/utils/editor/editor_operations.py
+++ b/Python/utils/editor/editor_operations.py
@@ -445,3 +445,21 @@ def import_static_mesh(ctx: Context, source_file_path: str, asset_name: str,
     }
     logger.info(f"Importing static mesh '{asset_name}' from '{source_file_path}'")
     return send_unreal_command("import_static_mesh", params)
+
+
+def import_texture(ctx: Context, source_file_path: str, asset_name: str,
+                   folder_path: str = "/Game/Textures",
+                   compression_settings: str = "Default",
+                   srgb: bool = True,
+                   preserve_alpha: bool = True) -> Dict[str, Any]:
+    """Import a texture (PNG, TGA, TIF, JPEG, EXR, HDR, BMP) from disk into the Unreal project."""
+    params = {
+        "source_file_path": source_file_path,
+        "asset_name": asset_name,
+        "folder_path": folder_path,
+        "compression_settings": compression_settings,
+        "srgb": srgb,
+        "preserve_alpha": preserve_alpha
+    }
+    logger.info(f"Importing texture '{asset_name}' from '{source_file_path}'")
+    return send_unreal_command("import_texture", params)

--- a/scripts/GRASS_WORKFLOW_REFERENCE.md
+++ b/scripts/GRASS_WORKFLOW_REFERENCE.md
@@ -5,85 +5,131 @@ Source: Ghislain Girardot — "My workflow to create grass assets for realtime a
 - ArtStation: https://www.artstation.com/artwork/a0RYBR
 - 80.lv interview: https://80.lv/articles/technical-challenges-of-game-environment-production
 
+Transcript extracted via `youtube-transcript-api` Python package (pip install youtube-transcript-api).
+
 ## Core Concept
 
-Instead of drawing grass textures procedurally (PIL/Photoshop), **model 3D grass blades in Blender and render/bake them into a 2D texture**. This gives natural shadows, volume, soft edges — impossible with flat polygon drawing.
+Model 3D grass blades in Blender, arrange into **small clumps** (3-5 blades each), render via orthographic camera to get a texture with multiple separated clumps. Then trace low-poly cards over each clump and arrange cards into the final game asset.
 
-## Workflow Steps
+**CRITICAL: The texture and cards are PAIRED. Each card is traced from a specific clump in the texture. The texture must have small separated clumps with gaps — NOT one continuous wall of grass.**
 
-### 1. Model Individual Grass Blades (Blender)
-- Create a single blade as extruded curve or thin mesh strip
-- Taper from wide base to thin tip
-- Add slight curve/bend for natural look
-- Vary: height, width, curve direction, lean angle
+## Complete Workflow (from video transcript)
 
-### 2. Arrange into Clump
-- Duplicate blade 15-25 times
-- Randomize: rotation, scale, lean, position within a small radius
-- Front-facing arrangement (like a bouquet viewed from the side)
-- Denser at base, sparser at top
-
-### 3. Setup Render
-- Orthographic camera, front-facing
-- Transparent background (RGBA)
-- Simple lighting: key light from above/front for subtle shadows
+### Phase 1: Setup
+- Delete everything, create orthographic camera pointing down
+- Set render resolution (e.g., 1024×512)
+- Color management: View Transform = Raw (no color correction)
 - Film > Transparent = ON
-- Resolution matches target texture (512x512 or 1024x1024)
+- Background color = pure black (no ambient light)
+- Create a canvas plane matching ortho width + aspect ratio (for reference)
 
-### 4. Material on Blades
-- Simple diffuse/emission (grayscale for our pipeline)
-- Gradient: darker at root, lighter at tips
-- No complex PBR needed — we tint in UE material
+### Phase 2: Model High-Poly Blades
+- Create a plane, scale X to make a thin strip
+- Add vertical edge loop (bevel weight = 1.0), add horizontal edge loops
+- Proportional editing to taper tip, adjust curvature
+- Add Bevel modifier (limit by weight, 1 segment)
+- Add Subdivision modifier (2 viewport, 3 render)
+- Add Solidify modifier (slight thickness)
+- Shade smooth
+- Result: one high-poly grass blade base model
 
-### 5. Render to PNG
-- Render with alpha channel
-- Result: natural-looking grass clump texture with real shadows and depth
+### Phase 3: Create PBR Passes via Shader AOVs
+- Create Shader AOVs: albedo, roughness, specular, opacity, normal, random, height, transmission
+- In compositor: file output node with inputs matching each AOV
+- In material: AOV Output nodes for each pass
+- Use UV-based gradients for roughness/specular (center highlight, edge variation)
+- Albedo: color gradients + per-object random value for tint variation
+- Normal: remap world-space normals to 0-1 range, flip green channel
+- Height: use a reference cube with object coordinates for vertical gradient
+- Opacity: constant 1.0
+- Transmission: top-down UV gradient
 
-### 6. Repeat for Variants
-- Rearrange blades, change seed, different blade counts
-- Short grass: shorter blades, more compact
-- Tall grass: taller, more dramatic curves
+### Phase 4: Arrange Clumps on Canvas
+**THIS IS THE KEY STEP WE GOT WRONG**
+- Duplicate blade, enter edit mode, use proportional editing to create variants
+- Arrange blades into **small clumps of 3-5 blades** each
+- **Leave enough room between clumps** — prevents bleeding, allows individual card tracing
+- Multiple small clumps spread across the canvas, NOT one dense wall
+- Render → saves all PBR pass PNGs to disk
 
-## UE Material Principles (from Girardot)
+### Phase 5: Mip-Flood Dilation
+- Problem: alpha-masked textures bleed black background color at distance (mip chain)
+- Solution: mip-flooding (GDC 2019 technique) — dilate textures
+- Alternative: GIMP value propagate filter, or duplicate+blur+merge layers
+- Reapply original alpha channel after flooding
+- Important for all passes, not just albedo
 
-### Normals
-- **Custom normals on grass blades** matching ground normals
-- Seamless integration with terrain
+### Phase 6: Create Low-Poly Cards
+- New scene, import opacity map as Image Mesh Plane
+- Set material to use alpha clip, emission for visualization
+- **In vertex mode, manually trace vertices around each clump silhouette**
+- Create quads (F key) to surface the cards
+- Check face orientation (normals), flip if red
+- Add edge loops for WPO deformation
+- Vertex placement considerations:
+  - Never outside canvas bounds
+  - Leave inner margin within clump
+  - Leave outer margin between clumps
+  - Minimize overdraw (transparent pixels)
+  - Think about vertex animation deformability
+  - Think about volume/bending potential
 
-### Texturing
-- **World projected textures** on both terrain AND grass blades
-- Same albedo/roughness where they clip → no visible seam at ground intersection
+### Phase 7: LODs
+- Create LOD0 (full detail), LOD1 (half verts), LOD2 (single quad or triangle)
+- Use material slots (lod0, lod1, lod2) to tag cards for easy selection later
+- Keep all LODs in same object (important for per-card random value consistency)
 
-### Shading
-- **Gradient root→tip** on albedo (push value at tips)
-- Grass blades **don't cast shadows** (reduces visual noise)
-- Two Sided Foliage shading model
-- Blend Mode: Masked
+### Phase 8: Separate, Rotate, Curve
+- Copy to new scene, separate cards into individual objects
+- Recenter origins, apply location
+- **Rotate 90° on X** (R X 90) — cards stand upright
+- Apply rotation
+- Use proportional editing to apply curvature:
+  - Side view: bend tips slightly (sharp falloff)
+  - Top view: gentle lateral bend
+- Goal: each card has slight 3D volume, not perfectly flat
 
-### WPO Animation
-- Bend, clump, tilt, wind effects via World Position Offset
-- Vertex color R channel = root-to-tip gradient for WPO intensity
-- Vertex color G channel = per-blade/per-clump phase offset
+### Phase 9: Arrange Final Asset
+- Create linked duplicate of collection
+- Duplicate cards (Alt+D) 1-2 times per card
+- Randomize transform to spread apart
+- Manually fine-tune spacing, silhouette from all angles
+- Ensure decent coverage and volume from any viewing direction
+- This is the final game asset
 
-### Performance
-- LODs (at least 2)
-- Instanced rendering
-- Landscape masking (hide grass under dirt blend via WPO push below ground)
+### Phase 10: Bake & Export
+- Bake pivot data (for shader tricks)
+- Bake per-card random value in UVs (for wind phase offset, tint variation)
+- Use material selection to isolate LODs
+- Export each LOD separately as FBX
+- Import to UE, set up LOD distances
+
+## UE Material (from video)
+- Albedo × top-down projected noise × per-instance/per-card random for color variation
+- Roughness/specular lerped towards constants at distance (mip map tricks)
+- Opacity with shadow pass switch, tip desaturation, fake light bleed
+- Normal map: tangent-space normals used AS world-space (hack but effective)
+- Subsurface scattering
+- Wind animation via spherical reprojection material function
+- Pixel depth offset at close distance (disabled at far distance)
+- LOD2 (far distance): much cheaper shader — constant roughness/specular/normals, no WPO, no PDO
 
 ## Our Pipeline Adaptation
 
 Since we use grayscale + alpha textures (colorized in UE material):
 1. Blender blades use simple white/gray material with root-to-tip gradient
-2. Render to grayscale + alpha PNG
-3. Each grass mesh variant gets its own baked texture
-4. UE material: tint with Wabi-Kawa palette (Sage #8BA888 / Green #86B97E)
+2. Arrange into **small separated clumps** (3-5 blades each) on canvas
+3. Render to grayscale + alpha PNG — multiple clumps visible with gaps
+4. Trace individual cards per clump
+5. Arrange cards into final grass asset
+6. UE material: tint with Wabi-Kawa palette (Sage #8BA888 / Green #86B97E)
 
-## Key Differences from Our Old Approach
+## Lessons Learned (2026-03-14)
 
-| Old (PIL drawing) | New (Blender bake) |
-|---|---|
-| Flat polygon shapes | 3D rendered with real shadows |
-| Sharp geometric edges | Soft natural edges from AA |
-| No depth/volume | Subtle self-shadowing |
-| Uniform brightness | Natural light variation |
-| Looks "procedural" | Looks "artistic" |
+| What went wrong | Why | Correct approach |
+|---|---|---|
+| 75 blades packed edge-to-edge as one wall | Misunderstood "arrange into clump" as one big mass | Small clumps of 3-5 blades with gaps between them |
+| One card covering entire texture | No distinct groups to trace | Individual cards per small clump |
+| 1,440 tris per grass asset (37×5 grid) | Over-tessellated to match silhouette | ~160 tris target (8×3 grid per card, 5 cards) |
+| Cross-plane meshes (SM_Grass_*) unrelated to textures | Created meshes and textures independently | Texture and card are paired — card traced FROM texture |
+| FBX scale issues | global_scale=100 + apply_unit_scale=True = double scale | Use global_scale=1.0 with apply_unit_scale=True |


### PR DESCRIPTION
…th support

New MCP tools:
- create_material_function: creates UMaterialFunction assets
- create_material_parameter_collection: creates MPC with scalar/vector params
- add_material_expression: now accepts material_function_path for MaterialFunctions
- connect_material_expressions: now accepts material_function_path
- import_texture: new editor command (C++ + Python)
- set_imc_mapping_settings: IMC mapping SettingBehavior override

MaterialFunction support:
- FMaterialExpressionCreationParams/ConnectionParams: added MaterialFunctionPath field
- MaterialFunctionExpressionCreation.cpp: AddExpressionToFunction using UMaterialEditingLibrary
- Handles FunctionInput/FunctionOutput with InputName, InputType, SortPriority
- FindExpressionInFunction for GUID lookup in function expression collection

Other changes:
- Removed StructUtils plugin dependency (.uplugin) — deprecated in UE 5.5
- Updated GRASS_WORKFLOW_REFERENCE.md with Girardot method details