### PR TITLE
fix(mesh): LOD screen sizes, texture size reporting, asset deletion +…

### DIFF
--- a/Docs/agents/research/asset-deletion-memory-cleanup.md
+++ b/Docs/agents/research/asset-deletion-memory-cleanup.md
@@ -1,0 +1,316 @@
+# Research: Proper UAsset Deletion from Memory in UE 5.7
+
+## Summary
+
+Our `delete_asset` command calls `UEditorAssetLibrary::DeleteAsset()`, which internally calls `ObjectTools::ForceDeleteObjects()` -- the most thorough deletion API in UE. This API replaces all references with nullptr, clears object flags, unloads packages, runs GC, and deletes from disk. Our code IS already calling the correct API. The bug is more subtle: either `ForceDeleteObjects` is silently failing/returning 0, or the import side is hitting stale in-memory state that survived the deletion.
+
+## Call Chain (Our Code)
+
+```
+delete_asset TCP command
+  -> FDeleteAssetCommand::Execute()                     [DeleteAssetCommand.cpp]
+  -> FProjectService::DeleteAsset()                     [ProjectService.cpp:335]
+  -> FProjectAssetOperations::DeleteAsset()             [ProjectAssetOperations.cpp:61]
+  -> UEditorAssetLibrary::DeleteAsset()                 [EditorAssetLibrary.cpp:339]
+  -> UEditorAssetSubsystem::DeleteAsset()               [EditorAssetSubsystem.cpp:795]
+  -> ObjectTools::ForceDeleteObjects(objects, false)    [ObjectTools.cpp:3553]
+```
+
+All dispatched via `AsyncTask(ENamedThreads::GameThread, ...)` from `UnrealMCPBridge.cpp:456`, so it runs on the game thread.
+
+## Root Cause Analysis
+
+### The Exact Bug Path
+
+1. `delete_asset` calls `UEditorAssetLibrary::DeleteAsset(path)` which calls `ObjectTools::ForceDeleteObjects`
+2. `ForceDeleteObjects` should do full cleanup (details below)
+3. Later, `import_static_mesh` calls `CreatePackage(*PackagePath)` (line 65 of ImportStaticMeshCommand.cpp)
+4. `CreatePackage` does `FindObject<UPackage>(nullptr, *InName)` (UObjectGlobals.cpp:1040) -- finds OLD in-memory package if still alive
+5. `FbxFactory::ImportObject` does `StaticFindObject(UObject::StaticClass(), InParent, *(Name.ToString()))` (FbxFactory.cpp:216) -- finds OLD UStaticMesh
+6. Factory treats it as REIMPORT instead of fresh import -- updates old object rather than creating new one
+
+### What ForceDeleteObjects Does (ObjectTools.cpp:3553-3981)
+
+Full pipeline when working correctly:
+1. `AddExtraObjectsToDelete` -- adds map build data, etc.
+2. `RecursiveRetrieveReferencers` -- finds ALL objects referencing the deleted objects
+3. Closes all editors for referencing assets
+4. Deselects objects from editor selection
+5. For Blueprints: destroys instances, SCS nodes, components, actors
+6. **`ForceReplaceReferences(nullptr, ObjectsToReplace, ...)`** -- replaces ALL references with nullptr (line 3885)
+7. `CollectGarbage(GARBAGE_COLLECTION_KEEPFLAGS)` -- first GC pass (line 3893)
+8. `FAssetRegistryModule::AssetDeleted(ObjectToDelete)` -- unregisters from registry (line 3464)
+9. `ObjectToDelete->ClearFlags(RF_Standalone | RF_Public)` -- makes GC-eligible (line 3467)
+10. `FAssetRegistryModule::PackageDeleted(Package)` -- unregisters package (line 3597 in CleanupAfterSuccessfulDelete)
+11. `CleanupAfterSuccessfulDelete(PotentialPackagesToDelete)` -- package unload + disk delete (line 3949)
+    - Calls `GatherObjectReferencersForDeletion` on the package (`bPerformReferenceCheck=true` default)
+    - **If package is still referenced: REMOVES it from unload list** (line 2549)
+    - If not referenced: `UPackageTools::UnloadPackages()` + `CollectGarbage()` + disk file delete
+
+### Three Likely Failure Points
+
+**Failure Point 1: `OnAssetsCanDelete` delegate blocks deletion (line 3561-3567)**
+Any delegate registered on `FEditorDelegates::OnAssetsCanDelete` can veto the deletion. If vetoed, `ForceDeleteObjects` returns 0 without logging (just shows a dialog that gets suppressed by `GIsRunningUnattendedScript`). Our code checks the return of `UEditorAssetLibrary::DeleteAsset` (bool) but the actual error may be swallowed.
+
+**Failure Point 2: Package survives CleanupAfterSuccessfulDelete (line 2535-2549)**
+`CleanupAfterSuccessfulDelete` is called with default `bPerformReferenceCheck=true`. It runs `GatherObjectReferencersForDeletion` on the package. If ANY external object still references the package (not the asset inside it), the package is removed from the unload list. Possible culprits:
+- FLinkerLoad (package loader) still attached
+- Transaction buffer holding a reference
+- Async loading system has a pending reference
+- Rendering resources still referencing the mesh
+
+**Failure Point 3: AsyncTask(GameThread) context issues (line 456 of UnrealMCPBridge.cpp)**
+`AsyncTask(GameThread)` runs inside the TaskGraph system. `ForceDeleteObjects` internally calls `FlushAsyncLoading()`, `FlushRenderingCommands()`, `CollectGarbage()`, and shows slow task UI. Some of these may have issues when called from within a TaskGraph task vs. a normal game thread tick. Our own code already works around this for FBX imports by using `FTSTicker` instead of `AsyncTask(GameThread)` -- the delete command may need the same treatment.
+
+## UE 5.7 Available APIs
+
+### Primary APIs for Asset Deletion
+
+| Function | Header | Purpose |
+|----------|--------|---------|
+| `ObjectTools::ForceDeleteObjects(objects, showConfirm)` | `ObjectTools.h` | Nuclear option: replaces ALL refs with nullptr, then deletes objects + packages + disk. **Already used by our code.** |
+| `ObjectTools::DeleteObjects(objects, showConfirm)` | `ObjectTools.h` | Safe delete: uses `FAssetDeleteModel` to scan refs first, shows UI if refs exist. |
+| `ObjectTools::DeleteAssets(assetDataArray, showConfirm)` | `ObjectTools.h` | Takes FAssetData instead of UObject*. |
+| `ObjectTools::DeleteSingleObject(obj, refCheck)` | `ObjectTools.h` | Low-level: clears flags, notifies registry. Does NOT delete from disk or unload package. |
+| `ObjectTools::DeleteObjectsUnchecked(objects)` | `ObjectTools.h` | Calls DeleteSingleObject + CleanupAfterSuccessfulDelete. No reference check. |
+| `ObjectTools::ForceReplaceReferences(nullptr, objects)` | `ObjectTools.h` | Replaces all refs to objects with nullptr across ALL loaded objects. |
+| `ObjectTools::CleanupAfterSuccessfulDelete(packages)` | `ObjectTools.h` | Unloads packages, runs GC, deletes .uasset from disk. |
+| `UPackageTools::UnloadPackages(packages)` | `PackageTools.h` | Unloads packages from memory, clears RF_Standalone, runs GC. |
+| `UEditorAssetLibrary::DeleteAsset(path)` | `EditorAssetLibrary.h` | Thin wrapper around `ForceDeleteObjects`. |
+
+### Supporting APIs
+
+| Function | Purpose |
+|----------|---------|
+| `FAssetRegistryModule::AssetDeleted(obj)` | Remove asset from registry |
+| `FAssetRegistryModule::PackageDeleted(pkg)` | Remove package from registry |
+| `obj->ClearFlags(RF_Standalone \| RF_Public)` | Make object GC-eligible |
+| `CollectGarbage(GARBAGE_COLLECTION_KEEPFLAGS)` | Run garbage collection |
+| `GEditor->ResetTransaction(reason)` | Clear undo buffer (holds strong refs) |
+| `FlushAsyncLoading()` | Complete pending async loads |
+| `ResetLoaders(packages)` | Detach package linkers |
+| `StaticFindObject(class, outer, name)` | Check if object exists in memory |
+| `FindObject<UPackage>(nullptr, name)` | Check if package exists in memory |
+
+## Recommended Fix Strategy
+
+### Step 1: Add Diagnostics First
+
+Before changing the deletion logic, add logging to understand what is actually happening:
+
+```cpp
+bool FProjectAssetOperations::DeleteAsset(const FString& AssetPath, FString& OutError)
+{
+    // Check pre-state
+    FString ObjectPath = AssetPath + TEXT(".") + FPaths::GetBaseFilename(AssetPath);
+    UObject* PreCheck = StaticFindObject(UObject::StaticClass(), nullptr, *ObjectPath);
+    UE_LOG(LogTemp, Warning, TEXT("MCP DeleteAsset PRE: Object in memory = %s"),
+        PreCheck ? TEXT("YES") : TEXT("NO"));
+
+    if (!UEditorAssetLibrary::DoesAssetExist(AssetPath))
+    {
+        OutError = FString::Printf(TEXT("Asset does not exist: %s"), *AssetPath);
+        return false;
+    }
+
+    bool bResult = UEditorAssetLibrary::DeleteAsset(AssetPath);
+    UE_LOG(LogTemp, Warning, TEXT("MCP DeleteAsset: UEditorAssetLibrary::DeleteAsset returned %s"),
+        bResult ? TEXT("true") : TEXT("false"));
+
+    // Check post-state
+    UObject* PostCheck = StaticFindObject(UObject::StaticClass(), nullptr, *ObjectPath);
+    UPackage* PostPkg = FindObject<UPackage>(nullptr, *AssetPath);
+    UE_LOG(LogTemp, Warning, TEXT("MCP DeleteAsset POST: Object in memory = %s, Package in memory = %s"),
+        PostCheck ? TEXT("YES") : TEXT("NO"),
+        PostPkg ? TEXT("YES") : TEXT("NO"));
+
+    if (PostCheck)
+    {
+        UE_LOG(LogTemp, Warning, TEXT("MCP DeleteAsset POST: Object flags = %d, RF_Standalone=%s, RF_Public=%s"),
+            PostCheck->GetFlags(),
+            PostCheck->HasAnyFlags(RF_Standalone) ? TEXT("yes") : TEXT("no"),
+            PostCheck->HasAnyFlags(RF_Public) ? TEXT("yes") : TEXT("no"));
+    }
+
+    return bResult;
+}
+```
+
+### Step 2: Fix Based on Diagnostics
+
+**If DeleteAsset returns false:** The `OnAssetsCanDelete` delegate or `bClosedAllEditors` check is vetoing. Need to investigate what's blocking.
+
+**If DeleteAsset returns true BUT object still in memory:** The object survived GC. Most likely cause:
+- Transaction buffer holding a reference
+- Rendering thread still has a reference
+- `CleanupAfterSuccessfulDelete` skipped the package unload due to reference check
+
+**Fix for "returns true but object survives"** -- use `ObjectTools::ForceDeleteObjects` directly with additional cleanup:
+
+```cpp
+bool FProjectAssetOperations::DeleteAsset(const FString& AssetPath, FString& OutError)
+{
+    // 1. Load the asset
+    FString ObjectPath = AssetPath;
+    if (!ObjectPath.Contains(TEXT(".")))
+    {
+        ObjectPath = AssetPath + TEXT(".") + FPaths::GetBaseFilename(AssetPath);
+    }
+
+    UObject* Asset = StaticFindObject(UObject::StaticClass(), nullptr, *ObjectPath);
+    if (!Asset)
+    {
+        Asset = LoadObject<UObject>(nullptr, *ObjectPath);
+    }
+    if (!Asset)
+    {
+        OutError = FString::Printf(TEXT("Asset not found: %s"), *AssetPath);
+        return false;
+    }
+
+    UPackage* Package = Asset->GetOutermost();
+
+    // 2. Close editors
+    if (GEditor)
+    {
+        GEditor->GetEditorSubsystem<UAssetEditorSubsystem>()->CloseAllEditorsForAsset(Asset);
+        GEditor->GetSelectedObjects()->Deselect(Asset);
+    }
+
+    // 3. Clear transaction buffer first (common blocker)
+    if (GEditor && GEditor->Trans)
+    {
+        GEditor->ResetTransaction(NSLOCTEXT("MCP", "DeleteAsset", "MCP Delete Asset"));
+    }
+
+    // 4. Force delete
+    TArray<UObject*> ObjectsToDelete;
+    ObjectsToDelete.Add(Asset);
+    int32 NumDeleted = ObjectTools::ForceDeleteObjects(ObjectsToDelete, /*bShowConfirmation=*/false);
+
+    if (NumDeleted == 0)
+    {
+        OutError = FString::Printf(TEXT("ForceDeleteObjects returned 0 for: %s"), *AssetPath);
+        return false;
+    }
+
+    // 5. Verify cleanup -- force additional GC if object survived
+    UObject* SurvivedCheck = StaticFindObject(UObject::StaticClass(), nullptr, *ObjectPath);
+    if (SurvivedCheck)
+    {
+        UE_LOG(LogTemp, Warning, TEXT("MCP DeleteAsset: Object survived ForceDeleteObjects, forcing manual cleanup"));
+
+        SurvivedCheck->ClearFlags(RF_Standalone | RF_Public);
+        FAssetRegistryModule::AssetDeleted(SurvivedCheck);
+
+        if (UPackage* SurvivedPkg = FindObject<UPackage>(nullptr, *AssetPath))
+        {
+            FAssetRegistryModule::PackageDeleted(SurvivedPkg);
+            TArray<UPackage*> PkgsToUnload;
+            PkgsToUnload.Add(SurvivedPkg);
+            UPackageTools::UnloadPackages(PkgsToUnload);
+        }
+
+        CollectGarbage(GARBAGE_COLLECTION_KEEPFLAGS);
+    }
+
+    UE_LOG(LogTemp, Display, TEXT("MCP Project: Successfully deleted asset: %s"), *AssetPath);
+    return true;
+}
+```
+
+### Step 3: Also Fix Import Side (Defense in Depth)
+
+Add stale object cleanup in `ImportStaticMeshCommand.cpp` before creating the package:
+
+```cpp
+// Before CreatePackage -- purge any stale in-memory objects at this path
+FString FullObjectPath = PackagePath + TEXT(".") + AssetName;
+UObject* StaleObject = StaticFindObject(UObject::StaticClass(), nullptr, *FullObjectPath);
+if (StaleObject)
+{
+    UE_LOG(LogTemp, Warning, TEXT("MCP Import: Found stale in-memory object at %s, purging before import"), *FullObjectPath);
+
+    UPackage* StalePackage = StaleObject->GetOutermost();
+    StaleObject->ClearFlags(RF_Standalone | RF_Public);
+    FAssetRegistryModule::AssetDeleted(StaleObject);
+
+    if (StalePackage)
+    {
+        FAssetRegistryModule::PackageDeleted(StalePackage);
+        TArray<UPackage*> PkgsToUnload;
+        PkgsToUnload.Add(StalePackage);
+        UPackageTools::UnloadPackages(PkgsToUnload);
+    }
+
+    CollectGarbage(GARBAGE_COLLECTION_KEEPFLAGS);
+}
+
+// Now safe to create package and import
+UPackage* Package = CreatePackage(*PackagePath);
+```
+
+### Step 4: Consider Ticker Dispatch
+
+If the above fixes still have issues, `delete_asset` may need to be dispatched via `FTSTicker` instead of `AsyncTask(GameThread)`, similar to how `import_static_mesh` and `import_lod` are handled. `ForceDeleteObjects` calls `FlushAsyncLoading()`, `CollectGarbage()`, and `FlushRenderingCommands()` which may cause issues inside TaskGraph context.
+
+Add `delete_asset` to the `TickerCommands` array in `UnrealMCPBridge.cpp`:
+
+```cpp
+static const TArray<FString> TickerCommands = {
+    TEXT("import_static_mesh"),
+    TEXT("import_lod"),
+    TEXT("delete_asset"),  // ForceDeleteObjects calls FlushAsyncLoading + CollectGarbage
+};
+```
+
+## ForceDelete vs Normal Delete
+
+| Aspect | `DeleteObjects` (Normal) | `ForceDeleteObjects` (Force) |
+|--------|-------------------------|------------------------------|
+| Reference check | Yes, scans all refs first | No, replaces all refs with nullptr |
+| User confirmation | Optional dialog | Optional dialog |
+| In-memory refs | Aborts if still referenced | Nulls them out forcefully |
+| On-disk refs | Shows dialog listing referencers | Does not check on-disk refs |
+| Blueprint instances | N/A (aborts if referenced) | Destroys all instances |
+| Reference replacement | N/A | `ForceReplaceReferences(nullptr, ...)` |
+| Use case | User-initiated "safe" delete | Programmatic/automated delete |
+
+**For MCP: ForceDeleteObjects is correct.** We need silent, non-interactive deletion.
+
+## Handling References from Other Assets (PCG Spawner)
+
+When a PCG spawner references the mesh being deleted:
+
+1. `ForceDeleteObjects` calls `RecursiveRetrieveReferencers` which finds the PCG component
+2. Closes any editors open for referencing assets
+3. `ForceReplaceReferences(nullptr, ObjectsToReplace)` replaces the mesh reference in PCG spawner with nullptr
+4. PCG spawner Blueprint is dirtied (unsaved change)
+5. After deletion, the PCG spawner's mesh reference is nullptr
+
+After reimport at the same path:
+- **Hard references** (`UStaticMesh*` properties): Will be nullptr. Need explicit re-assignment.
+- **Soft references** (`FSoftObjectPath`): Will still point to the old path string. When resolved after reimport, they will find the new asset automatically since it has the same path.
+- **PCG StaticMeshSpawner**: Uses `FSoftObjectPath` internally. After reimport to same path, the PCG component should pick up the new mesh on next evaluation/refresh.
+
+## Key UE Source Files
+
+| File | Key Content |
+|------|-------------|
+| `Engine/Source/Editor/UnrealEd/Private/ObjectTools.cpp` | `ForceDeleteObjects` (3553), `DeleteSingleObject` (3387), `CleanupAfterSuccessfulDelete` (2498), `DeleteObjects` (3064), `ForceReplaceReferences` (1129), `GatherObjectReferencersForDeletion` (305) |
+| `Engine/Source/Editor/UnrealEd/Public/ObjectTools.h` | All API declarations |
+| `Engine/Source/Editor/UnrealEd/Private/Subsystems/EditorAssetSubsystem.cpp` | `DeleteAsset` (795), `DeleteLoadedAssets` (772) |
+| `Engine/Plugins/Editor/EditorScriptingUtilities/.../EditorAssetLibrary.cpp` | Thin wrapper (339) |
+| `Engine/Source/Editor/UnrealEd/Private/PackageTools.cpp` | `UnloadPackages` (361) |
+| `Engine/Source/Editor/UnrealEd/Private/Fbx/FbxFactory.cpp` | `StaticFindObject` reimport detection (216) |
+| `Engine/Source/Editor/UnrealEd/Private/AssetDeleteModel.cpp` | `FAssetDeleteModel` reference scanning |
+| `Engine/Source/Runtime/CoreUObject/Private/UObject/UObjectGlobals.cpp` | `CreatePackage` with `FindObject<UPackage>` (1040) |
+
+## Implementation Notes
+
+- `ObjectTools.h` and `PackageTools.h` are in `UnrealEd` module (already a dependency)
+- `CollectGarbage(GARBAGE_COLLECTION_KEEPFLAGS)` MUST run on game thread
+- `ForceReplaceReferences` creates `FGlobalComponentRecreateRenderStateContext` (expensive, detaches/reattaches all components globally)
+- After `ForceDeleteObjects`, raw pointers to deleted object are dangling
+- Transaction buffer (`GEditor->Trans`) is the most common blocker for "object won't die"
+- `GIsRunningUnattendedScript` suppresses dialogs but does NOT prevent `ForceDeleteObjects` from returning 0 on failure

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Editor/ImportTextureCommand.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Editor/ImportTextureCommand.cpp
@@ -157,8 +157,18 @@ FString FImportTextureCommand::Execute(const FString& Parameters)
 
 	if (ImportedTexture)
 	{
-		SizeX = ImportedTexture->GetSizeX();
-		SizeY = ImportedTexture->GetSizeY();
+		// Read dimensions from source data instead of render resource
+		// (render resource may still be initializing asynchronously, returning 32x32 placeholder)
+		if (ImportedTexture->Source.IsValid())
+		{
+			SizeX = ImportedTexture->Source.GetSizeX();
+			SizeY = ImportedTexture->Source.GetSizeY();
+		}
+		else
+		{
+			SizeX = ImportedTexture->GetSizeX();
+			SizeY = ImportedTexture->GetSizeY();
+		}
 		bHasAlpha = ImportedTexture->HasAlphaChannel();
 
 		UE_LOG(LogTemp, Log, TEXT("Imported texture '%s' from '%s' (%dx%d, Alpha: %s, sRGB: %s, Compression: %s)"),

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Mesh/SetLodScreenSizesCommand.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Mesh/SetLodScreenSizesCommand.cpp
@@ -46,26 +46,28 @@ FString FSetLodScreenSizesCommand::Execute(const FString& Parameters)
 		ScreenSizes.Add((float)Val->AsNumber());
 	}
 
-	// Use subsystem for proper handling
-	UStaticMeshEditorSubsystem* Subsystem = GEditor->GetEditorSubsystem<UStaticMeshEditorSubsystem>();
-	if (Subsystem)
+	// Disable auto-compute so manual screen sizes stick
+	Mesh->SetAutoComputeLODScreenSize(false);
+
+	// Set on source models (persists to disk)
+	for (int32 i = 0; i < ScreenSizes.Num() && i < Mesh->GetNumSourceModels(); ++i)
 	{
-		Subsystem->SetLodScreenSizes(Mesh, ScreenSizes);
+		Mesh->GetSourceModel(i).ScreenSize.Default = ScreenSizes[i];
 	}
-	else
+
+	// Set on render data for immediate visual effect
+	if (Mesh->GetRenderData())
 	{
-		// Fallback: set directly on render data
-		if (Mesh->GetRenderData())
+		for (int32 i = 0; i < ScreenSizes.Num() && i < MAX_STATIC_MESH_LODS; ++i)
 		{
-			Mesh->SetAutoComputeLODScreenSize(false);
-			for (int32 i = 0; i < ScreenSizes.Num() && i < MAX_STATIC_MESH_LODS; ++i)
-			{
-				Mesh->GetRenderData()->ScreenSize[i].Default = ScreenSizes[i];
-			}
+			Mesh->GetRenderData()->ScreenSize[i].Default = ScreenSizes[i];
 		}
 	}
 
-	Mesh->PostEditChange();
+	// Do NOT call PostEditChange() — it triggers a full mesh rebuild that
+	// destroys and recreates RenderData, corrupting the mesh scale.
+	// This follows Epic's own UStaticMeshEditorSubsystem::SetLodScreenSizes pattern.
+	Mesh->Modify();
 	Mesh->MarkPackageDirty();
 
 	// Save

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Mesh/SetMeshPropertiesCommand.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Mesh/SetMeshPropertiesCommand.cpp
@@ -3,6 +3,7 @@
 #include "Serialization/JsonSerializer.h"
 #include "Serialization/JsonWriter.h"
 #include "Engine/StaticMesh.h"
+#include "Materials/MaterialInterface.h"
 #include "StaticMeshEditorSubsystem.h"
 #include "UObject/SavePackage.h"
 
@@ -55,6 +56,43 @@ FString FSetMeshPropertiesCommand::Execute(const FString& Parameters)
 			Mesh->SetNaniteSettings(NaniteSettings);
 		}
 		ChangedProperties.Add(FString::Printf(TEXT("Nanite=%s"), bEnableNanite ? TEXT("true") : TEXT("false")));
