### PR TITLE
feat(mesh): new Mesh MCP server — LOD management, metadata, auto-gene…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -487,6 +487,7 @@ UNREAL_PORT = 55557
 | `project_mcp_server.py` | Folders, input mappings, structs, enums | `Commands/Project/` |
 | `blueprint_action_mcp_server.py` | Action discovery, node creation, pin inspection | `Commands/BlueprintAction/` |
 | `statetree_mcp_server.py` | StateTree creation, states, transitions, tasks, conditions, evaluators, bindings | `Commands/StateTree/` |
+| `mesh_mcp_server.py` | Static Mesh LOD management, metadata, auto-generation, screen sizes | `Commands/Mesh/` |
 
 **These `*_mcp_server.py` files contain the `@app.tool()` decorated functions that Claude/AI assistants actually call.**
 

--- a/Docs/agents/research/static-mesh-lod-api.md
+++ b/Docs/agents/research/static-mesh-lod-api.md
@@ -1,0 +1,280 @@
+# Research: StaticMesh LOD API (UE 5.7)
+
+## Summary
+
+UE 5.7 provides comprehensive LOD management through `UStaticMesh` directly and the `UStaticMeshEditorSubsystem` (editor scripting). Key APIs: `SetNumSourceModels()` for LOD count, `FbxMeshUtils::ImportStaticMeshLOD()` for FBX LOD import, `FStaticMeshRenderData::ScreenSize[]` for transition thresholds, and `FMeshReductionSettings` for auto-reduction. The `UStaticMeshEditorSubsystem` wraps all of this with validated, script-friendly methods.
+
+## 1. Get Mesh Metadata
+
+### LOD Count
+```cpp
+#include "Engine/StaticMesh.h"
+
+UStaticMesh* Mesh = ...;
+int32 NumSourceModels = Mesh->GetNumSourceModels();  // Source/editable LOD count
+int32 NumRenderLODs = Mesh->GetNumLODs();             // Render data LOD count (after build)
+```
+
+### Verts/Tris Per LOD
+```cpp
+// Per-LOD stats (from render data)
+for (int32 LODIdx = 0; LODIdx < Mesh->GetNumLODs(); ++LODIdx)
+{
+    int32 Verts = Mesh->GetNumVertices(LODIdx);    // BlueprintPure
+    int32 Tris = Mesh->GetNumTriangles(LODIdx);     // BlueprintPure
+    int32 TexCoords = Mesh->GetNumTexCoords(LODIdx);
+    int32 Sections = Mesh->GetNumSections(LODIdx);
+}
+
+// Direct LODResources access (what our ImportStaticMesh already uses)
+if (Mesh->GetRenderData() && Mesh->GetRenderData()->LODResources.Num() > 0)
+{
+    const FStaticMeshLODResources& LOD0 = Mesh->GetRenderData()->LODResources[0];
+    int32 Verts = LOD0.GetNumVertices();
+    int32 Tris = LOD0.GetNumTriangles();
+}
+```
+
+### Bounds
+```cpp
+FBoxSphereBounds Bounds = Mesh->GetBounds();    // BlueprintPure
+FBox BBox = Mesh->GetBoundingBox();              // BlueprintPure, includes bounds extension
+```
+
+### Material Slots
+```cpp
+const TArray<FStaticMaterial>& Materials = Mesh->GetStaticMaterials();
+int32 NumMats = Materials.Num();
+UMaterialInterface* Mat = Mesh->GetMaterial(MaterialIndex); // BlueprintPure
+```
+
+### Screen Sizes
+```cpp
+// From RenderData
+FStaticMeshRenderData* RenderData = Mesh->GetRenderData();
+for (int32 i = 0; i < Mesh->GetNumLODs(); ++i)
+{
+    float ScreenSize = RenderData->ScreenSize[i].Default;
+}
+
+// From SourceModel
+for (int32 i = 0; i < Mesh->GetNumSourceModels(); ++i)
+{
+    float ScreenSize = Mesh->GetSourceModel(i).ScreenSize.Default;
+}
+
+// Or via subsystem
+UStaticMeshEditorSubsystem* Subsystem = GEditor->GetEditorSubsystem<UStaticMeshEditorSubsystem>();
+TArray<float> ScreenSizes = Subsystem->GetLodScreenSizes(Mesh);
+```
+
+### LOD Group
+```cpp
+FName LODGroup = Mesh->GetLODGroup();
+bool bAutoScreenSize = Mesh->GetAutoComputeLODScreenSize();
+```
+
+## 2. Set LOD Count
+
+```cpp
+// Set exact number of source models (LODs)
+Mesh->SetNumSourceModels(3);  // Now has LOD 0, 1, 2
+
+// Add a single new LOD
+FStaticMeshSourceModel& NewModel = Mesh->AddSourceModel();
+
+// Remove a specific LOD
+Mesh->RemoveSourceModel(2);  // Remove LOD 2
+
+// Access source model for config
+FStaticMeshSourceModel& SrcModel = Mesh->GetSourceModel(LODIndex);
+SrcModel.BuildSettings = ...;
+SrcModel.ReductionSettings = ...;
+SrcModel.ScreenSize = 0.5f;
+
+// MAX_STATIC_MESH_LODS = 8
+```
+
+## 3. Import Mesh Into LOD Slot
+
+### Method A: FbxMeshUtils (direct, used by the engine)
+```cpp
+#include "FbxMeshUtils.h"
+
+// Import FBX file as a specific LOD level
+bool bSuccess = FbxMeshUtils::ImportStaticMeshLOD(
+    BaseStaticMesh,    // UStaticMesh* - target mesh
+    Filename,          // const FString& - FBX file path
+    LODLevel,          // int32 - which LOD slot (0-based)
+    false              // bool bAsync - false for synchronous
+);
+```
+
+### Method B: UStaticMeshEditorSubsystem (recommended for scripting)
+```cpp
+#include "StaticMeshEditorSubsystem.h"
+
+UStaticMeshEditorSubsystem* Subsystem = GEditor->GetEditorSubsystem<UStaticMeshEditorSubsystem>();
+
+// Import or re-import a LOD from FBX file
+// LODIndex can be == NumSourceModels to add a new LOD
+// Returns LODIndex on success, INDEX_NONE on failure
+int32 Result = Subsystem->ImportLOD(BaseStaticMesh, LODIndex, SourceFilename);
+```
+
+### Method C: SetCustomLOD (copy from another mesh)
+```cpp
+// Copy LOD data from another static mesh
+bool bSuccess = DestMesh->SetCustomLOD(SourceStaticMesh, LodIndex, SourceDataFilename);
+```
+
+### Method D: SetLodFromStaticMesh (subsystem, mesh-to-mesh)
+```cpp
+// Copy LOD from one mesh to another
+int32 Result = Subsystem->SetLodFromStaticMesh(
+    DestinationStaticMesh, DestinationLodIndex,
+    SourceStaticMesh, SourceLodIndex,
+    bReuseExistingMaterialSlots
+);
+```
+
+### Note on ImportStaticMeshLOD internals:
+In UE 5.7, `ImportStaticMeshLOD` first tries Interchange (`UInterchangeMeshUtilities::ImportCustomLod`), and falls back to legacy FBX importer if Interchange can't handle it. The Interchange path is async-capable.
+
+## 4. Set LOD Screen Sizes
+
+### Direct approach
+```cpp
+Mesh->SetAutoComputeLODScreenSize(false);  // Disable auto-compute first
+
+FStaticMeshRenderData* RenderData = Mesh->GetRenderData();
+RenderData->ScreenSize[0].Default = 1.0f;   // LOD 0 always visible
+RenderData->ScreenSize[1].Default = 0.5f;   // LOD 1 at 50% screen
+RenderData->ScreenSize[2].Default = 0.25f;  // LOD 2 at 25% screen
+
+// Also set on source models for persistence
+Mesh->GetSourceModel(0).ScreenSize = 1.0f;
+Mesh->GetSourceModel(1).ScreenSize = 0.5f;
+Mesh->GetSourceModel(2).ScreenSize = 0.25f;
+```
+
+### Via subsystem (recommended - handles validation/monotonic clamping)
+```cpp
+UStaticMeshEditorSubsystem* Subsystem = GEditor->GetEditorSubsystem<UStaticMeshEditorSubsystem>();
+
+TArray<float> ScreenSizes = { 1.0f, 0.5f, 0.25f };
+bool bSuccess = Subsystem->SetLodScreenSizes(Mesh, ScreenSizes);
+// Automatically:
+// - Disables bAutoComputeLODScreenSize
+// - Clamps values to be monotonically decreasing (delta 0.0001f)
+// - Sets both RenderData->ScreenSize[i] and SourceModel.ScreenSize
+```
+
+## 5. Auto LOD Reduction
+
+### Via UStaticMeshEditorSubsystem::SetLods (simplest)
+```cpp
+#include "StaticMeshEditorSubsystem.h"
+#include "StaticMeshEditorSubsystemHelpers.h"
+
+UStaticMeshEditorSubsystem* Subsystem = GEditor->GetEditorSubsystem<UStaticMeshEditorSubsystem>();
+
+FStaticMeshReductionOptions Options;
+Options.bAutoComputeLODScreenSize = true;
+
+// Each entry = one LOD (LOD 0 is original, LOD 1+ are reduced)
+Options.ReductionSettings.Add({ 1.0f, 1.0f });    // LOD 0: 100% tris, screen 1.0
+Options.ReductionSettings.Add({ 0.5f, 0.5f });    // LOD 1: 50% tris, screen 0.5
+Options.ReductionSettings.Add({ 0.25f, 0.25f });  // LOD 2: 25% tris, screen 0.25
+
+int32 NumLODs = Subsystem->SetLods(Mesh, Options);  // Returns num LODs created
+// Internally: resets to LOD 0, adds source models, sets ReductionSettings, calls PostEditChange()
+```
+
+### Per-LOD reduction settings (fine-grained)
+```cpp
+FStaticMeshSourceModel& SrcModel = Mesh->GetSourceModel(LODIndex);
+SrcModel.ReductionSettings.PercentTriangles = 0.5f;      // 50% triangles
+SrcModel.ReductionSettings.PercentVertices = 1.0f;        // No vertex limit
+SrcModel.ReductionSettings.MaxDeviation = 0.0f;           // Max distance deviation
+SrcModel.ReductionSettings.PixelError = 8.0f;             // Pixel error allowance
+SrcModel.ReductionSettings.WeldingThreshold = 0.0f;
+SrcModel.ReductionSettings.HardAngleThreshold = 45.0f;
+SrcModel.ReductionSettings.BaseLODModel = 0;               // Reduce from LOD 0
+SrcModel.ReductionSettings.SilhouetteImportance = EMeshFeatureImportance::Normal;
+SrcModel.ReductionSettings.TextureImportance = EMeshFeatureImportance::Normal;
+SrcModel.ReductionSettings.ShadingImportance = EMeshFeatureImportance::Normal;
+SrcModel.ReductionSettings.TerminationCriterion = EStaticMeshReductionTerimationCriterion::Triangles;
+
+// Or via subsystem
+Subsystem->SetLodReductionSettings(Mesh, LODIndex, ReductionSettings);
+Subsystem->GetLodReductionSettings(Mesh, LODIndex, OutReductionSettings);
+```
+
+## 6. Rebuild Mesh After Modifications
+
+```cpp
+// Full rebuild (triggers mesh compilation, may be async)
+Mesh->Build(/*bSilent=*/true);
+
+// Notify of property changes (triggers rebuild + UI refresh)
+Mesh->PostEditChange();
+
+// Mark for save
+Mesh->MarkPackageDirty();
+
+// IMPORTANT from our existing code: Build() can trigger TaskGraph recursion
+// when called from MCP thread. PostEditChange() is safer as it handles async.
+// Or use the subsystem methods which handle this internally.
+
+// Batch build for multiple meshes
+TArray<UStaticMesh*> Meshes = { Mesh1, Mesh2 };
+UStaticMesh::BatchBuild(Meshes, /*bSilent=*/true);
+```
+
+## 7. Module Dependencies for Build.cs
+
+Current `UnrealMCP.Build.cs` already has:
+- `UnrealEd` (has `FbxMeshUtils`, `FbxFactory`)
+- `Engine` (has `UStaticMesh`)
+- `AssetTools`, `AssetRegistry`
+
+**Needed additions:**
+```csharp
+// In the bBuildEditor block:
+"StaticMeshEditor",    // UStaticMeshEditorSubsystem, FStaticMeshReductionOptions
+```
+
+**Headers needed:**
+```cpp
+#include "Engine/StaticMesh.h"                    // UStaticMesh (already used)
+#include "StaticMeshResources.h"                  // FStaticMeshRenderData, FStaticMeshLODResources
+#include "StaticMeshEditorSubsystem.h"            // UStaticMeshEditorSubsystem
+#include "StaticMeshEditorSubsystemHelpers.h"     // FStaticMeshReductionOptions
+#include "FbxMeshUtils.h"                         // FbxMeshUtils::ImportStaticMeshLOD
+#include "MeshReductionSettings.h"                // FMeshReductionSettings
+```
+
+## Key Constants
+
+```cpp
+#define MAX_STATIC_MESH_LODS 8  // Maximum LOD levels allowed
+```
+
+## Thread Safety Warning
+
+From our existing `ImportStaticMeshCommand.cpp` (line 119):
+> Don't call Build() here -- it triggers TaskGraph recursion when called from MCP thread.
+
+For LOD operations, prefer using `UStaticMeshEditorSubsystem` methods which internally handle `PostEditChange()` correctly. If calling directly, wrap in `AsyncTask(ENamedThreads::GameThread, [=]{ ... })` or use the `ExecuteOnGameThread` pattern our plugin already uses.
+
+## Reference Files
+
+- UE Source: `Engine/Source/Runtime/Engine/Classes/Engine/StaticMesh.h` (lines 1939-2155)
+- UE Source: `Engine/Source/Runtime/Engine/Classes/Engine/StaticMeshSourceData.h` (FStaticMeshSourceModel)
+- UE Source: `Engine/Source/Runtime/Engine/Public/StaticMeshResources.h` (FStaticMeshRenderData, line 773+)
+- UE Source: `Engine/Source/Runtime/Engine/Public/MeshReductionSettings.h` (FMeshReductionSettings)
+- UE Source: `Engine/Source/Editor/StaticMeshEditor/Public/StaticMeshEditorSubsystem.h` (full scripting API)
+- UE Source: `Engine/Source/Editor/StaticMeshEditor/Public/StaticMeshEditorSubsystemHelpers.h` (FStaticMeshReductionOptions)
+- UE Source: `Engine/Source/Editor/UnrealEd/Public/FbxMeshUtils.h` (ImportStaticMeshLOD)
+- Project: `MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Editor/ImportStaticMeshCommand.cpp`

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Mesh/AutoGenerateLodsCommand.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Mesh/AutoGenerateLodsCommand.cpp
@@ -1,0 +1,126 @@
+#include "Commands/Mesh/AutoGenerateLodsCommand.h"
+#include "Dom/JsonObject.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonWriter.h"
+#include "Engine/StaticMesh.h"
+#include "StaticMeshEditorSubsystem.h"
+#include "UObject/SavePackage.h"
+
+FString FAutoGenerateLodsCommand::Execute(const FString& Parameters)
+{
+	TSharedPtr<FJsonObject> JsonObject;
+	TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Parameters);
+	if (!FJsonSerializer::Deserialize(Reader, JsonObject) || !JsonObject.IsValid())
+	{
+		TSharedPtr<FJsonObject> E = MakeShared<FJsonObject>(); E->SetBoolField(TEXT("success"), false);
+		E->SetStringField(TEXT("error"), TEXT("Invalid JSON"));
+		FString O; TSharedRef<TJsonWriter<>> W = TJsonWriterFactory<>::Create(&O);
+		FJsonSerializer::Serialize(E.ToSharedRef(), W); return O;
+	}
+
+	FString MeshPath;
+	int32 TargetLodCount = 3;
+	JsonObject->TryGetStringField(TEXT("mesh_path"), MeshPath);
+	JsonObject->TryGetNumberField(TEXT("target_lod_count"), TargetLodCount);
+
+	if (MeshPath.IsEmpty())
+	{
+		TSharedPtr<FJsonObject> E = MakeShared<FJsonObject>(); E->SetBoolField(TEXT("success"), false);
+		E->SetStringField(TEXT("error"), TEXT("Missing mesh_path"));
+		FString O; TSharedRef<TJsonWriter<>> W = TJsonWriterFactory<>::Create(&O);
+		FJsonSerializer::Serialize(E.ToSharedRef(), W); return O;
+	}
+
+	UStaticMesh* Mesh = LoadObject<UStaticMesh>(nullptr, *MeshPath);
+	if (!Mesh)
+	{
+		TSharedPtr<FJsonObject> E = MakeShared<FJsonObject>(); E->SetBoolField(TEXT("success"), false);
+		E->SetStringField(TEXT("error"), FString::Printf(TEXT("Mesh not found: %s"), *MeshPath));
+		FString O; TSharedRef<TJsonWriter<>> W = TJsonWriterFactory<>::Create(&O);
+		FJsonSerializer::Serialize(E.ToSharedRef(), W); return O;
+	}
+
+	// Parse reduction percentages or generate defaults
+	TArray<float> ReductionPercentages;
+	const TArray<TSharedPtr<FJsonValue>>* RedArray;
+	if (JsonObject->TryGetArrayField(TEXT("reduction_percentages"), RedArray))
+	{
+		for (const auto& Val : *RedArray)
+		{
+			ReductionPercentages.Add((float)Val->AsNumber());
+		}
+	}
+	else
+	{
+		// Default: evenly distributed
+		for (int32 i = 0; i < TargetLodCount; ++i)
+		{
+			float Pct = 1.0f - ((float)i / (float)TargetLodCount);
+			ReductionPercentages.Add(FMath::Max(0.05f, Pct));
+		}
+	}
+
+	// Build reduction options
+	UStaticMeshEditorSubsystem* Subsystem = GEditor->GetEditorSubsystem<UStaticMeshEditorSubsystem>();
+	if (!Subsystem)
+	{
+		TSharedPtr<FJsonObject> E = MakeShared<FJsonObject>(); E->SetBoolField(TEXT("success"), false);
+		E->SetStringField(TEXT("error"), TEXT("StaticMeshEditorSubsystem not available"));
+		FString O; TSharedRef<TJsonWriter<>> W = TJsonWriterFactory<>::Create(&O);
+		FJsonSerializer::Serialize(E.ToSharedRef(), W); return O;
+	}
+
+	// Use SetLods with reduction options
+	FStaticMeshReductionOptions Options;
+	Options.bAutoComputeLODScreenSize = true;
+
+	for (int32 i = 0; i < TargetLodCount; ++i)
+	{
+		FStaticMeshReductionSettings Settings;
+		Settings.PercentTriangles = (i < ReductionPercentages.Num()) ? ReductionPercentages[i] : 0.5f;
+		Settings.ScreenSize = 1.0f - ((float)i / (float)TargetLodCount);
+		Options.ReductionSettings.Add(Settings);
+	}
+
+	Subsystem->SetLods(Mesh, Options);
+
+	// Save
+	Mesh->MarkPackageDirty();
+	UPackage* Package = Mesh->GetOutermost();
+	FString Filename = FPackageName::LongPackageNameToFilename(Package->GetName(), FPackageName::GetAssetPackageExtension());
+	FSavePackageArgs SaveArgs; SaveArgs.TopLevelFlags = RF_Public | RF_Standalone;
+	UPackage::SavePackage(Package, Mesh, *Filename, SaveArgs);
+
+	// Build result with per-LOD stats
+	TArray<TSharedPtr<FJsonValue>> LodArray;
+	for (int32 i = 0; i < Mesh->GetNumLODs(); ++i)
+	{
+		TSharedPtr<FJsonObject> LodObj = MakeShared<FJsonObject>();
+		LodObj->SetNumberField(TEXT("index"), i);
+		LodObj->SetNumberField(TEXT("vertices"), Mesh->GetNumVertices(i));
+		LodObj->SetNumberField(TEXT("triangles"), Mesh->GetNumTriangles(i));
+		LodArray.Add(MakeShared<FJsonValueObject>(LodObj));
+	}
+
+	UE_LOG(LogTemp, Log, TEXT("Auto-generated %d LODs for %s"), Mesh->GetNumLODs(), *MeshPath);
+
+	TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetNumberField(TEXT("lod_count"), Mesh->GetNumLODs());
+	Result->SetArrayField(TEXT("lods"), LodArray);
+	Result->SetStringField(TEXT("message"), FString::Printf(
+		TEXT("Generated %d LODs for %s"), Mesh->GetNumLODs(), *MeshPath));
+
+	FString OutputString;
+	TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&OutputString);
+	FJsonSerializer::Serialize(Result.ToSharedRef(), Writer);
+	return OutputString;
+}
+
+FString FAutoGenerateLodsCommand::GetCommandName() const { return TEXT("auto_generate_lods"); }
+bool FAutoGenerateLodsCommand::ValidateParams(const FString& Parameters) const
+{
+	TSharedPtr<FJsonObject> J; TSharedRef<TJsonReader<>> R = TJsonReaderFactory<>::Create(Parameters);
+	if (!FJsonSerializer::Deserialize(R, J)) return false;
+	FString P; return J->TryGetStringField(TEXT("mesh_path"), P);
+}

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Mesh/GetStaticMeshMetadataCommand.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Mesh/GetStaticMeshMetadataCommand.cpp
@@ -1,0 +1,109 @@
+#include "Commands/Mesh/GetStaticMeshMetadataCommand.h"
+#include "Dom/JsonObject.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonWriter.h"
+#include "Engine/StaticMesh.h"
+#include "StaticMeshEditorSubsystem.h"
+
+FString FGetStaticMeshMetadataCommand::Execute(const FString& Parameters)
+{
+	TSharedPtr<FJsonObject> JsonObject;
+	TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Parameters);
+	if (!FJsonSerializer::Deserialize(Reader, JsonObject) || !JsonObject.IsValid())
+	{
+		TSharedPtr<FJsonObject> Err = MakeShared<FJsonObject>();
+		Err->SetBoolField(TEXT("success"), false);
+		Err->SetStringField(TEXT("error"), TEXT("Invalid JSON"));
+		FString Out; TSharedRef<TJsonWriter<>> W = TJsonWriterFactory<>::Create(&Out);
+		FJsonSerializer::Serialize(Err.ToSharedRef(), W); return Out;
+	}
+
+	FString MeshPath;
+	if (!JsonObject->TryGetStringField(TEXT("mesh_path"), MeshPath))
+	{
+		TSharedPtr<FJsonObject> Err = MakeShared<FJsonObject>();
+		Err->SetBoolField(TEXT("success"), false);
+		Err->SetStringField(TEXT("error"), TEXT("Missing 'mesh_path'"));
+		FString Out; TSharedRef<TJsonWriter<>> W = TJsonWriterFactory<>::Create(&Out);
+		FJsonSerializer::Serialize(Err.ToSharedRef(), W); return Out;
+	}
+
+	UStaticMesh* Mesh = LoadObject<UStaticMesh>(nullptr, *MeshPath);
+	if (!Mesh)
+	{
+		TSharedPtr<FJsonObject> Err = MakeShared<FJsonObject>();
+		Err->SetBoolField(TEXT("success"), false);
+		Err->SetStringField(TEXT("error"), FString::Printf(TEXT("StaticMesh not found: %s"), *MeshPath));
+		FString Out; TSharedRef<TJsonWriter<>> W = TJsonWriterFactory<>::Create(&Out);
+		FJsonSerializer::Serialize(Err.ToSharedRef(), W); return Out;
+	}
+
+	TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("mesh_path"), MeshPath);
+
+	// LOD info
+	int32 NumLODs = Mesh->GetNumLODs();
+	Result->SetNumberField(TEXT("lod_count"), NumLODs);
+
+	TArray<TSharedPtr<FJsonValue>> LodArray;
+	for (int32 i = 0; i < NumLODs; ++i)
+	{
+		TSharedPtr<FJsonObject> LodObj = MakeShared<FJsonObject>();
+		LodObj->SetNumberField(TEXT("index"), i);
+		LodObj->SetNumberField(TEXT("vertices"), Mesh->GetNumVertices(i));
+		LodObj->SetNumberField(TEXT("triangles"), Mesh->GetNumTriangles(i));
+
+		// Screen size (fixed array of MAX_STATIC_MESH_LODS=8)
+		if (Mesh->GetRenderData() && i < MAX_STATIC_MESH_LODS)
+		{
+			LodObj->SetNumberField(TEXT("screen_size"), Mesh->GetRenderData()->ScreenSize[i].Default);
+		}
+
+		LodArray.Add(MakeShared<FJsonValueObject>(LodObj));
+	}
+	Result->SetArrayField(TEXT("lods"), LodArray);
+
+	// Source models count
+	Result->SetNumberField(TEXT("source_model_count"), Mesh->GetNumSourceModels());
+
+	// Bounds
+	FBoxSphereBounds Bounds = Mesh->GetBounds();
+	TSharedPtr<FJsonObject> BoundsObj = MakeShared<FJsonObject>();
+	BoundsObj->SetNumberField(TEXT("origin_x"), Bounds.Origin.X);
+	BoundsObj->SetNumberField(TEXT("origin_y"), Bounds.Origin.Y);
+	BoundsObj->SetNumberField(TEXT("origin_z"), Bounds.Origin.Z);
+	BoundsObj->SetNumberField(TEXT("extent_x"), Bounds.BoxExtent.X);
+	BoundsObj->SetNumberField(TEXT("extent_y"), Bounds.BoxExtent.Y);
+	BoundsObj->SetNumberField(TEXT("extent_z"), Bounds.BoxExtent.Z);
+	BoundsObj->SetNumberField(TEXT("sphere_radius"), Bounds.SphereRadius);
+	Result->SetObjectField(TEXT("bounds"), BoundsObj);
+
+	// Material slots
+	TArray<TSharedPtr<FJsonValue>> MatArray;
+	for (const FStaticMaterial& Mat : Mesh->GetStaticMaterials())
+	{
+		TSharedPtr<FJsonObject> MatObj = MakeShared<FJsonObject>();
+		MatObj->SetStringField(TEXT("slot_name"), Mat.MaterialSlotName.ToString());
+		MatObj->SetStringField(TEXT("material"), Mat.MaterialInterface ? Mat.MaterialInterface->GetPathName() : TEXT("None"));
+		MatArray.Add(MakeShared<FJsonValueObject>(MatObj));
+	}
+	Result->SetArrayField(TEXT("material_slots"), MatArray);
+
+	Result->SetStringField(TEXT("message"), FString::Printf(
+		TEXT("StaticMesh %s: %d LODs, LOD0=%d verts/%d tris"),
+		*MeshPath, NumLODs, Mesh->GetNumVertices(0), Mesh->GetNumTriangles(0)));
+
+	FString OutputString;
+	TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&OutputString);
+	FJsonSerializer::Serialize(Result.ToSharedRef(), Writer);
+	return OutputString;
+}
+
+FString FGetStaticMeshMetadataCommand::GetCommandName() const { return TEXT("get_static_mesh_metadata"); }
+bool FGetStaticMeshMetadataCommand::ValidateParams(const FString& Parameters) const
+{
+	TSharedPtr<FJsonObject> J; TSharedRef<TJsonReader<>> R = TJsonReaderFactory<>::Create(Parameters);
+	if (!FJsonSerializer::Deserialize(R, J)) return false;
+	FString P; return J->TryGetStringField(TEXT("mesh_path"), P);
+}

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Mesh/ImportLodCommand.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Mesh/ImportLodCommand.cpp
@@ -1,0 +1,105 @@
+#include "Commands/Mesh/ImportLodCommand.h"
+#include "Dom/JsonObject.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonWriter.h"
+#include "Engine/StaticMesh.h"
+#include "StaticMeshEditorSubsystem.h"
+#include "UObject/SavePackage.h"
+
+FString FImportLodCommand::Execute(const FString& Parameters)
+{
+	TSharedPtr<FJsonObject> JsonObject;
+	TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Parameters);
+	if (!FJsonSerializer::Deserialize(Reader, JsonObject) || !JsonObject.IsValid())
+	{
+		TSharedPtr<FJsonObject> E = MakeShared<FJsonObject>(); E->SetBoolField(TEXT("success"), false);
+		E->SetStringField(TEXT("error"), TEXT("Invalid JSON"));
+		FString O; TSharedRef<TJsonWriter<>> W = TJsonWriterFactory<>::Create(&O);
+		FJsonSerializer::Serialize(E.ToSharedRef(), W); return O;
+	}
+
+	FString MeshPath, SourceFilePath;
+	int32 LodIndex = 0;
+	JsonObject->TryGetStringField(TEXT("mesh_path"), MeshPath);
+	JsonObject->TryGetNumberField(TEXT("lod_index"), LodIndex);
+	JsonObject->TryGetStringField(TEXT("source_file_path"), SourceFilePath);
+
+	if (MeshPath.IsEmpty() || SourceFilePath.IsEmpty())
+	{
+		TSharedPtr<FJsonObject> E = MakeShared<FJsonObject>(); E->SetBoolField(TEXT("success"), false);
+		E->SetStringField(TEXT("error"), TEXT("Missing mesh_path or source_file_path"));
+		FString O; TSharedRef<TJsonWriter<>> W = TJsonWriterFactory<>::Create(&O);
+		FJsonSerializer::Serialize(E.ToSharedRef(), W); return O;
+	}
+
+	UStaticMesh* Mesh = LoadObject<UStaticMesh>(nullptr, *MeshPath);
+	if (!Mesh)
+	{
+		TSharedPtr<FJsonObject> E = MakeShared<FJsonObject>(); E->SetBoolField(TEXT("success"), false);
+		E->SetStringField(TEXT("error"), FString::Printf(TEXT("Mesh not found: %s"), *MeshPath));
+		FString O; TSharedRef<TJsonWriter<>> W = TJsonWriterFactory<>::Create(&O);
+		FJsonSerializer::Serialize(E.ToSharedRef(), W); return O;
+	}
+
+	// Ensure LOD slot exists
+	if (LodIndex >= Mesh->GetNumSourceModels())
+	{
+		Mesh->SetNumSourceModels(LodIndex + 1);
+	}
+
+	// Use UStaticMeshEditorSubsystem to import LOD
+	UStaticMeshEditorSubsystem* Subsystem = GEditor->GetEditorSubsystem<UStaticMeshEditorSubsystem>();
+	if (!Subsystem)
+	{
+		TSharedPtr<FJsonObject> E = MakeShared<FJsonObject>(); E->SetBoolField(TEXT("success"), false);
+		E->SetStringField(TEXT("error"), TEXT("StaticMeshEditorSubsystem not available"));
+		FString O; TSharedRef<TJsonWriter<>> W = TJsonWriterFactory<>::Create(&O);
+		FJsonSerializer::Serialize(E.ToSharedRef(), W); return O;
+	}
+
+	int32 ResultLOD = Subsystem->ImportLOD(Mesh, LodIndex, SourceFilePath);
+
+	if (ResultLOD < 0)
+	{
+		TSharedPtr<FJsonObject> E = MakeShared<FJsonObject>(); E->SetBoolField(TEXT("success"), false);
+		E->SetStringField(TEXT("error"), FString::Printf(TEXT("Failed to import LOD %d from %s"), LodIndex, *SourceFilePath));
+		FString O; TSharedRef<TJsonWriter<>> W = TJsonWriterFactory<>::Create(&O);
+		FJsonSerializer::Serialize(E.ToSharedRef(), W); return O;
+	}
+
+	// Save
+	Mesh->MarkPackageDirty();
+	UPackage* Package = Mesh->GetOutermost();
+	FString Filename = FPackageName::LongPackageNameToFilename(Package->GetName(), FPackageName::GetAssetPackageExtension());
+	FSavePackageArgs SaveArgs; SaveArgs.TopLevelFlags = RF_Public | RF_Standalone;
+	UPackage::SavePackage(Package, Mesh, *Filename, SaveArgs);
+
+	// Get stats for imported LOD
+	int32 Verts = Mesh->GetNumVertices(LodIndex);
+	int32 Tris = Mesh->GetNumTriangles(LodIndex);
+
+	UE_LOG(LogTemp, Log, TEXT("Imported LOD%d for %s from %s (%d verts, %d tris)"),
+		LodIndex, *MeshPath, *SourceFilePath, Verts, Tris);
+
+	TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetNumberField(TEXT("lod_index"), ResultLOD);
+	Result->SetNumberField(TEXT("vertices"), Verts);
+	Result->SetNumberField(TEXT("triangles"), Tris);
+	Result->SetNumberField(TEXT("total_lods"), Mesh->GetNumLODs());
+	Result->SetStringField(TEXT("message"), FString::Printf(
+		TEXT("Imported LOD%d: %d verts, %d tris. Total LODs: %d"), ResultLOD, Verts, Tris, Mesh->GetNumLODs()));
+
+	FString OutputString;
+	TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&OutputString);
+	FJsonSerializer::Serialize(Result.ToSharedRef(), Writer);
+	return OutputString;
+}
+
+FString FImportLodCommand::GetCommandName() const { return TEXT("import_lod"); }
+bool FImportLodCommand::ValidateParams(const FString& Parameters) const
+{
+	TSharedPtr<FJsonObject> J; TSharedRef<TJsonReader<>> R = TJsonReaderFactory<>::Create(Parameters);
+	if (!FJsonSerializer::Deserialize(R, J)) return false;
+	FString P1, P2; return J->TryGetStringField(TEXT("mesh_path"), P1) && J->TryGetStringField(TEXT("source_file_path"), P2);
+}

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Mesh/SetLodCountCommand.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Mesh/SetLodCountCommand.cpp
@@ -1,0 +1,73 @@
+#include "Commands/Mesh/SetLodCountCommand.h"
+#include "Dom/JsonObject.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonWriter.h"
+#include "Engine/StaticMesh.h"
+#include "UObject/SavePackage.h"
+
+FString FSetLodCountCommand::Execute(const FString& Parameters)
+{
+	TSharedPtr<FJsonObject> JsonObject;
+	TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Parameters);
+	if (!FJsonSerializer::Deserialize(Reader, JsonObject) || !JsonObject.IsValid())
+	{
+		TSharedPtr<FJsonObject> E = MakeShared<FJsonObject>(); E->SetBoolField(TEXT("success"), false);
+		E->SetStringField(TEXT("error"), TEXT("Invalid JSON"));
+		FString O; TSharedRef<TJsonWriter<>> W = TJsonWriterFactory<>::Create(&O);
+		FJsonSerializer::Serialize(E.ToSharedRef(), W); return O;
+	}
+
+	FString MeshPath;
+	int32 LodCount = 1;
+	JsonObject->TryGetStringField(TEXT("mesh_path"), MeshPath);
+	JsonObject->TryGetNumberField(TEXT("lod_count"), LodCount);
+
+	if (MeshPath.IsEmpty() || LodCount < 1 || LodCount > 8)
+	{
+		TSharedPtr<FJsonObject> E = MakeShared<FJsonObject>(); E->SetBoolField(TEXT("success"), false);
+		E->SetStringField(TEXT("error"), TEXT("Invalid mesh_path or lod_count (1-8)"));
+		FString O; TSharedRef<TJsonWriter<>> W = TJsonWriterFactory<>::Create(&O);
+		FJsonSerializer::Serialize(E.ToSharedRef(), W); return O;
+	}
+
+	UStaticMesh* Mesh = LoadObject<UStaticMesh>(nullptr, *MeshPath);
+	if (!Mesh)
+	{
+		TSharedPtr<FJsonObject> E = MakeShared<FJsonObject>(); E->SetBoolField(TEXT("success"), false);
+		E->SetStringField(TEXT("error"), FString::Printf(TEXT("Mesh not found: %s"), *MeshPath));
+		FString O; TSharedRef<TJsonWriter<>> W = TJsonWriterFactory<>::Create(&O);
+		FJsonSerializer::Serialize(E.ToSharedRef(), W); return O;
+	}
+
+	int32 OldCount = Mesh->GetNumSourceModels();
+	Mesh->SetNumSourceModels(LodCount);
+	Mesh->PostEditChange();
+	Mesh->MarkPackageDirty();
+
+	// Save
+	UPackage* Package = Mesh->GetOutermost();
+	FString Filename = FPackageName::LongPackageNameToFilename(Package->GetName(), FPackageName::GetAssetPackageExtension());
+	FSavePackageArgs SaveArgs; SaveArgs.TopLevelFlags = RF_Public | RF_Standalone;
+	UPackage::SavePackage(Package, Mesh, *Filename, SaveArgs);
+
+	UE_LOG(LogTemp, Log, TEXT("Set LOD count on %s: %d → %d"), *MeshPath, OldCount, LodCount);
+
+	TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetNumberField(TEXT("old_lod_count"), OldCount);
+	Result->SetNumberField(TEXT("new_lod_count"), LodCount);
+	Result->SetStringField(TEXT("message"), FString::Printf(TEXT("LOD count set to %d (was %d)"), LodCount, OldCount));
+
+	FString OutputString;
+	TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&OutputString);
+	FJsonSerializer::Serialize(Result.ToSharedRef(), Writer);
+	return OutputString;
+}
+
+FString FSetLodCountCommand::GetCommandName() const { return TEXT("set_lod_count"); }
+bool FSetLodCountCommand::ValidateParams(const FString& Parameters) const
+{
+	TSharedPtr<FJsonObject> J; TSharedRef<TJsonReader<>> R = TJsonReaderFactory<>::Create(Parameters);
+	if (!FJsonSerializer::Deserialize(R, J)) return false;
+	FString P; return J->TryGetStringField(TEXT("mesh_path"), P);
+}

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Mesh/SetLodScreenSizesCommand.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Mesh/SetLodScreenSizesCommand.cpp
@@ -1,0 +1,97 @@
+#include "Commands/Mesh/SetLodScreenSizesCommand.h"
+#include "Dom/JsonObject.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonWriter.h"
+#include "Engine/StaticMesh.h"
+#include "StaticMeshEditorSubsystem.h"
+#include "UObject/SavePackage.h"
+
+FString FSetLodScreenSizesCommand::Execute(const FString& Parameters)
+{
+	TSharedPtr<FJsonObject> JsonObject;
+	TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Parameters);
+	if (!FJsonSerializer::Deserialize(Reader, JsonObject) || !JsonObject.IsValid())
+	{
+		TSharedPtr<FJsonObject> E = MakeShared<FJsonObject>(); E->SetBoolField(TEXT("success"), false);
+		E->SetStringField(TEXT("error"), TEXT("Invalid JSON"));
+		FString O; TSharedRef<TJsonWriter<>> W = TJsonWriterFactory<>::Create(&O);
+		FJsonSerializer::Serialize(E.ToSharedRef(), W); return O;
+	}
+
+	FString MeshPath;
+	JsonObject->TryGetStringField(TEXT("mesh_path"), MeshPath);
+
+	const TArray<TSharedPtr<FJsonValue>>* ScreenSizesArray;
+	if (MeshPath.IsEmpty() || !JsonObject->TryGetArrayField(TEXT("screen_sizes"), ScreenSizesArray))
+	{
+		TSharedPtr<FJsonObject> E = MakeShared<FJsonObject>(); E->SetBoolField(TEXT("success"), false);
+		E->SetStringField(TEXT("error"), TEXT("Missing mesh_path or screen_sizes array"));
+		FString O; TSharedRef<TJsonWriter<>> W = TJsonWriterFactory<>::Create(&O);
+		FJsonSerializer::Serialize(E.ToSharedRef(), W); return O;
+	}
+
+	UStaticMesh* Mesh = LoadObject<UStaticMesh>(nullptr, *MeshPath);
+	if (!Mesh)
+	{
+		TSharedPtr<FJsonObject> E = MakeShared<FJsonObject>(); E->SetBoolField(TEXT("success"), false);
+		E->SetStringField(TEXT("error"), FString::Printf(TEXT("Mesh not found: %s"), *MeshPath));
+		FString O; TSharedRef<TJsonWriter<>> W = TJsonWriterFactory<>::Create(&O);
+		FJsonSerializer::Serialize(E.ToSharedRef(), W); return O;
+	}
+
+	// Parse screen sizes
+	TArray<float> ScreenSizes;
+	for (const auto& Val : *ScreenSizesArray)
+	{
+		ScreenSizes.Add((float)Val->AsNumber());
+	}
+
+	// Use subsystem for proper handling
+	UStaticMeshEditorSubsystem* Subsystem = GEditor->GetEditorSubsystem<UStaticMeshEditorSubsystem>();
+	if (Subsystem)
+	{
+		Subsystem->SetLodScreenSizes(Mesh, ScreenSizes);
+	}
+	else
+	{
+		// Fallback: set directly on render data
+		if (Mesh->GetRenderData())
+		{
+			Mesh->SetAutoComputeLODScreenSize(false);
+			for (int32 i = 0; i < ScreenSizes.Num() && i < MAX_STATIC_MESH_LODS; ++i)
+			{
+				Mesh->GetRenderData()->ScreenSize[i].Default = ScreenSizes[i];
+			}
+		}
+	}
+
+	Mesh->PostEditChange();
+	Mesh->MarkPackageDirty();
+
+	// Save
+	UPackage* Package = Mesh->GetOutermost();
+	FString Filename = FPackageName::LongPackageNameToFilename(Package->GetName(), FPackageName::GetAssetPackageExtension());
+	FSavePackageArgs SaveArgs; SaveArgs.TopLevelFlags = RF_Public | RF_Standalone;
+	UPackage::SavePackage(Package, Mesh, *Filename, SaveArgs);
+
+	UE_LOG(LogTemp, Log, TEXT("Set LOD screen sizes on %s: %d values"), *MeshPath, ScreenSizes.Num());
+
+	TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetNumberField(TEXT("lod_count"), ScreenSizes.Num());
+	Result->SetStringField(TEXT("message"), FString::Printf(TEXT("Screen sizes set for %d LODs"), ScreenSizes.Num()));
+
+	FString OutputString;
+	TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&OutputString);
+	FJsonSerializer::Serialize(Result.ToSharedRef(), Writer);
+	return OutputString;
+}
+
+FString FSetLodScreenSizesCommand::GetCommandName() const { return TEXT("set_lod_screen_sizes"); }
+bool FSetLodScreenSizesCommand::ValidateParams(const FString& Parameters) const
+{
+	TSharedPtr<FJsonObject> J; TSharedRef<TJsonReader<>> R = TJsonReaderFactory<>::Create(Parameters);
+	if (!FJsonSerializer::Deserialize(R, J)) return false;
+	FString P; const TArray<TSharedPtr<FJsonValue>>* A;
+	return J->TryGetStringField(TEXT("mesh_path"), P) && J->TryGetArrayField(TEXT("screen_sizes"), A);
+}

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/MeshCommandRegistration.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/MeshCommandRegistration.cpp
@@ -1,0 +1,48 @@
+#include "Commands/MeshCommandRegistration.h"
+#include "Commands/UnrealMCPCommandRegistry.h"
+
+#include "Commands/Mesh/GetStaticMeshMetadataCommand.h"
+#include "Commands/Mesh/SetLodCountCommand.h"
+#include "Commands/Mesh/ImportLodCommand.h"
+#include "Commands/Mesh/SetLodScreenSizesCommand.h"
+#include "Commands/Mesh/AutoGenerateLodsCommand.h"
+
+TArray<TSharedPtr<IUnrealMCPCommand>> FMeshCommandRegistration::RegisteredCommands;
+
+void FMeshCommandRegistration::RegisterAllCommands()
+{
+	UE_LOG(LogTemp, Log, TEXT("Registering Mesh commands..."));
+
+	RegisterAndTrackCommand(MakeShared<FGetStaticMeshMetadataCommand>());
+	RegisterAndTrackCommand(MakeShared<FSetLodCountCommand>());
+	RegisterAndTrackCommand(MakeShared<FImportLodCommand>());
+	RegisterAndTrackCommand(MakeShared<FSetLodScreenSizesCommand>());
+	RegisterAndTrackCommand(MakeShared<FAutoGenerateLodsCommand>());
+
+	UE_LOG(LogTemp, Log, TEXT("Registered %d Mesh commands"), RegisteredCommands.Num());
+}
+
+void FMeshCommandRegistration::UnregisterAllCommands()
+{
+	FUnrealMCPCommandRegistry& Registry = FUnrealMCPCommandRegistry::Get();
+	for (const TSharedPtr<IUnrealMCPCommand>& Command : RegisteredCommands)
+	{
+		if (Command.IsValid())
+		{
+			Registry.UnregisterCommand(Command->GetCommandName());
+		}
+	}
+	RegisteredCommands.Empty();
+}
+
+void FMeshCommandRegistration::RegisterAndTrackCommand(TSharedPtr<IUnrealMCPCommand> Command)
+{
+	if (!Command.IsValid()) return;
+
+	FUnrealMCPCommandRegistry& Registry = FUnrealMCPCommandRegistry::Get();
+	if (Registry.RegisterCommand(Command))
+	{
+		RegisteredCommands.Add(Command);
+		UE_LOG(LogTemp, Log, TEXT("Registered Mesh command: %s"), *Command->GetCommandName());
+	}
+}

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPMainDispatcher.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPMainDispatcher.cpp
@@ -14,6 +14,7 @@
 #include "Commands/StateTreeCommandRegistration.h"
 #include "Commands/SoundCommandRegistration.h"
 #include "Commands/PCGCommandRegistration.h"
