### PR TITLE
fix(blueprint): get_blueprint_metadata component_properties resolves …

### DIFF
--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Blueprint/BlueprintMetadataBuilderService.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Blueprint/BlueprintMetadataBuilderService.cpp
@@ -290,57 +290,28 @@ TSharedPtr<FJsonObject> FBlueprintMetadataBuilderService::BuildComponentsInfo(UB
     return ComponentsInfo;
 }
 
-TSharedPtr<FJsonObject> FBlueprintMetadataBuilderService::BuildComponentPropertiesInfo(UBlueprint* Blueprint, const FString& ComponentName) const
+TSharedPtr<FJsonObject> FBlueprintMetadataBuilderService::ExtractComponentProperties(UActorComponent* ComponentTemplate) const
 {
-    TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
-
-    if (!Blueprint)
+    TSharedPtr<FJsonObject> PropertiesObj = MakeShared<FJsonObject>();
+    if (!ComponentTemplate)
     {
-        Result->SetStringField(TEXT("error"), TEXT("Invalid Blueprint"));
-        return Result;
+        return PropertiesObj;
     }
 
-    if (ComponentName.IsEmpty())
+    UClass* ComponentClass = ComponentTemplate->GetClass();
+
+    // Iterate through all blueprint-visible properties
+    for (TFieldIterator<FProperty> PropIt(ComponentClass); PropIt; ++PropIt)
     {
-        Result->SetStringField(TEXT("error"), TEXT("component_name parameter is required"));
-        return Result;
-    }
+        FProperty* Property = *PropIt;
+        if (!Property) continue;
 
-    // Get components from Simple Construction Script
-    if (Blueprint->SimpleConstructionScript)
-    {
-        for (USCS_Node* Node : Blueprint->SimpleConstructionScript->GetAllNodes())
-        {
-            if (Node && Node->ComponentTemplate)
-            {
-                FString CurrentName = Node->GetVariableName().ToString();
+        // Only include editable/visible properties
+        if (!Property->HasAnyPropertyFlags(CPF_Edit | CPF_BlueprintVisible))
+            continue;
 
-                // Only process the requested component
-                if (!CurrentName.Equals(ComponentName, ESearchCase::IgnoreCase))
-                {
-                    continue;
-                }
-                TSharedPtr<FJsonObject> CompObj = MakeShared<FJsonObject>();
-                CompObj->SetStringField(TEXT("name"), Node->GetVariableName().ToString());
-                CompObj->SetStringField(TEXT("type"), Node->ComponentTemplate->GetClass()->GetName());
-
-                // Extract properties from the component template
-                TSharedPtr<FJsonObject> PropertiesObj = MakeShared<FJsonObject>();
-                UActorComponent* ComponentTemplate = Node->ComponentTemplate;
-                UClass* ComponentClass = ComponentTemplate->GetClass();
-
-                // Iterate through all blueprint-visible properties
-                for (TFieldIterator<FProperty> PropIt(ComponentClass); PropIt; ++PropIt)
-                {
-                    FProperty* Property = *PropIt;
-                    if (!Property) continue;
-
-                    // Only include editable/visible properties
-                    if (!Property->HasAnyPropertyFlags(CPF_Edit | CPF_BlueprintVisible))
-                        continue;
-
-                    FString PropName = Property->GetName();
-                    void* ValuePtr = Property->ContainerPtrToValuePtr<void>(ComponentTemplate);
+        FString PropName = Property->GetName();
+        void* ValuePtr = Property->ContainerPtrToValuePtr<void>(ComponentTemplate);
 
                     // Handle different property types
                     if (FBoolProperty* BoolProp = CastField<FBoolProperty>(Property))
@@ -517,21 +488,76 @@ TSharedPtr<FJsonObject> FBlueprintMetadataBuilderService::BuildComponentProperti
                                 }
                             }
 
-                            PropertiesObj->SetObjectField(PropName, BodyObj);
-                        }
-                        else
-                        {
-                            // For other struct types, just indicate the type
-                            PropertiesObj->SetStringField(PropName, FString::Printf(TEXT("[Struct:%s]"), *StructProp->Struct->GetName()));
-                        }
-                    }
-                }
+            PropertiesObj->SetObjectField(PropName, BodyObj);
+        }
+        else
+        {
+            // For other struct types, just indicate the type
+            PropertiesObj->SetStringField(PropName, FString::Printf(TEXT("[Struct:%s]"), *StructProp->Struct->GetName()));
+        }
+    }
+    }
 
