### PR TITLE
feat(editor): add profiling tools + PIE control commands

### DIFF
--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Editor/GetMeshDrawStatsCommand.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Editor/GetMeshDrawStatsCommand.cpp
@@ -1,0 +1,240 @@
+#include "Commands/Editor/GetMeshDrawStatsCommand.h"
+#include "Dom/JsonObject.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonWriter.h"
+#include "Engine/Engine.h"
+#include "Editor.h"
+#include "HAL/FileManager.h"
+#include "Misc/FileHelper.h"
+#include "Misc/Paths.h"
+
+FString FGetMeshDrawStatsCommand::GetCommandName() const
+{
+	return TEXT("get_mesh_draw_stats");
+}
+
+bool FGetMeshDrawStatsCommand::ValidateParams(const FString& Parameters) const
+{
+	return true;
+}
+
+FString FGetMeshDrawStatsCommand::Execute(const FString& Parameters)
+{
+	TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
+
+	// Parse optional mesh_filter parameter
+	TSharedPtr<FJsonObject> Params;
+	TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Parameters);
+	FJsonSerializer::Deserialize(Reader, Params);
+
+	FString MeshFilter;
+	if (Params.IsValid())
+	{
+		Params->TryGetStringField(TEXT("mesh_filter"), MeshFilter);
+	}
+
+	// Trigger dump: r.MeshDrawCommands.DumpStats requests stats collection
+	// for the next rendered frame, then writes CSV at end of that frame.
+	if (GEngine)
+	{
+		UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+		GEngine->Exec(World, TEXT("r.MeshDrawCommands.DumpStats"));
+	}
+
+	// Find CSV files in Saved/Profiling/
+	FString ProfilingDir = FPaths::ProfilingDir();
+	TArray<FString> FoundFiles;
+	IFileManager::Get().FindFiles(
+		FoundFiles,
+		*FPaths::Combine(ProfilingDir, TEXT("MeshDrawCommandStats*.csv")),
+		true, false);
+
+	if (FoundFiles.Num() == 0)
+	{
+		// No CSV yet — stats collection was just requested
+		Result->SetBoolField(TEXT("success"), true);
+		Result->SetBoolField(TEXT("stats_pending"), true);
+		Result->SetStringField(TEXT("message"),
+			TEXT("Mesh draw stats dump requested. Call again after one rendered frame for data."));
+
+		FString Out;
+		TSharedRef<TJsonWriter<>> W = TJsonWriterFactory<>::Create(&Out);
+		FJsonSerializer::Serialize(Result.ToSharedRef(), W);
+		return Out;
+	}
+
+	// Sort to find most recent file
+	FoundFiles.Sort();
+	FString LatestCSV = FPaths::Combine(ProfilingDir, FoundFiles.Last());
+
+	// Parse CSV
+	FString CSVContent;
+	if (!FFileHelper::LoadFileToString(CSVContent, *LatestCSV))
+	{
+		Result->SetBoolField(TEXT("success"), false);
+		Result->SetStringField(TEXT("error"),
+			FString::Printf(TEXT("Failed to read CSV: %s"), *LatestCSV));
+
+		FString Out;
+		TSharedRef<TJsonWriter<>> W = TJsonWriterFactory<>::Create(&Out);
+		FJsonSerializer::Serialize(Result.ToSharedRef(), W);
+		return Out;
+	}
+
+	// CSV header (from UE 5.7 MeshDrawCommandStats.cpp):
+	// Pass, VisiblePrimitiveCount, VisibleVertices, VisibleInstances,
+	// Category, ResourceName, LODIndex, SegmentIndex, MaterialName,
+	// PrimitiveCount, VertexCount, TotalInstanceCount, TotalPrimitiveCount, TotalVertexCount
+	TArray<FString> Lines;
+	CSVContent.ParseIntoArrayLines(Lines);
+
+	if (Lines.Num() < 2)
+	{
+		Result->SetBoolField(TEXT("success"), true);
+		Result->SetBoolField(TEXT("stats_pending"), true);
+		Result->SetStringField(TEXT("message"),
+			TEXT("CSV is empty — stats not yet collected. Call again after one rendered frame."));
+
+		FString Out;
+		TSharedRef<TJsonWriter<>> W = TJsonWriterFactory<>::Create(&Out);
+		FJsonSerializer::Serialize(Result.ToSharedRef(), W);
+		return Out;
+	}
+
+	// Parse header to find column indices dynamically
+	TArray<FString> Headers;
+	Lines[0].ParseIntoArray(Headers, TEXT(","), false);
+
+	auto FindCol = [&Headers](const FString& Name) -> int32 {
+		return Headers.IndexOfByPredicate([&Name](const FString& S) {
+			return S.TrimStartAndEnd().Equals(Name, ESearchCase::IgnoreCase);
+		});
+	};
+
+	int32 ColPass = FindCol(TEXT("Pass"));
+	int32 ColVisPrim = FindCol(TEXT("VisiblePrimitiveCount"));
+	int32 ColVisVert = FindCol(TEXT("VisibleVertices"));
+	int32 ColVisInst = FindCol(TEXT("VisibleInstances"));
+	int32 ColCategory = FindCol(TEXT("Category"));
+	int32 ColResource = FindCol(TEXT("ResourceName"));
+	int32 ColLOD = FindCol(TEXT("LODIndex"));
+	int32 ColSegment = FindCol(TEXT("SegmentIndex"));
+	int32 ColMaterial = FindCol(TEXT("MaterialName"));
+	int32 ColTotalInst = FindCol(TEXT("TotalInstanceCount"));
+	int32 ColTotalPrim = FindCol(TEXT("TotalPrimitiveCount"));
+	int32 ColTotalVert = FindCol(TEXT("TotalVertexCount"));
+
+	// Parse data rows
+	struct FEntry
+	{
+		FString Pass, Resource, Category, Material;
+		int64 VisiblePrimitives = 0, VisibleVertices = 0, VisibleInstances = 0;
+		int32 LODIndex = 0, SegmentIndex = 0;
+		int64 TotalInstances = 0, TotalPrimitives = 0, TotalVertices = 0;
+	};
+	TArray<FEntry> Entries;
+
+	auto GetCol = [](const TArray<FString>& Cols, int32 Idx) -> FString {
+		return (Idx >= 0 && Idx < Cols.Num()) ? Cols[Idx].TrimStartAndEnd() : TEXT("");
+	};
+	auto GetColInt = [&GetCol](const TArray<FString>& Cols, int32 Idx) -> int64 {
+		FString Val = GetCol(Cols, Idx);
+		return Val.IsEmpty() ? 0 : FCString::Atoi64(*Val);
+	};
+
+	for (int32 i = 1; i < Lines.Num(); ++i)
+	{
+		if (Lines[i].TrimStartAndEnd().IsEmpty()) continue;
+
+		TArray<FString> Cols;
+		Lines[i].ParseIntoArray(Cols, TEXT(","), false);
+		if (Cols.Num() < 2) continue;
+
+		FString Resource = GetCol(Cols, ColResource);
+
+		// Apply mesh filter
+		if (!MeshFilter.IsEmpty() &&
+			!Resource.Contains(MeshFilter, ESearchCase::IgnoreCase))
+		{
+			continue;
+		}
+
+		FEntry E;
+		E.Pass = GetCol(Cols, ColPass);
+		E.Resource = Resource;
+		E.Category = GetCol(Cols, ColCategory);
+		E.Material = GetCol(Cols, ColMaterial);
+		E.VisiblePrimitives = GetColInt(Cols, ColVisPrim);
+		E.VisibleVertices = GetColInt(Cols, ColVisVert);
+		E.VisibleInstances = GetColInt(Cols, ColVisInst);
+		E.LODIndex = (int32)GetColInt(Cols, ColLOD);
+		E.SegmentIndex = (int32)GetColInt(Cols, ColSegment);
+		E.TotalInstances = GetColInt(Cols, ColTotalInst);
+		E.TotalPrimitives = GetColInt(Cols, ColTotalPrim);
+		E.TotalVertices = GetColInt(Cols, ColTotalVert);
+		Entries.Add(MoveTemp(E));
+	}
+
+	// Sort by visible primitives descending
+	Entries.Sort([](const FEntry& A, const FEntry& B) {
+		return A.VisiblePrimitives > B.VisiblePrimitives;
+	});
+
+	// Build JSON (limit to top 100)
+	TArray<TSharedPtr<FJsonValue>> JsonEntries;
+	int32 Limit = FMath::Min(100, Entries.Num());
+	for (int32 i = 0; i < Limit; ++i)
+	{
+		const FEntry& E = Entries[i];
+		TSharedPtr<FJsonObject> Obj = MakeShared<FJsonObject>();
+		Obj->SetStringField(TEXT("pass"), E.Pass);
+		Obj->SetStringField(TEXT("resource"), E.Resource);
+		Obj->SetStringField(TEXT("category"), E.Category);
+		if (!E.Material.IsEmpty())
+			Obj->SetStringField(TEXT("material"), E.Material);
+		Obj->SetNumberField(TEXT("visible_primitives"), (double)E.VisiblePrimitives);
+		Obj->SetNumberField(TEXT("visible_vertices"), (double)E.VisibleVertices);
+		Obj->SetNumberField(TEXT("visible_instances"), (double)E.VisibleInstances);
+		Obj->SetNumberField(TEXT("lod_index"), E.LODIndex);
+		Obj->SetNumberField(TEXT("total_instances"), (double)E.TotalInstances);
+		Obj->SetNumberField(TEXT("total_primitives"), (double)E.TotalPrimitives);
+		Obj->SetNumberField(TEXT("total_vertices"), (double)E.TotalVertices);
+		JsonEntries.Add(MakeShared<FJsonValueObject>(Obj));
+	}
+
+	// Totals
+	int64 TotalVisPrim = 0, TotalVisVert = 0, TotalVisInst = 0;
+	for (const FEntry& E : Entries)
+	{
+		TotalVisPrim += E.VisiblePrimitives;
+		TotalVisVert += E.VisibleVertices;
+		TotalVisInst += E.VisibleInstances;
+	}
+
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetArrayField(TEXT("entries"), JsonEntries);
+	Result->SetNumberField(TEXT("total_entries"), Entries.Num());
+	Result->SetNumberField(TEXT("shown_entries"), JsonEntries.Num());
+	Result->SetNumberField(TEXT("total_visible_primitives"), (double)TotalVisPrim);
+	Result->SetNumberField(TEXT("total_visible_vertices"), (double)TotalVisVert);
+	Result->SetNumberField(TEXT("total_visible_instances"), (double)TotalVisInst);
+	Result->SetStringField(TEXT("csv_file"), LatestCSV);
+
+	if (!MeshFilter.IsEmpty())
+		Result->SetStringField(TEXT("mesh_filter"), MeshFilter);
+
+	Result->SetStringField(TEXT("message"), FString::Printf(
+		TEXT("%d entries (%d shown), %lld visible primitives, %lld visible vertices, %lld visible instances"),
+		Entries.Num(), JsonEntries.Num(), TotalVisPrim, TotalVisVert, TotalVisInst));
+
+	// Clean up old CSV files (keep only the latest)
+	for (int32 i = 0; i < FoundFiles.Num() - 1; ++i)
+	{
+		IFileManager::Get().Delete(*FPaths::Combine(ProfilingDir, FoundFiles[i]));
+	}
+
+	FString Out;
+	TSharedRef<TJsonWriter<>> W = TJsonWriterFactory<>::Create(&Out);
+	FJsonSerializer::Serialize(Result.ToSharedRef(), W);
+	return Out;
+}

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Editor/GetRenderingStatsCommand.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Editor/GetRenderingStatsCommand.cpp
@@ -7,6 +7,11 @@
 #include "RHI.h"
 #include "Engine/Engine.h"
 