+#include "Commands/MeshCommandRegistration.h"
 #include "Services/BlueprintActionService.h"
 // Legacy adapter removed
 #include "Services/BlueprintService.h"
@@ -134,6 +135,9 @@ void FUnrealMCPMainDispatcher::RegisterAllCommands()
     // Register PCG (Procedural Content Generation) commands
     FPCGCommandRegistration::RegisterAllCommands();
 
+    // Register Mesh commands (LOD, metadata, properties)
+    FMeshCommandRegistration::RegisterAllCommands();
+
     UE_LOG(LogTemp, Log, TEXT("FUnrealMCPMainDispatcher::RegisterAllCommands: All command types registered"));
 }
 
@@ -178,6 +182,7 @@ void FUnrealMCPMainDispatcher::Shutdown()
     FNiagaraCommandRegistration::UnregisterAllCommands();
     FAnimationCommandRegistration::UnregisterAllAnimationCommands();
     FStateTreeCommandRegistration::UnregisterAllStateTreeCommands();
+    FMeshCommandRegistration::UnregisterAllCommands();
 
     // Clear the entire registry
     FUnrealMCPCommandRegistry::Get().ClearRegistry();

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Mesh/AutoGenerateLodsCommand.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Mesh/AutoGenerateLodsCommand.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Commands/IUnrealMCPCommand.h"
+
+class UNREALMCP_API FAutoGenerateLodsCommand : public IUnrealMCPCommand
+{
+public:
+	FAutoGenerateLodsCommand() = default;
+	virtual FString Execute(const FString& Parameters) override;
+	virtual FString GetCommandName() const override;
+	virtual bool ValidateParams(const FString& Parameters) const override;
+};

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Mesh/GetStaticMeshMetadataCommand.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Mesh/GetStaticMeshMetadataCommand.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Commands/IUnrealMCPCommand.h"
+
+class UNREALMCP_API FGetStaticMeshMetadataCommand : public IUnrealMCPCommand
+{
+public:
+	FGetStaticMeshMetadataCommand() = default;
+	virtual FString Execute(const FString& Parameters) override;
+	virtual FString GetCommandName() const override;
+	virtual bool ValidateParams(const FString& Parameters) const override;
+};

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Mesh/ImportLodCommand.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Mesh/ImportLodCommand.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Commands/IUnrealMCPCommand.h"
+
+class UNREALMCP_API FImportLodCommand : public IUnrealMCPCommand
+{
+public:
+	FImportLodCommand() = default;
+	virtual FString Execute(const FString& Parameters) override;
+	virtual FString GetCommandName() const override;
+	virtual bool ValidateParams(const FString& Parameters) const override;
+};

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Mesh/SetLodCountCommand.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Mesh/SetLodCountCommand.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Commands/IUnrealMCPCommand.h"
+
+class UNREALMCP_API FSetLodCountCommand : public IUnrealMCPCommand
+{
+public:
+	FSetLodCountCommand() = default;
+	virtual FString Execute(const FString& Parameters) override;
+	virtual FString GetCommandName() const override;
+	virtual bool ValidateParams(const FString& Parameters) const override;
+};

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Mesh/SetLodScreenSizesCommand.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Mesh/SetLodScreenSizesCommand.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Commands/IUnrealMCPCommand.h"
+
+class UNREALMCP_API FSetLodScreenSizesCommand : public IUnrealMCPCommand
+{
+public:
+	FSetLodScreenSizesCommand() = default;
+	virtual FString Execute(const FString& Parameters) override;
+	virtual FString GetCommandName() const override;
+	virtual bool ValidateParams(const FString& Parameters) const override;
+};

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/MeshCommandRegistration.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/MeshCommandRegistration.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Commands/IUnrealMCPCommand.h"
+
+class FMeshCommandRegistration
+{
+public:
+	static void RegisterAllCommands();
+	static void UnregisterAllCommands();
+
+private:
+	static TArray<TSharedPtr<IUnrealMCPCommand>> RegisteredCommands;
+	static void RegisterAndTrackCommand(TSharedPtr<IUnrealMCPCommand> Command);
+};

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/UnrealMCP.Build.cs
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/UnrealMCP.Build.cs
@@ -137,7 +137,9 @@ public class UnrealMCP : ModuleRules
 					"StateTreeEditorModule",   // StateTree editor utilities (factories, compilation)
 					"PropertyBindingUtils",    // Property binding path utilities
 					// PCG (Procedural Content Generation) support