+	}
+
+	// Materials — array of {slot_index, material_path} or single material_path for all slots
+	FString MaterialPath;
+	if (JsonObject->TryGetStringField(TEXT("material_path"), MaterialPath))
+	{
+		UMaterialInterface* Material = LoadObject<UMaterialInterface>(nullptr, *MaterialPath);
+		if (Material)
+		{
+			int32 NumSlots = Mesh->GetStaticMaterials().Num();
+			for (int32 i = 0; i < NumSlots; i++)
+			{
+				Mesh->SetMaterial(i, Material);
+			}
+			ChangedProperties.Add(FString::Printf(TEXT("Material=%s (all %d slots)"), *MaterialPath, NumSlots));
+		}
+		else
+		{
+			TSharedPtr<FJsonObject> E = MakeShared<FJsonObject>(); E->SetBoolField(TEXT("success"), false);
+			E->SetStringField(TEXT("error"), FString::Printf(TEXT("Material not found: %s"), *MaterialPath));
+			FString O; TSharedRef<TJsonWriter<>> W = TJsonWriterFactory<>::Create(&O);
+			FJsonSerializer::Serialize(E.ToSharedRef(), W); return O;
+		}
+	}
+
+	// Material per slot
+	int32 SlotIndex;
+	FString SlotMaterialPath;
+	if (JsonObject->TryGetNumberField(TEXT("material_slot_index"), SlotIndex) &&
+		JsonObject->TryGetStringField(TEXT("material_slot_path"), SlotMaterialPath))
+	{
+		UMaterialInterface* Material = LoadObject<UMaterialInterface>(nullptr, *SlotMaterialPath);
+		if (Material && SlotIndex >= 0 && SlotIndex < Mesh->GetStaticMaterials().Num())
+		{
+			Mesh->SetMaterial(SlotIndex, Material);
+			ChangedProperties.Add(FString::Printf(TEXT("Material[%d]=%s"), SlotIndex, *SlotMaterialPath));
+		}
 	}
 
 	// Collision

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Project/ProjectAssetOperations.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Project/ProjectAssetOperations.cpp
@@ -1,8 +1,10 @@
 #include "Services/Project/ProjectAssetOperations.h"
 #include "EditorAssetLibrary.h"
 #include "AssetRegistry/AssetRegistryModule.h"