+#if STATS
+#include "Stats/StatsData.h"
+#include "Stats/Stats.h"
+#endif
+
 FString FGetRenderingStatsCommand::Execute(const FString& Parameters)
 {
 	TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
@@ -21,7 +26,12 @@ FString FGetRenderingStatsCommand::Execute(const FString& Parameters)
 	Result->SetNumberField(TEXT("gpu_time_ms"), FPlatformTime::ToMilliseconds(GPUCycles));
 
 	// === Draw Call Categories ===
-#if HAS_GPU_STATS
+#if RHI_NEW_GPU_PROFILER
+	// UE 5.7+ new GPU profiler: per-category draw call breakdown not available via legacy FRHIDrawStatsCategory API
+	Result->SetArrayField(TEXT("draw_call_categories"), TArray<TSharedPtr<FJsonValue>>());
+	Result->SetStringField(TEXT("draw_call_categories_note"),
+		TEXT("Per-category breakdown unavailable in UE 5.7+ (RHI_NEW_GPU_PROFILER). Use get_gpu_stats for per-pass GPU timing."));
+#elif HAS_GPU_STATS
 	{
 		TArray<TSharedPtr<FJsonValue>> CategoriesArray;
 		FRHIDrawStatsCategory::FManager& Manager = FRHIDrawStatsCategory::GetManager();
@@ -36,7 +46,6 @@ FString FGetRenderingStatsCommand::Execute(const FString& Parameters)
 			CategoriesArray.Add(MakeShared<FJsonValueObject>(CatObj));
 		}
 
-		// Sort by draw calls descending
 		CategoriesArray.Sort([](const TSharedPtr<FJsonValue>& A, const TSharedPtr<FJsonValue>& B)
 		{
 			return A->AsObject()->GetNumberField(TEXT("draw_calls")) > B->AsObject()->GetNumberField(TEXT("draw_calls"));
@@ -65,13 +74,74 @@ FString FGetRenderingStatsCommand::Execute(const FString& Parameters)
 		Result->SetObjectField(TEXT("vram"), VramObj);
 	}
 
+	// === Visibility / InitViews Stats ===
+#if STATS
+	{
+		TSharedPtr<FJsonObject> VisObj = MakeShared<FJsonObject>();
+		FGameThreadStatsData* ViewData = FLatestGameThreadStatsData::Get().Latest;
+		if (!ViewData)
+		{
+			// Auto-enable stat initviews if not active
+			if (GEngine)
+			{
+				UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+				GEngine->Exec(World, TEXT("stat initviews"));
+			}
+			VisObj->SetBoolField(TEXT("just_enabled"), true);
+			VisObj->SetStringField(TEXT("note"), TEXT("InitViews stats enabled. Call again for visibility data."));
+		}
+		else
+		{
+			// Use short FNames (GetShortName() returns these) — NOT GET_STATFNAME() which returns long encoded paths
+			struct FStatMapping
+			{
+				FName StatName;
+				const TCHAR* JsonKey;
+			};
+			const FStatMapping Mappings[] = {
+				{ FName(TEXT("STAT_ProcessedPrimitives")),          TEXT("processed_primitives") },
+				{ FName(TEXT("STAT_CulledPrimitives")),             TEXT("frustum_culled_primitives") },
+				{ FName(TEXT("STAT_OccludedPrimitives")),           TEXT("occluded_primitives") },
+				{ FName(TEXT("STAT_StaticallyOccludedPrimitives")), TEXT("statically_occluded") },
+				{ FName(TEXT("STAT_VisibleStaticMeshElements")),    TEXT("visible_static_mesh_elements") },
+				{ FName(TEXT("STAT_VisibleDynamicPrimitives")),     TEXT("visible_dynamic_primitives") },
+				{ FName(TEXT("STAT_OcclusionQueries")),             TEXT("occlusion_queries") },
+			};
+
+			// Collect counter values — stored as double in stats system, read via GetValue_double
+			TMap<FName, double> StatValues;
+			for (int32 GroupIdx = 0; GroupIdx < ViewData->ActiveStatGroups.Num(); ++GroupIdx)
+			{
+				const FActiveStatGroupInfo& StatGroup = ViewData->ActiveStatGroups[GroupIdx];
+				for (const FComplexStatMessage& Message : StatGroup.CountersAggregate)
+				{
+					FName ShortName = Message.GetShortName();
+					ShortName.SetNumber(0);
+					double Value = Message.GetValue_double(EComplexStatField::IncAve);
+					StatValues.Add(ShortName, Value);
+				}
+			}
+
+			// Extract the specific stats we care about
+			for (const FStatMapping& M : Mappings)
+			{
+				double* Found = StatValues.Find(M.StatName);
+				VisObj->SetNumberField(M.JsonKey, Found ? FMath::RoundToInt(*Found) : 0.0);
+			}
+		}
+		Result->SetObjectField(TEXT("visibility"), VisObj);
+	}
+#endif
+
 	// === Summary ===
 	FString Summary = FString::Printf(
 		TEXT("Draw calls: %d, Tris: %d, GPU: %.1fms"),
 		GNumDrawCallsRHI[0], GNumPrimitivesDrawnRHI[0],
 		FPlatformTime::ToMilliseconds(GPUCycles));
 
-#if HAS_GPU_STATS
+#if RHI_NEW_GPU_PROFILER
+	// No per-category breakdown available in UE 5.7+
+#elif HAS_GPU_STATS
 	{
 		FRHIDrawStatsCategory::FManager& Manager = FRHIDrawStatsCategory::GetManager();
 		Summary += TEXT(" | Categories: ");

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Editor/StartPIECommand.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Editor/StartPIECommand.cpp
@@ -1,0 +1,66 @@
+#include "Commands/Editor/StartPIECommand.h"
+#include "Dom/JsonObject.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonWriter.h"
+#include "Editor.h"
+#include "Editor/UnrealEdEngine.h"
+#include "UnrealEdGlobals.h"
+#include "LevelEditor.h"
+#include "IAssetViewport.h"
+#include "PlayInEditorDataTypes.h"
+
+FString FStartPIECommand::Execute(const FString& Parameters)
+{
+	TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
+
+	if (!GUnrealEd)
+	{
+		Result->SetBoolField(TEXT("success"), false);
+		Result->SetStringField(TEXT("error"), TEXT("GUnrealEd is null"));
+		FString Out;
+		TSharedRef<TJsonWriter<>> W = TJsonWriterFactory<>::Create(&Out);
+		FJsonSerializer::Serialize(Result.ToSharedRef(), W);
+		return Out;
+	}
+
+	if (GUnrealEd->IsPlaySessionInProgress())
+	{
+		Result->SetBoolField(TEXT("success"), true);
+		Result->SetBoolField(TEXT("already_running"), true);
+		Result->SetStringField(TEXT("message"), TEXT("PIE session already in progress"));
+		FString Out;
+		TSharedRef<TJsonWriter<>> W = TJsonWriterFactory<>::Create(&Out);
+		FJsonSerializer::Serialize(Result.ToSharedRef(), W);
+		return Out;
+	}
+
+	FLevelEditorModule& LevelEditorModule = FModuleManager::GetModuleChecked<FLevelEditorModule>("LevelEditor");
+	TSharedPtr<IAssetViewport> ActiveViewport = LevelEditorModule.GetFirstActiveViewport();
+
+	if (!ActiveViewport.IsValid())
+	{
+		Result->SetBoolField(TEXT("success"), false);
+		Result->SetStringField(TEXT("error"), TEXT("No active level viewport found"));
+		FString Out;
+		TSharedRef<TJsonWriter<>> W = TJsonWriterFactory<>::Create(&Out);
+		FJsonSerializer::Serialize(Result.ToSharedRef(), W);
+		return Out;
+	}
+
+	FRequestPlaySessionParams Params;
+	Params.WorldType = EPlaySessionWorldType::PlayInEditor;
+	Params.DestinationSlateViewport = ActiveViewport;
+
+	GUnrealEd->RequestPlaySession(Params);
+
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("message"), TEXT("PIE session requested (starts next tick)"));
+
+	FString Out;
+	TSharedRef<TJsonWriter<>> W = TJsonWriterFactory<>::Create(&Out);
+	FJsonSerializer::Serialize(Result.ToSharedRef(), W);
+	return Out;
+}
+
+FString FStartPIECommand::GetCommandName() const { return TEXT("start_pie"); }
+bool FStartPIECommand::ValidateParams(const FString& Parameters) const { return true; }

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Editor/StopPIECommand.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Editor/StopPIECommand.cpp
@@ -1,0 +1,46 @@
+#include "Commands/Editor/StopPIECommand.h"
+#include "Dom/JsonObject.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonWriter.h"
+#include "Editor.h"
+#include "Editor/UnrealEdEngine.h"
+#include "UnrealEdGlobals.h"
+
+FString FStopPIECommand::Execute(const FString& Parameters)
+{
+	TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
+
+	if (!GUnrealEd)
+	{
+		Result->SetBoolField(TEXT("success"), false);
+		Result->SetStringField(TEXT("error"), TEXT("GUnrealEd is null"));
+		FString Out;
+		TSharedRef<TJsonWriter<>> W = TJsonWriterFactory<>::Create(&Out);
+		FJsonSerializer::Serialize(Result.ToSharedRef(), W);
+		return Out;
+	}
+
+	if (!GUnrealEd->IsPlaySessionInProgress())
+	{
+		Result->SetBoolField(TEXT("success"), true);
+		Result->SetBoolField(TEXT("already_stopped"), true);
+		Result->SetStringField(TEXT("message"), TEXT("No PIE session is running"));
+		FString Out;
+		TSharedRef<TJsonWriter<>> W = TJsonWriterFactory<>::Create(&Out);
+		FJsonSerializer::Serialize(Result.ToSharedRef(), W);
+		return Out;
+	}
+
+	GUnrealEd->RequestEndPlayMap();
+
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("message"), TEXT("PIE session end requested"));
+
+	FString Out;
+	TSharedRef<TJsonWriter<>> W = TJsonWriterFactory<>::Create(&Out);
+	FJsonSerializer::Serialize(Result.ToSharedRef(), W);
+	return Out;
+}
+
+FString FStopPIECommand::GetCommandName() const { return TEXT("stop_pie"); }
+bool FStopPIECommand::ValidateParams(const FString& Parameters) const { return true; }

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EditorCommandRegistration.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EditorCommandRegistration.cpp
@@ -21,6 +21,9 @@
 #include "Commands/Editor/GetGPUStatsCommand.h"
 #include "Commands/Editor/GetSceneBreakdownCommand.h"
 #include "Commands/Editor/GetRenderingStatsCommand.h"
+#include "Commands/Editor/GetMeshDrawStatsCommand.h"
+#include "Commands/Editor/StartPIECommand.h"
+#include "Commands/Editor/StopPIECommand.h"
 
 TArray<TSharedPtr<IUnrealMCPCommand>> FEditorCommandRegistration::RegisteredCommands;
 
@@ -58,6 +61,9 @@ void FEditorCommandRegistration::RegisterAllCommands()
     RegisterAndTrackCommand(MakeShared<FGetGPUStatsCommand>());
     RegisterAndTrackCommand(MakeShared<FGetSceneBreakdownCommand>());
     RegisterAndTrackCommand(MakeShared<FGetRenderingStatsCommand>());
+    RegisterAndTrackCommand(MakeShared<FGetMeshDrawStatsCommand>());
+    RegisterAndTrackCommand(MakeShared<FStartPIECommand>());
+    RegisterAndTrackCommand(MakeShared<FStopPIECommand>());
 
     // Note: Additional editor commands are handled by legacy command system
     // and will be migrated to the new architecture in future iterations:

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Editor/GetMeshDrawStatsCommand.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Editor/GetMeshDrawStatsCommand.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Commands/IUnrealMCPCommand.h"
+
+/**
+ * Per-mesh draw count breakdown per render pass.
+ * Triggers r.MeshDrawCommands.DumpStats CSV and parses results.
+ */
+class UNREALMCP_API FGetMeshDrawStatsCommand : public IUnrealMCPCommand
+{
+public:
+	FGetMeshDrawStatsCommand() = default;
+	virtual FString Execute(const FString& Parameters) override;
+	virtual FString GetCommandName() const override;
+	virtual bool ValidateParams(const FString& Parameters) const override;
+};

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Editor/StartPIECommand.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Editor/StartPIECommand.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Commands/IUnrealMCPCommand.h"
+
+/**
+ * Start a Play In Editor (PIE) session.
+ * Queues session start for the next engine tick.
+ */
+class UNREALMCP_API FStartPIECommand : public IUnrealMCPCommand
+{
+public:
+	FStartPIECommand() = default;
+	virtual FString Execute(const FString& Parameters) override;
+	virtual FString GetCommandName() const override;
+	virtual bool ValidateParams(const FString& Parameters) const override;
+};

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Editor/StopPIECommand.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Editor/StopPIECommand.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Commands/IUnrealMCPCommand.h"
+
+/**
+ * Stop the current Play In Editor (PIE) session.
+ */
+class UNREALMCP_API FStopPIECommand : public IUnrealMCPCommand
+{
+public:
+	FStopPIECommand() = default;
+	virtual FString Execute(const FString& Parameters) override;
+	virtual FString GetCommandName() const override;
+	virtual bool ValidateParams(const FString& Parameters) const override;
+};

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/UnrealMCP.Build.cs
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/UnrealMCP.Build.cs
@@ -139,7 +139,9 @@ public class UnrealMCP : ModuleRules
 					// PCG (Procedural Content Generation) support
 					"PCG",                     // Core PCG runtime (graphs, nodes, elements)
 					// Static Mesh editor support (LOD management)
-					"StaticMeshEditor"         // UStaticMeshEditorSubsystem
+					"StaticMeshEditor",        // UStaticMeshEditorSubsystem
+					// PIE (Play In Editor) control
+					"LevelEditor"              // FLevelEditorModule for PIE viewport access
 				}
 			);
 		}

