### PR TITLE
feat(editor): add create_level + set_level_world_settings commands

### DIFF
--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Editor/CreateLevelCommand.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Editor/CreateLevelCommand.cpp
@@ -1,0 +1,115 @@
+#include "Commands/Editor/CreateLevelCommand.h"
+
+#include "Dom/JsonObject.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonWriter.h"
+#include "Editor.h"
+#include "LevelEditorSubsystem.h"
+
+namespace
+{
+	FString MakeErr(const FString& Msg)
+	{
+		TSharedPtr<FJsonObject> Obj = MakeShared<FJsonObject>();
+		Obj->SetBoolField(TEXT("success"), false);
+		Obj->SetStringField(TEXT("error"), Msg);
+		FString Out;
+		TSharedRef<TJsonWriter<>> W = TJsonWriterFactory<>::Create(&Out);
+		FJsonSerializer::Serialize(Obj.ToSharedRef(), W);
+		return Out;
+	}
+}
+
+FString FCreateLevelCommand::Execute(const FString& Parameters)
+{
+	TSharedPtr<FJsonObject> JsonObject;
+	TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Parameters);
+	if (!FJsonSerializer::Deserialize(Reader, JsonObject) || !JsonObject.IsValid())
+	{
+		return MakeErr(TEXT("Invalid JSON parameters"));
+	}
+
+	FString LevelName;
+	FString SavePath;
+	FString Template;
+	JsonObject->TryGetStringField(TEXT("template"), Template);
+
+	if (!JsonObject->TryGetStringField(TEXT("level_name"), LevelName) || LevelName.IsEmpty())
+	{
+		return MakeErr(TEXT("Missing 'level_name' parameter"));
+	}
+	if (!JsonObject->TryGetStringField(TEXT("save_path"), SavePath) || SavePath.IsEmpty())
+	{
+		return MakeErr(TEXT("Missing 'save_path' parameter"));
+	}
+
+	// Normalize: ensure save_path starts with /Game and does not end with /
+	if (!SavePath.StartsWith(TEXT("/Game")))
+	{
+		return MakeErr(TEXT("'save_path' must start with /Game"));
+	}
+	SavePath.RemoveFromEnd(TEXT("/"));
+	const FString FullPath = FString::Printf(TEXT("%s/%s"), *SavePath, *LevelName);
+
+	if (!GEditor)
+	{
+		return MakeErr(TEXT("GEditor is null — command requires editor context"));
+	}
+
+	ULevelEditorSubsystem* LES = GEditor->GetEditorSubsystem<ULevelEditorSubsystem>();
+	if (!LES)
+	{
+		return MakeErr(TEXT("ULevelEditorSubsystem unavailable"));
+	}
+
+	bool bOk = false;
+	if (Template.IsEmpty())
+	{
+		bOk = LES->NewLevel(FullPath);
+	}
+	else
+	{
+		bOk = LES->NewLevelFromTemplate(FullPath, Template);
+	}
+
+	if (!bOk)
+	{
+		return MakeErr(FString::Printf(TEXT("Failed to create level at %s (template='%s')"),
+			*FullPath, *Template));
+	}
+
+	// Persist the newly created level
+	const bool bSaved = LES->SaveCurrentLevel();
+	if (!bSaved)
+	{
+		UE_LOG(LogTemp, Warning, TEXT("CreateLevel: level created but SaveCurrentLevel returned false for %s"),
+			*FullPath);
+	}
+
+	TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("level_path"), FullPath);
+	Result->SetStringField(TEXT("template"), Template);
+	Result->SetBoolField(TEXT("saved"), bSaved);
+
+	FString OutString;
+	TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&OutString);
+	FJsonSerializer::Serialize(Result.ToSharedRef(), Writer);
+	return OutString;
+}
+
+FString FCreateLevelCommand::GetCommandName() const
+{
+	return TEXT("create_level");
+}
+
+bool FCreateLevelCommand::ValidateParams(const FString& Parameters) const
+{
+	TSharedPtr<FJsonObject> JsonObject;
+	TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Parameters);
+	if (!FJsonSerializer::Deserialize(Reader, JsonObject) || !JsonObject.IsValid()) return false;
+
+	FString LevelName, SavePath;
+	return JsonObject->TryGetStringField(TEXT("level_name"), LevelName) && !LevelName.IsEmpty()
+		&& JsonObject->TryGetStringField(TEXT("save_path"), SavePath) && !SavePath.IsEmpty();
+}

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Editor/SetLevelWorldSettingsCommand.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Editor/SetLevelWorldSettingsCommand.cpp
@@ -1,0 +1,171 @@
+#include "Commands/Editor/SetLevelWorldSettingsCommand.h"
+
+#include "Dom/JsonObject.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonWriter.h"
+#include "Editor.h"
+#include "Engine/World.h"
+#include "GameFramework/GameModeBase.h"
+#include "GameFramework/WorldSettings.h"
+#include "LevelEditorSubsystem.h"
+
+namespace
+{
+	FString MakeErr(const FString& Msg)
+	{
+		TSharedPtr<FJsonObject> Obj = MakeShared<FJsonObject>();
+		Obj->SetBoolField(TEXT("success"), false);
+		Obj->SetStringField(TEXT("error"), Msg);
+		FString Out;
+		TSharedRef<TJsonWriter<>> W = TJsonWriterFactory<>::Create(&Out);
+		FJsonSerializer::Serialize(Obj.ToSharedRef(), W);
+		return Out;
+	}
+
+	UClass* ResolveGameModeClass(const FString& Path)
+	{
+		if (Path.IsEmpty()) return nullptr;
+
+		// Try direct class load (e.g. /Script/Module.ClassName)
+		if (Path.StartsWith(TEXT("/Script/")))
+		{
+			if (UClass* C = LoadClass<AGameModeBase>(nullptr, *Path)) return C;
+			// Some sources may pass /Script/Module.ClassName without _C — also try LoadObject
+			if (UClass* C2 = LoadObject<UClass>(nullptr, *Path)) return C2;
+			return nullptr;
+		}
+
+		// Blueprint path — append _C if missing for class load
+		FString ClassPath = Path;
+		if (!ClassPath.EndsWith(TEXT("_C")))
+		{
+			// Convert /Game/Path/BP_X to /Game/Path/BP_X.BP_X_C
+			FString PackageName;
+			FString ObjectName = Path;
+			int32 DotIdx;
+			if (Path.FindChar('.', DotIdx))
+			{
+				PackageName = Path.Left(DotIdx);
+				ObjectName = Path.RightChop(DotIdx + 1);
+			}
+			else
+			{
+				int32 SlashIdx;
+				if (Path.FindLastChar('/', SlashIdx))
+				{
+					PackageName = Path;
+					ObjectName = Path.RightChop(SlashIdx + 1);
+				}
+			}
+			ClassPath = FString::Printf(TEXT("%s.%s_C"), *PackageName, *ObjectName);
+		}
+		return LoadClass<AGameModeBase>(nullptr, *ClassPath);
+	}
+}
+
+FString FSetLevelWorldSettingsCommand::Execute(const FString& Parameters)
+{
+	TSharedPtr<FJsonObject> JsonObject;
+	TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Parameters);
+	if (!FJsonSerializer::Deserialize(Reader, JsonObject) || !JsonObject.IsValid())
+	{
+		return MakeErr(TEXT("Invalid JSON parameters"));
+	}
+
+	FString LevelPath;
+	if (!JsonObject->TryGetStringField(TEXT("level_path"), LevelPath) || LevelPath.IsEmpty())
+	{
+		return MakeErr(TEXT("Missing 'level_path' parameter"));
+	}
+
+	FString GameModePath;
+	const bool bHasGameMode = JsonObject->TryGetStringField(TEXT("game_mode"), GameModePath);
+
+	if (!GEditor)
+	{
+		return MakeErr(TEXT("GEditor is null — command requires editor context"));
+	}
+
+	ULevelEditorSubsystem* LES = GEditor->GetEditorSubsystem<ULevelEditorSubsystem>();
+	if (!LES)
+	{
+		return MakeErr(TEXT("ULevelEditorSubsystem unavailable"));
+	}
+
+	if (!LES->LoadLevel(LevelPath))
+	{
+		return MakeErr(FString::Printf(TEXT("Failed to load level at %s"), *LevelPath));
+	}
+
+	UWorld* World = GEditor->GetEditorWorldContext().World();
+	if (!World)
+	{
+		return MakeErr(TEXT("Editor world is null after LoadLevel"));
+	}
+
+	AWorldSettings* WS = World->GetWorldSettings();
+	if (!WS)
+	{
+		return MakeErr(TEXT("WorldSettings is null"));
+	}
+
+	bool bChanged = false;
+	FString ResolvedGameModePath;
+
+	if (bHasGameMode)
+	{
+		if (GameModePath.IsEmpty())
+		{
+			WS->DefaultGameMode = nullptr;
+			bChanged = true;
+		}
+		else
+		{
+			UClass* GMClass = ResolveGameModeClass(GameModePath);
+			if (!GMClass)
+			{
+				return MakeErr(FString::Printf(
+					TEXT("Could not resolve GameMode class from path: %s"), *GameModePath));
+			}
+			WS->DefaultGameMode = GMClass;
+			ResolvedGameModePath = GMClass->GetPathName();
+			bChanged = true;
+		}
+	}
+
+	if (bChanged)
+	{
+		WS->MarkPackageDirty();
+		if (!LES->SaveCurrentLevel())
+		{
+			UE_LOG(LogTemp, Warning, TEXT("SetLevelWorldSettings: SaveCurrentLevel returned false for %s"),
+				*LevelPath);
+		}
+	}
+
+	TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("level_path"), LevelPath);
+	Result->SetStringField(TEXT("game_mode_resolved"), ResolvedGameModePath);
+	Result->SetBoolField(TEXT("changed"), bChanged);
+
+	FString OutString;
+	TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&OutString);
+	FJsonSerializer::Serialize(Result.ToSharedRef(), Writer);
+	return OutString;
+}
+
+FString FSetLevelWorldSettingsCommand::GetCommandName() const
+{
+	return TEXT("set_level_world_settings");
+}
+
+bool FSetLevelWorldSettingsCommand::ValidateParams(const FString& Parameters) const
+{
+	TSharedPtr<FJsonObject> JsonObject;
+	TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Parameters);
+	if (!FJsonSerializer::Deserialize(Reader, JsonObject) || !JsonObject.IsValid()) return false;
+
+	FString LevelPath;
+	return JsonObject->TryGetStringField(TEXT("level_path"), LevelPath) && !LevelPath.IsEmpty();
+}

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EditorCommandRegistration.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EditorCommandRegistration.cpp
@@ -24,6 +24,8 @@
 #include "Commands/Editor/GetMeshDrawStatsCommand.h"
 #include "Commands/Editor/StartPIECommand.h"
 #include "Commands/Editor/StopPIECommand.h"