-                // Found the component - return its properties directly
-                Result->SetStringField(TEXT("name"), CurrentName);
-                Result->SetStringField(TEXT("type"), Node->ComponentTemplate->GetClass()->GetName());
-                Result->SetObjectField(TEXT("properties"), PropertiesObj);
-                return Result;
+    return PropertiesObj;
+}
+
+TSharedPtr<FJsonObject> FBlueprintMetadataBuilderService::BuildComponentPropertiesInfo(UBlueprint* Blueprint, const FString& ComponentName) const
+{
+    TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
+
+    if (!Blueprint)
+    {
+        Result->SetStringField(TEXT("error"), TEXT("Invalid Blueprint"));
+        return Result;
+    }
+
+    if (ComponentName.IsEmpty())
+    {
+        Result->SetStringField(TEXT("error"), TEXT("component_name parameter is required"));
+        return Result;
+    }
+
+    // 1) Look in Simple Construction Script (BP-local components)
+    if (Blueprint->SimpleConstructionScript)
+    {
+        for (USCS_Node* Node : Blueprint->SimpleConstructionScript->GetAllNodes())
+        {
+            if (!Node || !Node->ComponentTemplate) continue;
+
+            FString CurrentName = Node->GetVariableName().ToString();
+            if (!CurrentName.Equals(ComponentName, ESearchCase::IgnoreCase))
+            {
+                continue;
+            }
+
+            Result->SetStringField(TEXT("name"), CurrentName);
+            Result->SetStringField(TEXT("type"), Node->ComponentTemplate->GetClass()->GetName());
+            Result->SetObjectField(TEXT("properties"), ExtractComponentProperties(Node->ComponentTemplate));
+            return Result;
+        }
+    }
+
+    // 2) Fallback: look in inherited components via the CDO (e.g. ACharacter's
+    //    CharacterMesh0/CapsuleComponent/CharacterMovement and any other native
+    //    DefaultSubobjects from parent classes).
+    if (Blueprint->GeneratedClass)
+    {
+        if (AActor* DefaultActor = Cast<AActor>(Blueprint->GeneratedClass->GetDefaultObject()))
+        {
+            TArray<UActorComponent*> AllComponents;
+            DefaultActor->GetComponents(AllComponents);
+            for (UActorComponent* Component : AllComponents)
+            {
+                if (!Component) continue;
+
+                if (Component->GetName().Equals(ComponentName, ESearchCase::IgnoreCase))
+                {
+                    Result->SetStringField(TEXT("name"), Component->GetName());
+                    Result->SetStringField(TEXT("type"), Component->GetClass()->GetName());
+                    Result->SetBoolField(TEXT("inherited"), true);
+                    Result->SetObjectField(TEXT("properties"), ExtractComponentProperties(Component));
+                    return Result;
+                }
             }
         }
     }

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Services/Blueprint/BlueprintMetadataBuilderService.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Services/Blueprint/BlueprintMetadataBuilderService.h
@@ -67,4 +67,8 @@ public:
 
 private:
     IBlueprintService& BlueprintService;
+
+    // Extract properties from a component template/instance into a JSON object.
+    // Works for both SCS templates and inherited CDO components.
+    TSharedPtr<FJsonObject> ExtractComponentProperties(class UActorComponent* ComponentTemplate) const;
 };