--- a/Python/editor_tools/editor_tools.py
+++ b/Python/editor_tools/editor_tools.py
@@ -905,25 +905,101 @@ def register_editor_tools(mcp: FastMCP):
     @mcp.tool()
     def get_rendering_stats(ctx: Context) -> Dict[str, Any]:
         """
-        Get focused rendering diagnostics: draw call categories, VRAM, key counters.
+        Get focused rendering diagnostics: draw call categories, VRAM, visibility/culling stats.
 
         Complements get_gpu_stats (GPU pass timing) and get_scene_breakdown (mesh instances).
-        Shows per-category draw call breakdown (shadow, basepass, translucency, etc.),
-        VRAM usage, and total draw calls / triangles.
+        Shows VRAM usage, total draw calls / triangles, and initviews visibility data.
 
         Returns:
             Dictionary containing:
             - draw_calls: Total draw calls
             - primitives_drawn: Total triangles
             - gpu_time_ms: GPU frame time
-            - draw_call_categories: Array of {name, draw_calls} sorted by cost
-            - vram: {dedicated_vram_mb, budget_mb, allocated_mb, streaming_mb}
+            - draw_call_categories: Array (empty in UE 5.7+ due to RHI_NEW_GPU_PROFILER)
+            - visibility: Culling/visibility stats (auto-enabled on first call):
+                - processed_primitives: Total primitives processed
+                - frustum_culled_primitives: Primitives culled by frustum
+                - occluded_primitives: Primitives culled by occlusion
+                - statically_occluded: Statically occluded primitives
+                - visible_static_mesh_elements: Visible static mesh draw elements
+                - visible_dynamic_primitives: Visible dynamic primitives
+                - occlusion_queries: Number of occlusion queries
+            - vram: {dedicated_vram_mb, budget_mb, streaming_mb, non_streaming_mb}
             - message: Human-readable summary
 
         Example:
             get_rendering_stats()
         """
         return send_unreal_command("get_rendering_stats", {})