+#include "Commands/Editor/CreateLevelCommand.h"
+#include "Commands/Editor/SetLevelWorldSettingsCommand.h"
 
 TArray<TSharedPtr<IUnrealMCPCommand>> FEditorCommandRegistration::RegisteredCommands;
 
@@ -64,6 +66,10 @@ void FEditorCommandRegistration::RegisterAllCommands()
     RegisterAndTrackCommand(MakeShared<FGetMeshDrawStatsCommand>());
     RegisterAndTrackCommand(MakeShared<FStartPIECommand>());
     RegisterAndTrackCommand(MakeShared<FStopPIECommand>());
+
+    // Level management commands
+    RegisterAndTrackCommand(MakeShared<FCreateLevelCommand>());
+    RegisterAndTrackCommand(MakeShared<FSetLevelWorldSettingsCommand>());
 
     // Note: Additional editor commands are handled by legacy command system
     // and will be migrated to the new architecture in future iterations:

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Editor/CreateLevelCommand.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Editor/CreateLevelCommand.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Commands/IUnrealMCPCommand.h"
+
+/**
+ * Create a new empty level (umap) at a given content path.
+ *
+ * Params (JSON):
+ *   level_name  (string, required) — name without prefix/suffix, e.g. "TestLevel_Building"
+ *   save_path   (string, required) — folder path, e.g. "/Game/Tests"
+ *   template    (string, optional) — content path to an existing level to clone; empty = blank
+ *
+ * Returns success + the full asset path of the created level.
+ *
+ * Side effect: the newly-created level becomes the active editor world.
+ */
+class UNREALMCP_API FCreateLevelCommand : public IUnrealMCPCommand
+{
+public:
+	FCreateLevelCommand() = default;
+	virtual FString Execute(const FString& Parameters) override;
+	virtual FString GetCommandName() const override;
+	virtual bool ValidateParams(const FString& Parameters) const override;
+};

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Editor/SetLevelWorldSettingsCommand.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Editor/SetLevelWorldSettingsCommand.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Commands/IUnrealMCPCommand.h"
+
+/**
+ * Modify a level's World Settings. Currently supports setting the GameMode override.
+ *
+ * Params (JSON):
+ *   level_path  (string, required) — full asset path, e.g. "/Game/Tests/TestLevel_Building"
+ *   game_mode   (string, optional) — content path to a GameMode (BP or C++ class).
+ *                                    Examples:
+ *                                      "/Game/TopDown/Blueprints/BP_TopDownGameMode"
+ *                                      "/Script/SimPrototype.GameModeMain"
+ *                                    Empty string clears the override.
+ *
+ * Loads the level, modifies WorldSettings, marks dirty, saves. Becomes the active editor level.
+ */
+class UNREALMCP_API FSetLevelWorldSettingsCommand : public IUnrealMCPCommand
+{
+public:
+	FSetLevelWorldSettingsCommand() = default;
+	virtual FString Execute(const FString& Parameters) override;
+	virtual FString GetCommandName() const override;
+	virtual bool ValidateParams(const FString& Parameters) const override;
+};