-					"PCG"                      // Core PCG runtime (graphs, nodes, elements)
+					"PCG",                     // Core PCG runtime (graphs, nodes, elements)
+					// Static Mesh editor support (LOD management)
+					"StaticMeshEditor"         // UStaticMeshEditorSubsystem
 				}
 			);
 		}

--- a/Python/mesh_mcp_server.py
+++ b/Python/mesh_mcp_server.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""
+Mesh MCP Server - Static Mesh operations for Unreal Engine.
+Includes: LOD management, mesh metadata, mesh properties.
+"""
+
+import asyncio
+import json
+from typing import Any, Dict, List
+
+from fastmcp import FastMCP
+
+# Initialize FastMCP app
+app = FastMCP("Mesh MCP Server")
+
+# TCP connection settings
+TCP_HOST = "127.0.0.1"
+TCP_PORT = 55557
+
+
+async def send_tcp_command(command_type: str, params: Dict[str, Any]) -> Dict[str, Any]:
+    """Send a command to the Unreal Engine TCP server."""
+    try:
+        command_data = {
+            "type": command_type,
+            "params": params
+        }
+        json_data = json.dumps(command_data)
+
+        reader, writer = await asyncio.open_connection(TCP_HOST, TCP_PORT)
+        writer.write(json_data.encode('utf-8'))
+        writer.write(b'\n')
+        await writer.drain()
+
+        response_data = await reader.read(49152)
+        response_str = response_data.decode('utf-8').strip()
+
+        writer.close()
+        await writer.wait_closed()
+
+        if response_str:
+            try:
+                return json.loads(response_str)
+            except json.JSONDecodeError as json_err:
+                return {"success": False, "error": f"JSON decode error: {str(json_err)}, Response: {response_str[:200]}"}
+        else:
+            return {"success": False, "error": "Empty response from server"}
+
+    except Exception as e:
+        return {"success": False, "error": f"TCP communication error: {str(e)}"}
+
+
+# ============================================================================
+# Mesh Metadata
+# ============================================================================
+
+@app.tool()
+async def get_static_mesh_metadata(
+    mesh_path: str
+) -> Dict[str, Any]:
+    """
+    Get detailed metadata about a Static Mesh asset.
+
+    Returns LOD count, vertex/triangle counts per LOD, bounds, material slots,
+    screen sizes, and other mesh properties.
+
+    Args:
+        mesh_path: Path to the Static Mesh (e.g., "/Game/Environment/GroundCover/SM_GrassPatch_01")
+
+    Returns:
+        Dictionary containing:
+        - lod_count: Number of LOD levels
+        - lods: Array of per-LOD info (vertices, triangles, screen_size)
+        - bounds: Bounding box dimensions
+        - material_slots: Array of material slot names/paths
+        - has_collision: Whether mesh has collision
+        - nanite_enabled: Whether Nanite is enabled
+
+    Example:
+        get_static_mesh_metadata(mesh_path="/Game/Meshes/SM_Rock_01")
+    """
+    return await send_tcp_command("get_static_mesh_metadata", {"mesh_path": mesh_path})
+
+
+# ============================================================================
+# LOD Management
+# ============================================================================
+
+@app.tool()
+async def set_lod_count(
+    mesh_path: str,
+    lod_count: int
+) -> Dict[str, Any]:
+    """
+    Set the number of LOD levels on a Static Mesh.
+
+    This adds or removes LOD source models. New LODs are empty until
+    populated via import_lod or auto-reduction.
+
+    Args:
+        mesh_path: Path to the Static Mesh
+        lod_count: Desired number of LODs (1-8)
+
+    Example:
+        set_lod_count(mesh_path="/Game/Meshes/SM_Grass_01", lod_count=3)
+    """
+    return await send_tcp_command("set_lod_count", {
+        "mesh_path": mesh_path,
+        "lod_count": lod_count
+    })
+
+
+@app.tool()
+async def import_lod(
+    mesh_path: str,
+    lod_index: int,
+    source_file_path: str
+) -> Dict[str, Any]:
+    """
+    Import a mesh file (FBX/OBJ) into a specific LOD slot of a Static Mesh.
+
+    The target LOD slot must exist (use set_lod_count first if needed).
+    The imported mesh replaces any existing geometry in that LOD slot.
+
+    Args:
+        mesh_path: Path to the target Static Mesh in UE
+        lod_index: LOD slot to import into (0=highest detail, 1=first reduction, etc.)
+        source_file_path: Absolute path to the FBX/OBJ file on disk
+
+    Example:
+        import_lod(
+            mesh_path="/Game/Meshes/SM_Grass_01",
+            lod_index=1,
+            source_file_path="E:/meshes/SM_Grass_01_LOD1.fbx"
+        )
+    """
+    return await send_tcp_command("import_lod", {
+        "mesh_path": mesh_path,
+        "lod_index": lod_index,
+        "source_file_path": source_file_path
+    })
+
+
+@app.tool()
+async def set_lod_screen_sizes(
+    mesh_path: str,
+    screen_sizes: list
+) -> Dict[str, Any]:
+    """
+    Set screen size thresholds for LOD transitions.
+
+    Screen size is the percentage of screen height the mesh's bounds occupy.
+    Lower values = mesh appears smaller = lower LOD used.
+
+    Args:
+        mesh_path: Path to the Static Mesh
+        screen_sizes: Array of screen size values per LOD.
+            LOD0 is typically 1.0 (always used when close).
+            Example: [1.0, 0.5, 0.25] for 3 LODs.
+
+    Example:
+        set_lod_screen_sizes(
+            mesh_path="/Game/Meshes/SM_Grass_01",
+            screen_sizes=[1.0, 0.4, 0.15]
+        )
+    """
+    return await send_tcp_command("set_lod_screen_sizes", {
+        "mesh_path": mesh_path,
+        "screen_sizes": screen_sizes
+    })
+
+
+@app.tool()
+async def auto_generate_lods(
+    mesh_path: str,
+    target_lod_count: int = 3,
+    reduction_percentages: list = None
+) -> Dict[str, Any]:
+    """
+    Auto-generate LODs using UE's built-in mesh reduction.
+
+    Creates simplified versions of LOD0 at specified reduction percentages.
+    Much faster than manually creating LOD meshes in Blender.
+
+    Args:
+        mesh_path: Path to the Static Mesh
+        target_lod_count: Total number of LODs to have (including LOD0)
+        reduction_percentages: Triangle reduction per LOD (0.0-1.0).
+            Default: evenly distributed (e.g., [1.0, 0.5, 0.25] for 3 LODs).
+            Values are percentage of LOD0 triangles to KEEP.
+
+    Example:
+        auto_generate_lods(
+            mesh_path="/Game/Meshes/SM_Grass_01",
+            target_lod_count=3,
+            reduction_percentages=[1.0, 0.35, 0.1]
+        )
+    """
+    params = {
+        "mesh_path": mesh_path,
+        "target_lod_count": target_lod_count,
+    }
+    if reduction_percentages:
+        params["reduction_percentages"] = reduction_percentages
+
+    return await send_tcp_command("auto_generate_lods", params)
+
+
+# ============================================================================
+# Mesh Properties
+# ============================================================================
+
+@app.tool()
+async def set_static_mesh_properties(
+    mesh_path: str,
+    enable_nanite: bool = None,
+    has_collision: bool = None,
+    cull_distance: float = None,
+    cast_shadow: bool = None
+) -> Dict[str, Any]:
+    """
+    Set properties on a Static Mesh asset.
+
+    Args:
+        mesh_path: Path to the Static Mesh
+        enable_nanite: Enable/disable Nanite (note: doesn't work well with masked materials)
+        has_collision: Enable/disable collision
+        cull_distance: Max draw distance (0 = no limit)
+        cast_shadow: Enable/disable shadow casting
+
+    Example:
+        set_static_mesh_properties(
+            mesh_path="/Game/Meshes/SM_Grass_01",
+            cull_distance=8000,
+            cast_shadow=False
+        )
+    """
+    params = {"mesh_path": mesh_path}
+    if enable_nanite is not None:
+        params["enable_nanite"] = enable_nanite
+    if has_collision is not None:
+        params["has_collision"] = has_collision
+    if cull_distance is not None:
+        params["cull_distance"] = cull_distance
+    if cast_shadow is not None:
+        params["cast_shadow"] = cast_shadow
+
+    return await send_tcp_command("set_static_mesh_properties", params)
+
+
+if __name__ == "__main__":
+    app.run()

--- a/README.md
+++ b/README.md
@@ -141,6 +141,13 @@ Design AI behavior with StateTree system:
 - Configure tasks and conditions
 - Property bindings and target bindings
 
+### 📐 Static Mesh Operations
+Manage Static Mesh assets and LOD systems:
+- Get mesh metadata (LOD count, vertices, triangles, bounds, materials)
+- Import LODs from FBX files into specific LOD slots
+- Set LOD screen size thresholds for transitions
+- Auto-generate LODs with built-in mesh reduction
+
 ### 🌿 Procedural Content Generation (PCG)
 Build and execute PCG graphs for procedural world-building:
 - Create PCG Graph assets with optional templates
@@ -167,6 +174,8 @@ Manage actors and the editor environment:
 - Find actors by name patterns and wildcards
 - Control viewport camera focus and orientation
 - Query and modify actor properties
+- Performance profiling (FPS, GPU time, draw calls, memory)
+- Execute console commands with captured output
 
 ### 📁 Project Organization
 Organize assets, inputs, and project structure:
@@ -211,7 +220,7 @@ The project uses a **dual-component synchronized architecture** enabling natural
 ```
 AI Assistant (Claude/Cursor/Windsurf)
     ↓ [MCP Protocol]
-Python MCP Servers (14 specialized FastMCP servers)
+Python MCP Servers (15 specialized FastMCP servers)
     ↓ [TCP/JSON on localhost:55557]
 C++ Plugin (UnrealMCP EditorSubsystem)
     ↓ [Direct Unreal Engine API]
@@ -270,6 +279,7 @@ unreal-mcp/
 │   ├── font_mcp_server.py            # Font tools server
 │   ├── statetree_mcp_server.py       # StateTree AI server
 │   ├── pcg_mcp_server.py            # PCG procedural generation server
+│   ├── mesh_mcp_server.py           # Static Mesh LOD & properties server
 │   ├── *_tools/                      # Tool implementations
 │   ├── utils/                        # Shared utilities
 │   └── scripts/                      # Test scripts
@@ -387,7 +397,7 @@ For more details, see [Python/README.md](Python/README.md).
 
 ### Configure Your MCP Client
 
-The 14 MCP servers need to be configured in your AI assistant. Below is the configuration template - **adjust the path** to match your installation directory.
+The 15 MCP servers need to be configured in your AI assistant. Below is the configuration template - **adjust the path** to match your installation directory.
 
 #### Configuration Template
 
@@ -449,6 +459,10 @@ The 14 MCP servers need to be configured in your AI assistant. Below is the conf
     "pcgMCP": {
       "command": "uv",
       "args": ["--directory", "/path/to/unreal-mcp/Python", "run", "pcg_mcp_server.py"]
+    },
+    "meshMCP": {
+      "command": "uv",
+      "args": ["--directory", "/path/to/unreal-mcp/Python", "run", "mesh_mcp_server.py"]
     }
   }
 }


### PR DESCRIPTION
…ration

New MCP server (meshMCP) with 5 tools for Static Mesh operations:
- get_static_mesh_metadata: LOD count, verts/tris per LOD, bounds, materials
- set_lod_count: set number of LOD levels (1-8)
- import_lod: import FBX into specific LOD slot via UStaticMeshEditorSubsystem
- set_lod_screen_sizes: set screen size thresholds per LOD transition
- auto_generate_lods: auto-reduce mesh using UE built-in reduction

Infrastructure:
- New Python server: mesh_mcp_server.py (FastMCP)
- New C++ commands: Commands/Mesh/ (5 commands + registration)
- Added StaticMeshEditor module dependency to Build.cs
README.md (15 servers), CLAUDE.md