### PR TITLE
fix: add missing include and plugin dependencies for clean builds

### DIFF
--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/AnimationBlueprintStateMachineOps.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/AnimationBlueprintStateMachineOps.cpp
@@ -6,6 +6,7 @@
 #include "Animation/AnimBlueprint.h"
 #include "AnimGraphNode_StateMachine.h"
 #include "AnimGraphNode_SequencePlayer.h"
+#include "AnimGraphNode_StateResult.h"
 #include "AnimStateNode.h"
 #include "AnimStateTransitionNode.h"
 #include "AnimationGraph.h"

--- a/MCPGameProject/Plugins/UnrealMCP/UnrealMCP.uplugin
+++ b/MCPGameProject/Plugins/UnrealMCP/UnrealMCP.uplugin
@@ -40,7 +40,15 @@
 			"Enabled": true
 		},
 		{
+			"Name": "StructUtils",
+			"Enabled": true
+		},
+		{
 			"Name": "Metasound",
+			"Enabled": true
+		},
+		{
+			"Name": "Niagara",
 			"Enabled": true
 		},
 		{


### PR DESCRIPTION
AnimGraphNode_StateResult.h was implicitly included via unity builds, causing compile errors on fresh/different unity configurations. Added StructUtils and Niagara to .uplugin plugin dependencies.