+#include "PackageTools.h"
 #include "Misc/Paths.h"
 #include "HAL/PlatformFileManager.h"
+#include "Editor.h"
 
 FProjectAssetOperations& FProjectAssetOperations::Get()
 {
@@ -67,12 +69,33 @@ bool FProjectAssetOperations::DeleteAsset(const FString& AssetPath, FString& Out
         return false;
     }
 
-    // Use UEditorAssetLibrary::DeleteAsset to remove the asset
+    // Reset transaction buffer to release references that prevent full cleanup
+    if (GEditor)
+    {
+        GEditor->ResetTransaction(FText::FromString(TEXT("MCP Delete Asset")));
+    }
+
+    // Use UEditorAssetLibrary::DeleteAsset (calls ForceDeleteObjects internally)
     if (!UEditorAssetLibrary::DeleteAsset(AssetPath))
     {
         OutError = FString::Printf(TEXT("Failed to delete asset: %s"), *AssetPath);
         return false;
     }
+
+    // Post-delete cleanup: ensure package is unloaded from memory
+    // ForceDeleteObjects may leave the package in memory if references remain
+    FString PackagePath = AssetPath;
+    // Strip asset name to get package path (e.g. "/Game/Foo/Bar" -> "/Game/Foo/Bar")
+    UPackage* StalePackage = FindPackage(nullptr, *PackagePath);
+    if (StalePackage)
+    {
+        TArray<UPackage*> PackagesToUnload;
+        PackagesToUnload.Add(StalePackage);
+        UPackageTools::UnloadPackages(PackagesToUnload);
+    }
+
+    // Force garbage collection to fully purge the object
+    CollectGarbage(GARBAGE_COLLECTION_KEEPFLAGS);
 
     UE_LOG(LogTemp, Display, TEXT("MCP Project: Successfully deleted asset: %s"), *AssetPath);
     return true;

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/UnrealMCPBridge.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/UnrealMCPBridge.cpp
@@ -224,7 +224,8 @@ FString UUnrealMCPBridge::ExecuteCommand(const FString& CommandType, const TShar
     // but FBX ImportObject queues more tasks on GameThread → recursion crash.
     // FTSTicker runs on game thread tick, OUTSIDE TaskGraph.
     static const TArray<FString> TickerCommands = {
-        TEXT("import_static_mesh")
+        TEXT("import_static_mesh"),
+        TEXT("import_lod")
     };
     const bool bUseTicker = TickerCommands.Contains(CommandType);
 

--- a/Python/mesh_mcp_server.py
+++ b/Python/mesh_mcp_server.py
@@ -214,7 +214,10 @@ async def auto_generate_lods(
 async def set_static_mesh_properties(
     mesh_path: str,
     enable_nanite: bool = None,
-    has_collision: bool = None
+    has_collision: bool = None,
+    material_path: str = None,
+    material_slot_index: int = None,
+    material_slot_path: str = None
 ) -> Dict[str, Any]:
     """
     Set properties on a Static Mesh asset.
@@ -228,11 +231,18 @@ async def set_static_mesh_properties(
         mesh_path: Path to the Static Mesh asset
         enable_nanite: Enable/disable Nanite (note: doesn't work well with masked materials)
         has_collision: Enable/disable collision
+        material_path: Path to material to set on ALL slots (e.g., "/Game/Materials/M_Grass")
+        material_slot_index: Specific slot index to set material on (use with material_slot_path)
+        material_slot_path: Material path for the specific slot (use with material_slot_index)
 
     Example:
         set_static_mesh_properties(
             mesh_path="/Game/Meshes/SM_Grass_01",
             enable_nanite=False
+        )
+        set_static_mesh_properties(
+            mesh_path="/Game/Meshes/SM_Grass_01",
+            material_path="/Game/Environment/Materials/M_Grass"
         )
     """
     params = {"mesh_path": mesh_path}
@@ -240,6 +250,12 @@ async def set_static_mesh_properties(
         params["enable_nanite"] = enable_nanite
     if has_collision is not None:
         params["has_collision"] = has_collision
+    if material_path is not None:
+        params["material_path"] = material_path
+    if material_slot_index is not None:
+        params["material_slot_index"] = material_slot_index
+    if material_slot_path is not None:
+        params["material_slot_path"] = material_slot_path
 
     return await send_tcp_command("set_static_mesh_properties", params)
 

--- a/tools/mipflooding/mipflooding/__init__.py
+++ b/tools/mipflooding/mipflooding/__init__.py
@@ -1,0 +1,1 @@
+"""MipFlooding — Texture optimization using the mip flooding algorithm."""

--- a/tools/mipflooding/mipflooding/bin/loader/__init__.py
+++ b/tools/mipflooding/mipflooding/bin/loader/__init__.py
@@ -1,0 +1,55 @@
+import logging
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import clr
+
+logger = logging.getLogger(__name__)
+
+_dll_name = Path("ImageProcessingLibrary.dll")
+_dll_path = Path(__file__).parent.parent / "net4.7.2"
+_unblocked = False
+
+
+def _unblock_library(dll_full_path: Path) -> None:
+    """Unblock a DLL downloaded from the internet (Windows only).
+
+    Uses PowerShell's Unblock-File command. Only runs once per process
+    and is skipped entirely on non-Windows platforms.
+    """
+    global _unblocked
+    if _unblocked:
+        return
+
+    if os.name != "nt":
+        logger.debug("Unblocking is not necessary on this OS.")
+        _unblocked = True
+        return
+
+    try:
+        subprocess.run(
+            ["powershell", "-Command", f"Unblock-File -Path '{dll_full_path}'"],
+            check=True,
+            capture_output=True,
+        )
+        logger.info("%s has been unblocked.", dll_full_path)
+    except subprocess.CalledProcessError as e:
+        logger.warning("Failed to unblock %s: %s", dll_full_path, e)
+    except FileNotFoundError:
+        logger.debug("PowerShell not found — skipping unblock.")
+
+    _unblocked = True
+
+
+_unblock_library(_dll_path / _dll_name)
+
+sys.path.append(str(_dll_path))
+clr.AddReference(str(_dll_name.stem))
+
+# noinspection PyUnresolvedReferences
+from ImageProcessingLibrary import MipFlooding as mip_flooding
+
+if __name__ == "__main__":
+    print(_dll_path)

--- a/tools/mipflooding/mipflooding/wrapper/__init__.py
+++ b/tools/mipflooding/mipflooding/wrapper/__init__.py
@@ -1,0 +1,1 @@
+"""Wrapper layer exposing mip flooding functionality to Python."""

--- a/tools/mipflooding/mipflooding/wrapper/batch_processing.py
+++ b/tools/mipflooding/mipflooding/wrapper/batch_processing.py
@@ -1,0 +1,60 @@
+import logging
+import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import List
+
+from . import image_processing
+
+logger = logging.getLogger(__name__)
+
+
+def _match_mask(image_path: str, color_name_pattern: str, mask_name_pattern: str) -> str | None:
+    mask_path = image_path.replace(color_name_pattern, mask_name_pattern)
+    return mask_path if Path(mask_path).exists() else None
+
+
+def _mip_flooding_task(file: str, mask: str, output: str) -> None:
+    """Run the mip flooding algorithm on a single file."""
+    img_fmt = Path(output).suffix.lstrip(".").lower()
+    image_processing.run_mip_flooding(file, mask, output, img_format=img_fmt)
+
+
+def run_batch_mip_flood(
+    files: List[str],
+    output_dir: str,
+    input_color_pattern: str = "_C",
+    input_mask_pattern: str = "_A",
+    output_pattern: str = "_C",
+    max_workers: int | None = None,
+) -> List[str]:
+    """Process all relevant files in parallel using mip flooding.
+
+    Returns:
+        A list of error messages for any files that failed to process.
+        An empty list means all files succeeded.
+    """
+    errors: List[str] = []
+
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        future_to_file = {}
+        for file in files:
+            mask = _match_mask(file, input_color_pattern, input_mask_pattern)
+            if mask is None:
+                logger.warning("No mask found for %s — skipping.", file)
+                continue
+            file_name = file.replace(input_color_pattern, output_pattern)
+            output = os.path.join(output_dir, Path(file_name).name)
+            future = executor.submit(_mip_flooding_task, file, mask, output)
+            future_to_file[future] = file
+
+        for future in as_completed(future_to_file):
+            source_file = future_to_file[future]
+            try:
+                future.result()
+            except Exception as e:
+                error_msg = f"Failed to process {source_file}: {e}"
+                logger.error(error_msg)
+                errors.append(error_msg)
+
+    return errors

--- a/tools/mipflooding/mipflooding/wrapper/image_format.py
+++ b/tools/mipflooding/mipflooding/wrapper/image_format.py
@@ -1,0 +1,27 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ImageFormat:
+    """
+    A class representing various image formats as attributes.
+    This class can be used to access standardized strings representing
+    image formats, which can be used for image processing, loading,
+    saving, or any related tasks.
+
+    Attributes:
+    JPG (str): Joint Photographic Experts Group, a commonly used method of lossy compression for digital images.
+    JPEG (str): Joint Photographic Experts Group, a commonly used method of lossy compression for digital images.
+    PNG (str): Portable Network Graphics, a raster-graphics file-format that supports lossless data compression.
+    TIFF (str): Tagged Image File Format, a file format for storing raster graphics images.
+    BMP (str): Bitmap image file format.
+    GIF (str): Graphics Interchange Format, a bitmap image format.
+    Default (None): An attribute to handle unspecified or unknown formats.
+    """
+    JPG: str = "JPG"
+    JPEG: str = "JPEG"
+    PNG: str = "PNG"
+    TIFF: str = "TIFF"
+    BMP: str = "BMP"
+    GIF: str = "GIF"
+    Default: None = None

--- a/tools/mipflooding/mipflooding/wrapper/image_processing.py
+++ b/tools/mipflooding/mipflooding/wrapper/image_processing.py
@@ -1,0 +1,27 @@
+from ..bin.loader import mip_flooding
+from . import image_format as imgf
+
+
+def run_mip_flooding(
+    color_path: str,
+    mask_path: str,
+    output_path: str,
+    img_format: str = imgf.ImageFormat.PNG,
+    recomposite_mip0: bool = True,
+) -> None:
+    """
+    Perform Mipmap Flooding on input color and mask textures to optimize for disk storage.
+
+    Args:
+        color_path: The absolute path to the color texture image.
+        mask_path: The absolute path to the mask texture image.
+        output_path: The absolute path for the output image.
+        img_format: The image format of the output image, use ImageFormat to call supported formats.
+        recomposite_mip0: If True (default), composite the original Mip0 color back on top
+            of the mip-flooded result to preserve full texture fidelity in opaque regions.
+
+    Example:
+        run_mip_flooding('input_color.png', 'input_mask.png', 'output_texture.png', ImageFormat.PNG)
+    """
+    mip_flooding.RunMipFlooding(color_path, mask_path, output_path, img_format, recomposite_mip0)
+


### PR DESCRIPTION
… material support

- SetLodScreenSizes: use Modify()+MarkPackageDirty() instead of PostEditChange() which destroyed RenderData
- ImportTexture: read Source.GetSizeX() instead of GetSizeX() (async init returns 32x32 placeholder)
- DeleteAsset: ResetTransaction + UnloadPackages + CollectGarbage to fully purge ghost objects
- SetMeshProperties: add material_path (all slots) and per-slot material assignment
- Bridge: add import_lod to ticker commands to prevent recursion crash
- Add mipflooding tool and asset deletion research docs