--- a/Python/editor_tools/editor_tools.py
+++ b/Python/editor_tools/editor_tools.py
@@ -22,7 +22,9 @@ from utils.editor.editor_operations import (
     batch_delete_actors as batch_delete_actors_impl,
     batch_spawn_actors as batch_spawn_actors_impl,
     import_static_mesh as import_static_mesh_impl,
-    import_texture as import_texture_impl
+    import_texture as import_texture_impl,
+    create_level as create_level_impl,
+    set_level_world_settings as set_level_world_settings_impl
 )
 from utils.mcp_help import get_help_registry, get_mcp_help as get_mcp_help_impl
 from utils.unreal_connection_utils import send_unreal_command
@@ -662,6 +664,90 @@ def register_editor_tools(mcp: FastMCP):
             delete_asset(asset_path="/Game/UI/WBP_TestWidget")
         """
         return delete_asset_impl(ctx, asset_path)
+
+    @mcp.tool()
+    def create_level(
+        ctx: Context,
+        level_name: str,
+        save_path: str,
+        template: str = ""
+    ) -> Dict[str, Any]:
+        """
+        Create a new level (umap) at a content path.
+
+        Creates an empty level or clones from a template. The new level becomes the
+        active editor world. Saves the level to disk after creation.
+
+        Args:
+            level_name: Name of the level without extension (e.g., "TestLevel_Building")
+            save_path: Folder path under /Game where the level will be saved (e.g., "/Game/Tests")
+            template: Optional content path to an existing level to clone from.
+                      Empty (default) creates a blank empty level.
+
+        Returns:
+            Dict containing:
+            - success: Whether creation succeeded
+            - level_path: Full asset path of the new level (e.g., "/Game/Tests/TestLevel_Building")
+            - template: The template used (empty if blank)
+            - saved: Whether the initial save succeeded
+
+        Side effect:
+            The newly created level becomes the editor's active world.
+
+        Examples:
+            # Create an empty test level
+            create_level(level_name="TestLevel_Building", save_path="/Game/Tests")
+
+            # Clone from an existing level template
+            create_level(
+                level_name="TestLevel_Combat",
+                save_path="/Game/Tests",
+                template="/Game/Templates/CombatBase"
+            )
+        """
+        return create_level_impl(ctx, level_name, save_path, template)
+
+    @mcp.tool()
+    def set_level_world_settings(
+        ctx: Context,
+        level_path: str,
+        game_mode: str = None
+    ) -> Dict[str, Any]:
+        """
+        Modify a level's World Settings. Currently supports GameMode override.
+
+        Loads the target level, applies changes, saves. Target level becomes the
+        editor's active world after this call.
+
+        Args:
+            level_path: Full asset path of the level (e.g., "/Game/Tests/TestLevel_Building")
+            game_mode: GameMode override class path. Examples:
+                       - "/Game/TopDown/Blueprints/BP_TopDownGameMode" (Blueprint)
+                       - "/Script/SimPrototype.GameModeMain" (C++ class)
+                       - "" (empty string) clears the override (uses project default)
+                       - None (default): leaves GameMode unchanged
+
+        Returns:
+            Dict containing:
+            - success: Whether the operation succeeded
+            - level_path: The level that was modified
+            - game_mode_resolved: Full class path of the resolved GameMode (empty if cleared)
+            - changed: Whether any change was applied
+
+        Examples:
+            # Set a Blueprint GameMode
+            set_level_world_settings(
+                level_path="/Game/Tests/TestLevel_Building",
+                game_mode="/Game/TopDown/Blueprints/BP_TopDownGameMode"
+            )
+
+            # Clear the GameMode override (use project default)
+            set_level_world_settings(
+                level_path="/Game/Tests/TestLevel_Building",
+                game_mode=""
+            )
+        """
+        return set_level_world_settings_impl(ctx, level_path, game_mode)
 
     @mcp.tool()
     def create_render_target(

--- a/Python/utils/editor/editor_operations.py
+++ b/Python/utils/editor/editor_operations.py
@@ -226,6 +226,20 @@ def create_render_target(ctx: Context, name: str, folder_path: str = "/Game", wi
     params = {"name": name, "folder_path": folder_path, "width": width, "height": height}
     return send_unreal_command("create_render_target", params)
 
+def create_level(ctx: Context, level_name: str, save_path: str, template: str = "") -> Dict[str, Any]:
+    """Implementation for creating a new level."""
+    params = {"level_name": level_name, "save_path": save_path}
+    if template:
+        params["template"] = template
+    return send_unreal_command("create_level", params)
+
+def set_level_world_settings(ctx: Context, level_path: str, game_mode: str = None) -> Dict[str, Any]:
+    """Implementation for modifying a level's World Settings (GameMode override)."""
+    params = {"level_path": level_path}
+    if game_mode is not None:
+        params["game_mode"] = game_mode
+    return send_unreal_command("set_level_world_settings", params)
+
 def create_folder(ctx: Context, folder_path: str) -> Dict[str, Any]:
     """Implementation for creating a new folder in the Content Browser."""
     params = {"folder_path": folder_path}


### PR DESCRIPTION
Adds two new MCP tools for level management via ULevelEditorSubsystem:

- create_level(level_name, save_path, template="") — creates new umap, blank or cloned from a template. Saves to disk. Becomes active world.
- set_level_world_settings(level_path, game_mode=None) — loads target level and applies WorldSettings overrides (currently GameMode). Auto-resolves Blueprint paths to *_C suffix for class loading.

Both verified live in SimPrototype editor:
  create_level "/Game/Tests/TestLevel_Building" → success, saved set_level_world_settings → resolved BP_TopDownGameMode_C, changed

Closes a gap discovered during SimPrototype building-system planning: plan 03 needed level creation through MCP and previously had to fall back to manual editor steps.