+
+    @mcp.tool()
+    def get_mesh_draw_stats(ctx: Context, mesh_filter: str = None) -> Dict[str, Any]:
+        """
+        Get per-mesh draw count breakdown per render pass.
+
+        Triggers mesh draw command stats dump and returns per-resource/material
+        breakdown showing how many primitives, vertices, and instances each mesh
+        contributes to each render pass (BasePass, ShadowDepths, etc.).
+
+        First call triggers stats collection. Call again after one rendered frame for data.
+
+        Args:
+            mesh_filter: Optional filter by mesh/resource name (case-insensitive contains)
+
+        Returns:
+            Dictionary containing:
+            - entries: Array of {pass, resource, category, material, visible_primitives,
+              visible_vertices, visible_instances, lod_index, total_instances,
+              total_primitives, total_vertices}
+            - total_entries: Total CSV rows (after filter)
+            - shown_entries: Entries returned (max 100)
+            - total_visible_primitives/vertices/instances: Aggregated totals
+            - mesh_filter: Applied filter (if any)
+            - message: Human-readable summary
+
+        Example:
+            get_mesh_draw_stats()
+            get_mesh_draw_stats(mesh_filter="Grass")
+        """
+        params = {}
+        if mesh_filter:
+            params["mesh_filter"] = mesh_filter
+        return send_unreal_command("get_mesh_draw_stats", params)
+
+    @mcp.tool()
+    def start_pie(ctx: Context) -> Dict[str, Any]:
+        """
+        Start a Play In Editor (PIE) session.
+
+        Queues PIE start for the next engine tick. The session begins
+        asynchronously — it won't be active the instant this returns.
+
+        Returns:
+            Dictionary containing:
+            - success: Whether the request was accepted
+            - already_running: True if PIE was already active
+            - message: Status message
+
+        Example:
+            start_pie()
+        """
+        return send_unreal_command("start_pie", {})
+
+    @mcp.tool()
+    def stop_pie(ctx: Context) -> Dict[str, Any]:
+        """
+        Stop the current Play In Editor (PIE) session.
+
+        Returns:
+            Dictionary containing:
+            - success: Whether the request was accepted
+            - already_stopped: True if no PIE session was running
+            - message: Status message
+
+        Example:
+            stop_pie()
+        """
+        return send_unreal_command("stop_pie", {})
 
     # Register all tools with the help system
     _help_registry.register(spawn_actor, category="actors")
@@ -946,5 +1022,8 @@ def register_editor_tools(mcp: FastMCP):
     _help_registry.register(get_gpu_stats, category="profiling")
     _help_registry.register(get_scene_breakdown, category="profiling")
     _help_registry.register(get_rendering_stats, category="profiling")
+    _help_registry.register(get_mesh_draw_stats, category="profiling")
+    _help_registry.register(start_pie, category="profiling")
+    _help_registry.register(stop_pie, category="profiling")
 
     logger.info("Editor tools registered successfully")


### PR DESCRIPTION
- get_rendering_stats: fix empty draw_call_categories (RHI_NEW_GPU_PROFILER guard), add visibility/initviews stats (processed/culled/occluded primitives)
- get_mesh_draw_stats: new tool - per-mesh draw counts per render pass via r.MeshDrawCommands.DumpStats CSV parsing with mesh_filter support
- start_pie / stop_pie: programmatic PIE session control via GUnrealEd->RequestPlaySession/RequestEndPlayMap
- LevelEditor module dependency added for PIE viewport access