--- a/Python/scripts/blueprints/test_get_blueprint_metadata_inherited_components.py
+++ b/Python/scripts/blueprints/test_get_blueprint_metadata_inherited_components.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python
+"""
+Integration test for get_blueprint_metadata 'component_properties' field on
+INHERITED components (e.g. ACharacter's Mesh / CharacterMesh0 / CapsuleComponent /
+CharacterMovement which come from the native parent class, not the BP's own SCS).
+
+Regression test for the bug where component_properties returned
+    "Component 'CharacterMesh0' not found in Blueprint"
+for components that 'components' field happily listed (because BuildComponentsInfo
+includes inherited components via the CDO, but BuildComponentPropertiesInfo
+only searched the local SimpleConstructionScript).
+
+Requires the UE editor running with the UnrealMCP plugin on 127.0.0.1:55557.
+
+Pass criteria:
+  1. create_blueprint with parent_class=Character succeeds.
+  2. get_blueprint_metadata fields=[components] lists CharacterMesh0 (or "Mesh").
+  3. get_blueprint_metadata fields=[component_properties] component_name="CharacterMesh0"
+     returns success with a 'properties' object and 'inherited': true.
+  4. Same call for CapsuleComponent / CharacterMovement also succeeds.
+  5. Backwards-compat: an SCS component on a plain Actor BP still resolves.
+"""
+
+import sys
+import os
+import socket
+import json
+import logging
+from typing import Dict, Any, Optional
+
+logging.basicConfig(level=logging.INFO,
+                    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+logger = logging.getLogger("TestInheritedComponentProps")
+
+
+def send_command(command: str, params: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    try:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.connect(("127.0.0.1", 55557))
+        try:
+            command_obj = {"type": command, "params": params}
+            sock.sendall(json.dumps(command_obj).encode('utf-8'))
+            chunks = []
+            while True:
+                chunk = sock.recv(4096)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+                try:
+                    json.loads(b''.join(chunks).decode('utf-8'))
+                    break
+                except json.JSONDecodeError:
+                    continue
+            return json.loads(b''.join(chunks).decode('utf-8'))
+        finally:
+            sock.close()
+    except Exception as e:
+        logger.error(f"send_command error: {e}")
+        return None
+
+
+def assert_true(cond, msg):
+    if not cond:
+        logger.error(f"FAIL: {msg}")
+        sys.exit(1)
+    logger.info(f"PASS: {msg}")
+
+
+def test_inherited_character_components():
+    bp_name = "BP_TestInheritedComponents"
+
+    # 1. Create a Character BP (idempotent)
+    resp = send_command("create_blueprint",
+                        {"name": bp_name, "parent_class": "Character"})
+    assert_true(resp and resp.get("status") == "success",
+                f"create_blueprint Character ok: {resp}")
+
+    # 2. List components - must include an inherited mesh slot
+    resp = send_command("get_blueprint_metadata",
+                        {"blueprint_name": bp_name, "fields": ["components"]})
+    assert_true(resp and resp.get("status") == "success",
+                "get_blueprint_metadata components ok")
+    components = (resp.get("result", {})
+                      .get("metadata", {})
+                      .get("components", {})
+                      .get("components", []))
+    names = [c.get("name") for c in components]
+    logger.info(f"Components found: {names}")
+    # ACharacter exposes CharacterMesh0 (variable name "Mesh"). UE may report
+    # either depending on which name is used. Accept both.
+    mesh_name = next((n for n in names if n in ("CharacterMesh0", "Mesh")), None)
+    assert_true(mesh_name is not None,
+                f"Inherited mesh component listed (got {names})")
+
+    capsule_name = next((n for n in names if "Capsule" in n), None)
+    assert_true(capsule_name is not None,
+                f"Inherited capsule component listed (got {names})")
+
+    # 3. component_properties on the inherited mesh - this is the regression
+    resp = send_command("get_blueprint_metadata",
+                        {"blueprint_name": bp_name,
+                         "fields": ["component_properties"],
+                         "component_name": mesh_name})
+    assert_true(resp and resp.get("status") == "success",
+                f"get_blueprint_metadata component_properties on inherited "
+                f"mesh ok: {resp}")
+    props_block = (resp.get("result", {})
+                       .get("metadata", {})
+                       .get("component_properties", {}))
+    assert_true("error" not in props_block,
+                f"No 'error' field for inherited mesh (got {props_block})")
+    assert_true(isinstance(props_block.get("properties"), dict),
+                "Inherited mesh exposes a 'properties' dict")
+    assert_true(props_block.get("inherited") is True,
+                "Inherited component is flagged with inherited=true")
+
+    # 4. capsule + movement
+    for inherited in (capsule_name, "CharMoveComp", "CharacterMovement"):
+        resp = send_command("get_blueprint_metadata",
+                            {"blueprint_name": bp_name,
+                             "fields": ["component_properties"],
+                             "component_name": inherited})
+        if resp and resp.get("status") == "success":
+            block = (resp.get("result", {})
+                         .get("metadata", {})
+                         .get("component_properties", {}))
+            if "error" not in block:
+                logger.info(f"Resolved inherited '{inherited}' ok")
+                continue
+        logger.info(f"Inherited '{inherited}' not present under that exact "
+                    f"name - tolerated (CharacterMovement reports as "
+                    f"CharMoveComp on some setups)")
+
+
+def test_scs_component_backwards_compat():
+    bp_name = "BP_TestSCSCompat"
+
+    resp = send_command("create_blueprint",
+                        {"name": bp_name, "parent_class": "Actor"})
+    assert_true(resp and resp.get("status") == "success",
+                "create_blueprint Actor ok for SCS compat test")
+
+    resp = send_command("add_component_to_blueprint",
+                        {"blueprint_name": bp_name,
+                         "component_type": "StaticMeshComponent",
+                         "component_name": "MyMeshComp"})
+    assert_true(resp and resp.get("status") == "success",
+                f"add SCS StaticMeshComponent ok: {resp}")
+
+    resp = send_command("compile_blueprint", {"blueprint_name": bp_name})
+    assert_true(resp and resp.get("status") == "success", "compile ok")
+
+    resp = send_command("get_blueprint_metadata",
+                        {"blueprint_name": bp_name,
+                         "fields": ["component_properties"],
+                         "component_name": "MyMeshComp"})
+    assert_true(resp and resp.get("status") == "success",
+                f"component_properties on SCS comp still works: {resp}")
+    block = (resp.get("result", {})
+                 .get("metadata", {})
+                 .get("component_properties", {}))
+    assert_true("error" not in block,
+                f"No error for SCS comp (got {block})")
+    assert_true(isinstance(block.get("properties"), dict),
+                "SCS component exposes 'properties' dict")
+    # SCS components should NOT be flagged inherited
+    assert_true(block.get("inherited") is not True,
+                "SCS component is not flagged inherited")
+
+
+def main():
+    logger.info("=== test_inherited_character_components ===")
+    test_inherited_character_components()
+    logger.info("=== test_scs_component_backwards_compat ===")
+    test_scs_component_backwards_compat()
+    logger.info("All assertions passed.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
…inherited components

BuildComponentPropertiesInfo only searched the local SimpleConstructionScript, so calling it with an inherited component (e.g. ACharacter's CharacterMesh0, CapsuleComponent, CharMoveComp) returned "Component not found" even though BuildComponentsInfo listed those same names (it already walks the CDO via GetBlueprintComponents).

Fix:
- Extract the per-property serialization loop into a private ExtractComponentProperties(UActorComponent*) helper.
- BuildComponentPropertiesInfo first tries SCS (BP-local, unchanged behavior), then falls back to the GeneratedClass CDO's GetComponents() to resolve inherited native components. Inherited hits are flagged with "inherited": true in the response so callers can disambiguate.

Backwards compatibility preserved: SCS-resolved components keep the same shape (name/type/properties) and do NOT carry the inherited flag.

Test:
- Python/scripts/blueprints/test_get_blueprint_metadata_inherited_components.py exercises the regression on a Character BP (mesh + capsule lookup) and verifies SCS-component compat on a plain Actor BP. Requires the UE editor running with the UnrealMCP plugin on 127.0.0.1:55557 - manual run on user side needed since automated headless integration test infra isn't set up in this repo yet (no IMPLEMENT_*_AUTOMATION_TEST in the plugin).

Plugin DLL build verified: RebuildProject.bat -> Succeeded.