### PR TITLE
feat(project): generic create_asset + set_object_property MCP tools

### DIFF
--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Project/CreateAssetCommand.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Project/CreateAssetCommand.cpp
@@ -1,0 +1,78 @@
+#include "Commands/Project/CreateAssetCommand.h"
+#include "Utils/UnrealMCPCommonUtils.h"
+
+FCreateAssetCommand::FCreateAssetCommand(TSharedPtr<IProjectService> InProjectService)
+    : ProjectService(InProjectService)
+{
+}
+
+bool FCreateAssetCommand::ValidateParams(const FString& Parameters) const
+{
+    TSharedPtr<FJsonObject> JsonObject;
+    TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Parameters);
+    if (!FJsonSerializer::Deserialize(Reader, JsonObject) || !JsonObject.IsValid())
+    {
+        return false;
+    }
+    FString Name;
+    if (!JsonObject->TryGetStringField(TEXT("name"), Name) || Name.IsEmpty())
+    {
+        return false;
+    }
+    FString AssetClass;
+    if (!JsonObject->TryGetStringField(TEXT("asset_class"), AssetClass) || AssetClass.IsEmpty())
+    {
+        return false;
+    }
+    return true;
+}
+
+FString FCreateAssetCommand::Execute(const FString& Parameters)
+{
+    auto MakeError = [](const FString& Msg) -> FString
+    {
+        TSharedPtr<FJsonObject> ErrorResponse = FUnrealMCPCommonUtils::CreateErrorResponse(Msg);
+        FString Out;
+        TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&Out);
+        FJsonSerializer::Serialize(ErrorResponse.ToSharedRef(), Writer);
+        return Out;
+    };
+
+    TSharedPtr<FJsonObject> JsonObject;
+    TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Parameters);
+    if (!FJsonSerializer::Deserialize(Reader, JsonObject) || !JsonObject.IsValid())
+    {
+        return MakeError(TEXT("Invalid JSON parameters"));
+    }
+    if (!ValidateParams(Parameters))
+    {
+        return MakeError(TEXT("Parameter validation failed. Required: name (string), asset_class (string). Optional: folder_path (string)"));
+    }
+
+    const FString Name = JsonObject->GetStringField(TEXT("name"));
+    const FString AssetClass = JsonObject->GetStringField(TEXT("asset_class"));
+    FString FolderPath;
+    if (!JsonObject->TryGetStringField(TEXT("folder_path"), FolderPath) || FolderPath.IsEmpty())
+    {
+        FolderPath = TEXT("/Game");
+    }
+
+    FString AssetPath, Error;
+    if (!ProjectService->CreateAsset(Name, AssetClass, FolderPath, AssetPath, Error))
+    {
+        return MakeError(Error);
+    }
+
+    TSharedPtr<FJsonObject> ResponseData = MakeShared<FJsonObject>();
+    ResponseData->SetBoolField(TEXT("success"), true);
+    ResponseData->SetStringField(TEXT("name"), Name);
+    ResponseData->SetStringField(TEXT("asset_class"), AssetClass);
+    ResponseData->SetStringField(TEXT("folder_path"), FolderPath);
+    ResponseData->SetStringField(TEXT("asset_path"), AssetPath);
+    ResponseData->SetStringField(TEXT("message"), FString::Printf(TEXT("Successfully created asset at %s"), *AssetPath));
+
+    FString OutputString;
+    TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&OutputString);
+    FJsonSerializer::Serialize(ResponseData.ToSharedRef(), Writer);
+    return OutputString;
+}

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Project/SetObjectPropertyCommand.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Project/SetObjectPropertyCommand.cpp
@@ -1,0 +1,80 @@
+#include "Commands/Project/SetObjectPropertyCommand.h"
+#include "Utils/UnrealMCPCommonUtils.h"
+
+FSetObjectPropertyCommand::FSetObjectPropertyCommand(TSharedPtr<IProjectService> InProjectService)
+    : ProjectService(InProjectService)
+{
+}
+
+bool FSetObjectPropertyCommand::ValidateParams(const FString& Parameters) const
+{
+    TSharedPtr<FJsonObject> JsonObject;
+    TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Parameters);
+    if (!FJsonSerializer::Deserialize(Reader, JsonObject) || !JsonObject.IsValid())
+    {
+        return false;
+    }
+    FString AssetPath;
+    if (!JsonObject->TryGetStringField(TEXT("asset_path"), AssetPath) || AssetPath.IsEmpty())
+    {
+        return false;
+    }
+    FString PropertyName;
+    if (!JsonObject->TryGetStringField(TEXT("property_name"), PropertyName) || PropertyName.IsEmpty())
+    {
+        return false;
+    }
+    // property_value is required but may legitimately be any string; presence only.
+    return JsonObject->HasField(TEXT("property_value"));
+}
+
+FString FSetObjectPropertyCommand::Execute(const FString& Parameters)
+{
+    auto MakeError = [](const FString& Msg) -> FString
+    {
+        TSharedPtr<FJsonObject> ErrorResponse = FUnrealMCPCommonUtils::CreateErrorResponse(Msg);
+        FString Out;
+        TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&Out);
+        FJsonSerializer::Serialize(ErrorResponse.ToSharedRef(), Writer);
+        return Out;
+    };
+
+    TSharedPtr<FJsonObject> JsonObject;
+    TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Parameters);
+    if (!FJsonSerializer::Deserialize(Reader, JsonObject) || !JsonObject.IsValid())
+    {
+        return MakeError(TEXT("Invalid JSON parameters"));
+    }
+    if (!ValidateParams(Parameters))
+    {
+        return MakeError(TEXT("Parameter validation failed. Required: asset_path (string), property_name (string), property_value (string in UE property-text form)"));
+    }
+
+    const FString AssetPath = JsonObject->GetStringField(TEXT("asset_path"));
+    const FString PropertyName = JsonObject->GetStringField(TEXT("property_name"));
+    // Accept value as string; numbers/bools are also fine via JSON string coercion.
+    FString ValueString;
+    if (!JsonObject->TryGetStringField(TEXT("property_value"), ValueString))
+    {
+        // Coerce non-string JSON (number/bool) to string.
+        const TSharedPtr<FJsonValue> Raw = JsonObject->TryGetField(TEXT("property_value"));
+        if (Raw.IsValid()) { Raw->TryGetString(ValueString); }
+    }
+
+    FString Error;
+    if (!ProjectService->SetObjectProperty(AssetPath, PropertyName, ValueString, Error))
+    {
+        return MakeError(Error);
+    }
+
+    TSharedPtr<FJsonObject> ResponseData = MakeShared<FJsonObject>();
+    ResponseData->SetBoolField(TEXT("success"), true);
+    ResponseData->SetStringField(TEXT("asset_path"), AssetPath);
+    ResponseData->SetStringField(TEXT("property_name"), PropertyName);
+    ResponseData->SetStringField(TEXT("message"), FString::Printf(TEXT("Set '%s' on %s"), *PropertyName, *AssetPath));
+
+    FString OutputString;
+    TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&OutputString);
+    FJsonSerializer::Serialize(ResponseData.ToSharedRef(), Writer);
+    return OutputString;
+}

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/ProjectCommandRegistration.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/ProjectCommandRegistration.cpp
@@ -24,6 +24,8 @@
 #include "Commands/Project/CreateDataAssetCommand.h"
 #include "Commands/Project/SetDataAssetPropertyCommand.h"
 #include "Commands/Project/GetDataAssetMetadataCommand.h"
+#include "Commands/Project/CreateAssetCommand.h"
+#include "Commands/Project/SetObjectPropertyCommand.h"
 #include "Commands/Project/RenameAssetCommand.h"
 #include "Commands/Project/MoveAssetCommand.h"
 #include "Commands/Project/SearchAssetsCommand.h"
@@ -94,6 +96,10 @@ void FProjectCommandRegistration::RegisterCommands(FUnrealMCPCommandRegistry& Re
     Registry.RegisterCommand(MakeShared<FCreateDataAssetCommand>(ProjectService));
     Registry.RegisterCommand(MakeShared<FSetDataAssetPropertyCommand>(ProjectService));
     Registry.RegisterCommand(MakeShared<FGetDataAssetMetadataCommand>(ProjectService));
+
+    // Generic asset ops (any UObject class — e.g. Voxel assets)
+    Registry.RegisterCommand(MakeShared<FCreateAssetCommand>(ProjectService));
+    Registry.RegisterCommand(MakeShared<FSetObjectPropertyCommand>(ProjectService));
 
     // Register Asset Management commands
     Registry.RegisterCommand(MakeShared<FRenameAssetCommand>(ProjectService));

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Project/ProjectDataAssetService.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Project/ProjectDataAssetService.cpp
@@ -4,7 +4,9 @@
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "Misc/Paths.h"
 #include "UObject/UObjectGlobals.h"
+#include "UObject/UnrealType.h"
 #include "Serialization/ObjectReader.h"
+#include "Misc/StringOutputDevice.h"
 
 FProjectDataAssetService& FProjectDataAssetService::Get()
 {
@@ -220,6 +222,145 @@ bool FProjectDataAssetService::SetDataAssetProperty(const FString& AssetPath, co
     UEditorAssetLibrary::SaveAsset(AssetPath, false);
 
     UE_LOG(LogTemp, Display, TEXT("MCP Project: Set property '%s' on DataAsset '%s'"), *PropertyName, *AssetPath);
+    return true;
+}
+
+bool FProjectDataAssetService::CreateAsset(const FString& Name, const FString& AssetClass, const FString& FolderPath, FString& OutAssetPath, FString& OutError)
+{
+    if (Name.IsEmpty())
+    {
+        OutError = TEXT("Asset name cannot be empty");
+        return false;
+    }
+    if (AssetClass.IsEmpty())
+    {
+        OutError = TEXT("Asset class cannot be empty");
+        return false;
+    }
+
+    const FString BasePath = FolderPath.IsEmpty() ? TEXT("/Game") : FolderPath;
+    const FString PackageName = BasePath / Name;
+
+    ProjectDataAssetServiceHelpers::EnsureFolderExists(BasePath);
+
+    // Resolve the class generically (any UObject), trying: exact, U-prefixed, by path.
+    UClass* AssetUClass = FindFirstObject<UClass>(*AssetClass, EFindFirstObjectOptions::ExactClass);
+    if (!AssetUClass)
+    {
+        AssetUClass = FindFirstObject<UClass>(*(TEXT("U") + AssetClass), EFindFirstObjectOptions::ExactClass);
+    }
+    if (!AssetUClass && AssetClass.Contains(TEXT("/")))
+    {
+        AssetUClass = LoadObject<UClass>(nullptr, *AssetClass);
+    }
+    if (!AssetUClass)
+    {
+        OutError = FString::Printf(TEXT("Class '%s' not found. Pass a full class path like '/Script/Voxel.VoxelSurfaceTypeAsset' or a registered class name."), *AssetClass);
+        return false;
+    }
+
+    // Guard against classes that can't be instantiated as standalone assets.
+    if (AssetUClass->HasAnyClassFlags(CLASS_Abstract))
+    {
+        OutError = FString::Printf(TEXT("Class '%s' is abstract — cannot create an instance."), *AssetUClass->GetName());
+        return false;
+    }
+    if (!AssetUClass->IsChildOf(UObject::StaticClass()))
+    {
+        OutError = FString::Printf(TEXT("Class '%s' is not a UObject subclass."), *AssetUClass->GetName());
+        return false;
+    }
+
+    // Refuse to clobber an existing asset.
+    if (UEditorAssetLibrary::DoesAssetExist(PackageName))
+    {
+        OutError = FString::Printf(TEXT("Asset already exists at '%s' — choose a different name/folder."), *PackageName);
+        return false;
+    }
+
+    UPackage* Package = CreatePackage(*PackageName);
+    if (!Package)
+    {
+        OutError = FString::Printf(TEXT("Failed to create package: %s"), *PackageName);
+        return false;
+    }
+
+    UObject* NewAsset = NewObject<UObject>(Package, AssetUClass, *Name, RF_Public | RF_Standalone);
+    if (!NewAsset)
+    {
+        OutError = FString::Printf(TEXT("NewObject failed for class '%s' (name '%s')."), *AssetUClass->GetName(), *Name);
+        return false;
+    }
+
+    NewAsset->MarkPackageDirty();
+    Package->MarkPackageDirty();
+    FAssetRegistryModule::AssetCreated(NewAsset);
+
+    if (!UEditorAssetLibrary::SaveAsset(PackageName, false))
+    {
+        OutError = FString::Printf(TEXT("Asset created in memory but SaveAsset failed for '%s'."), *PackageName);
+        return false;
+    }
+
+    OutAssetPath = PackageName;
+    UE_LOG(LogTemp, Display, TEXT("MCP Project: Created asset '%s' of class '%s' at '%s'"),
+        *Name, *AssetUClass->GetName(), *OutAssetPath);
+    return true;
+}
+
+bool FProjectDataAssetService::SetObjectProperty(const FString& AssetPath, const FString& PropertyName, const FString& ValueString, FString& OutError)
+{
+    if (AssetPath.IsEmpty()) { OutError = TEXT("Asset path cannot be empty"); return false; }
+    if (PropertyName.IsEmpty()) { OutError = TEXT("Property name cannot be empty"); return false; }
+
+    // Normalize Package → Object path (append .AssetName if missing).
+    FString NormalizedPath = AssetPath;
+    if (!NormalizedPath.Contains(TEXT(".")))
+    {
+        NormalizedPath = AssetPath + TEXT(".") + FPaths::GetBaseFilename(AssetPath);
+    }
+
+    UObject* Asset = StaticLoadObject(UObject::StaticClass(), nullptr, *NormalizedPath);
+    if (!Asset)
+    {
+        OutError = FString::Printf(TEXT("Failed to load asset at '%s'."), *AssetPath);
+        return false;
+    }
+
+    FProperty* Property = Asset->GetClass()->FindPropertyByName(FName(*PropertyName));
+    if (!Property)
+    {
+        OutError = FString::Printf(TEXT("Property '%s' not found on class '%s'."),
+            *PropertyName, *Asset->GetClass()->GetName());
+        return false;
+    }
+
+    void* ValuePtr = Property->ContainerPtrToValuePtr<void>(Asset);
+
+    // Generic import — ImportText parses object refs, arrays, structs, enums, etc.
+    // Capture the UE parser's diagnostics for a precise error message.
+    FStringOutputDevice ImportErrors;
+    Asset->Modify();
+    const TCHAR* Result = Property->ImportText_Direct(*ValueString, ValuePtr, Asset, PPF_None, &ImportErrors);
+    if (Result == nullptr || !ImportErrors.IsEmpty())
+    {
+        OutError = FString::Printf(TEXT("Failed to set '%s' (type %s) to '%s': %s"),
+            *PropertyName, *Property->GetCPPType(), *ValueString,
+            ImportErrors.IsEmpty() ? TEXT("value could not be parsed for this property type") : *ImportErrors);
+        return false;
+    }
+
+    FPropertyChangedEvent ChangedEvent(Property);
+    Asset->PostEditChangeProperty(ChangedEvent);
+    Asset->MarkPackageDirty();
+
+    if (!UEditorAssetLibrary::SaveAsset(AssetPath, false))
+    {
+        OutError = FString::Printf(TEXT("Property set but SaveAsset failed for '%s'."), *AssetPath);
+        return false;
+    }
+
+    UE_LOG(LogTemp, Display, TEXT("MCP Project: Set '%s' = '%s' on '%s'"), *PropertyName, *ValueString, *AssetPath);
     return true;
 }
 

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/ProjectService.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/ProjectService.cpp
@@ -404,3 +404,13 @@ TSharedPtr<FJsonObject> FProjectService::GetDataAssetMetadata(const FString& Ass
 {
     return FProjectDataAssetService::Get().GetDataAssetMetadata(AssetPath, OutError);
 }
+
+bool FProjectService::CreateAsset(const FString& Name, const FString& AssetClass, const FString& FolderPath, FString& OutAssetPath, FString& OutError)
+{
+    return FProjectDataAssetService::Get().CreateAsset(Name, AssetClass, FolderPath, OutAssetPath, OutError);
+}
+
+bool FProjectService::SetObjectProperty(const FString& AssetPath, const FString& PropertyName, const FString& ValueString, FString& OutError)
+{
+    return FProjectDataAssetService::Get().SetObjectProperty(AssetPath, PropertyName, ValueString, OutError);
+}

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Project/CreateAssetCommand.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Project/CreateAssetCommand.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Commands/IUnrealMCPCommand.h"
+#include "Services/IProjectService.h"
+
+/**
+ * Command for creating an asset of ANY UObject class (generic — for asset
+ * types without a dedicated MCP tool, e.g. Voxel plugin assets).
+ */
+class UNREALMCP_API FCreateAssetCommand : public IUnrealMCPCommand
+{
+public:
+    FCreateAssetCommand(TSharedPtr<IProjectService> InProjectService);
+    virtual ~FCreateAssetCommand() = default;
+
+    virtual FString Execute(const FString& Parameters) override;
+    virtual FString GetCommandName() const override { return TEXT("create_asset"); }
+    virtual bool ValidateParams(const FString& Parameters) const override;
+
+private:
+    TSharedPtr<IProjectService> ProjectService;
+};

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Project/SetObjectPropertyCommand.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Project/SetObjectPropertyCommand.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Commands/IUnrealMCPCommand.h"
+#include "Services/IProjectService.h"
+
+/**
+ * Command for setting ANY property on ANY UObject asset via UE property-text
+ * import (handles object refs, arrays, structs, enums — anything ExportText
+ * round-trips). Generic counterpart to set_data_asset_property.
+ */
+class UNREALMCP_API FSetObjectPropertyCommand : public IUnrealMCPCommand
+{
+public:
+    FSetObjectPropertyCommand(TSharedPtr<IProjectService> InProjectService);
+    virtual ~FSetObjectPropertyCommand() = default;
+
+    virtual FString Execute(const FString& Parameters) override;
+    virtual FString GetCommandName() const override { return TEXT("set_object_property"); }
+    virtual bool ValidateParams(const FString& Parameters) const override;
+
+private:
+    TSharedPtr<IProjectService> ProjectService;
+};

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Services/IProjectService.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Services/IProjectService.h
@@ -51,6 +51,10 @@ public:
     virtual bool SetDataAssetProperty(const FString& AssetPath, const FString& PropertyName, const TSharedPtr<FJsonValue>& PropertyValue, FString& OutError) = 0;
     virtual TSharedPtr<FJsonObject> GetDataAssetMetadata(const FString& AssetPath, FString& OutError) = 0;
 
+    // Generic asset operations (any UObject class — for assets with no dedicated MCP tool, e.g. Voxel)
+    virtual bool CreateAsset(const FString& Name, const FString& AssetClass, const FString& FolderPath, FString& OutAssetPath, FString& OutError) = 0;
+    virtual bool SetObjectProperty(const FString& AssetPath, const FString& PropertyName, const FString& ValueString, FString& OutError) = 0;
+
     // Font Face operations (for TTF-based fonts)
     virtual bool CreateFontFace(const FString& FontName, const FString& Path, const FString& SourceTexturePath, bool bUseSDF, int32 DistanceFieldSpread, const TSharedPtr<FJsonObject>& FontMetrics, FString& OutAssetPath, FString& OutError) = 0;
     virtual bool SetFontFaceProperties(const FString& FontPath, const TSharedPtr<FJsonObject>& Properties, TArray<FString>& OutSuccessProperties, TArray<FString>& OutFailedProperties, FString& OutError) = 0;

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Services/Project/ProjectDataAssetService.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Services/Project/ProjectDataAssetService.h
@@ -58,6 +58,40 @@ public:
         const FString& AssetPath,
         FString& OutError);
 
+    /**
+     * Create a new asset of ANY UObject class (generic — not restricted to
+     * UDataAsset). Use for Voxel assets, etc. that have no factory MCP tool.
+     * @param Name - Name for the new asset
+     * @param AssetClass - Class path or name (e.g. "/Script/Voxel.VoxelSurfaceTypeAsset")
+     * @param FolderPath - Content browser folder (default /Game)
+     * @param OutAssetPath - Output: full object path of created asset
+     * @param OutError - Output: detailed error message if failed
+     * @return true on success
+     */
+    bool CreateAsset(
+        const FString& Name,
+        const FString& AssetClass,
+        const FString& FolderPath,
+        FString& OutAssetPath,
+        FString& OutError);
+
+    /**
+     * Set ANY property on ANY loaded UObject asset via UE property text import
+     * (ImportText). Handles numerics, bools, strings, names, enums, object
+     * references (by path), structs, and arrays — anything ExportText round-trips.
+     * @param AssetPath - Path of the asset
+     * @param PropertyName - Reflected property name
+     * @param ValueString - UE property-text value (e.g. "/Game/X.X" for object ref,
+     *        "(\"/Game/A.A\",\"/Game/B.B\")" for an array of object refs, "5.0", "true")
+     * @param OutError - Output: detailed error (incl. UE import parser message)
+     * @return true on success
+     */
+    bool SetObjectProperty(
+        const FString& AssetPath,
+        const FString& PropertyName,
+        const FString& ValueString,
+        FString& OutError);
+
 private:
     FProjectDataAssetService() = default;
 };

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Services/ProjectService.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Services/ProjectService.h
@@ -38,6 +38,8 @@ public:
     virtual bool CreateDataAsset(const FString& Name, const FString& AssetClass, const FString& FolderPath, const TSharedPtr<FJsonObject>& Properties, FString& OutAssetPath, FString& OutError) override;
     virtual bool SetDataAssetProperty(const FString& AssetPath, const FString& PropertyName, const TSharedPtr<FJsonValue>& PropertyValue, FString& OutError) override;
     virtual TSharedPtr<FJsonObject> GetDataAssetMetadata(const FString& AssetPath, FString& OutError) override;
+    virtual bool CreateAsset(const FString& Name, const FString& AssetClass, const FString& FolderPath, FString& OutAssetPath, FString& OutError) override;
+    virtual bool SetObjectProperty(const FString& AssetPath, const FString& PropertyName, const FString& ValueString, FString& OutError) override;
 
     // Font Face operations (for TTF-based fonts)
     virtual bool CreateFontFace(const FString& FontName, const FString& Path, const FString& SourceTexturePath, bool bUseSDF, int32 DistanceFieldSpread, const TSharedPtr<FJsonObject>& FontMetrics, FString& OutAssetPath, FString& OutError) override;

--- a/Python/project_tools/project_tools.py
+++ b/Python/project_tools/project_tools.py
@@ -1287,6 +1287,142 @@ def register_project_tools(mcp: FastMCP):
             logger.error(error_msg)
             return {"success": False, "message": error_msg}
 
+    # ========================================
+    # Generic Asset Tools (any UObject class)
+    # ========================================
+
+    @mcp.tool()
+    def create_asset(
+        ctx: Context,
+        name: str,
+        asset_class: str,
+        folder_path: str = "/Game"
+    ) -> Dict[str, Any]:
+        """
+        Create a new asset of ANY UObject class. Generic — unlike create_data_asset
+        this is NOT restricted to UDataAsset subclasses, so it works for plugin
+        asset types that have no dedicated MCP tool (e.g. Voxel Plugin assets:
+        UVoxelSurfaceTypeAsset, UVoxelMegaMaterial, UVoxelHeightmap).
+
+        Set the new asset's properties afterward with set_object_property.
+
+        Args:
+            name: Name of the asset (e.g., "ST_Grass")
+            asset_class: Class path (recommended) or registered name. Examples:
+                - "/Script/Voxel.VoxelSurfaceTypeAsset"
+                - "/Script/Voxel.VoxelMegaMaterial"
+            folder_path: Content folder (default "/Game")
+
+        Returns:
+            Dict with success, name, asset_class, folder_path, asset_path, message.
+            On failure: success=False + a detailed message (class not found,
+            abstract class, already exists, save failed, etc.).
+
+        Examples:
+            create_asset(name="ST_Grass",
+                         asset_class="/Script/Voxel.VoxelSurfaceTypeAsset",
+                         folder_path="/Game/Landscape/Surface")
+        """
+        from utils.unreal_connection_utils import get_unreal_engine_connection as get_unreal_connection
+
+        try:
+            unreal = get_unreal_connection()
+            if not unreal:
+                logger.error("Failed to connect to Unreal Engine")
+                return {"success": False, "message": "Failed to connect to Unreal Engine"}
+
+            params = {
+                "name": name,
+                "asset_class": asset_class,
+                "folder_path": folder_path
+            }
+
+            logger.info(f"Creating asset '{name}' of class '{asset_class}' at '{folder_path}'")
+            response = unreal.send_command("create_asset", params)
+
+            if not response:
+                logger.error("No response from Unreal Engine")
+                return {"success": False, "message": "No response from Unreal Engine"}
+
+            logger.info(f"Create asset response: {response}")
+            return response
+
+        except Exception as e:
+            error_msg = f"Error creating asset: {e}"
+            logger.error(error_msg)
+            return {"success": False, "message": error_msg}
+
+    @mcp.tool()
+    def set_object_property(
+        ctx: Context,
+        asset_path: str,
+        property_name: str,
+        property_value: str
+    ) -> Dict[str, Any]:
+        """
+        Set ANY property on ANY UObject asset via Unreal property-text import.
+        Generic counterpart to set_data_asset_property — handles object
+        references, arrays, structs, and enums in addition to scalars, because
+        it uses Unreal's ImportText (the same format ExportText produces).
+
+        property_value is a STRING in Unreal property-text form:
+            - Scalar:        "4000.0", "5", "true"
+            - Name/String:   "Plains"
+            - Enum:          "AlphaBlended"
+            - Object ref:    "/Game/Path/Asset.Asset"
+            - Array:         '("/Game/A.A","/Game/B.B")'
+            - Struct:        "(X=1.0,Y=2.0)"
+
+        Args:
+            asset_path: Full path to the asset (e.g., "/Game/Landscape/Surface/ST_Grass")
+            property_name: Reflected property name (e.g., "Material", "SurfaceTypes")
+            property_value: Value in Unreal property-text form (see above)
+
+        Returns:
+            Dict with success, asset_path, property_name, message. On failure:
+            success=False + detailed message including the Unreal parser error
+            (property not found, type mismatch, unresolved object path, etc.).
+
+        Examples:
+            # Object reference
+            set_object_property(asset_path="/Game/Landscape/Surface/ST_Grass",
+                                property_name="Material",
+                                property_value="/Game/Landscape/Materials/M_Biome_Grass.M_Biome_Grass")
+
+            # Array of object references
+            set_object_property(asset_path="/Game/Landscape/MM_Landscape",
+                                property_name="SurfaceTypes",
+                                property_value='("/Game/Landscape/Surface/ST_Grass.ST_Grass","/Game/Landscape/Surface/ST_Rock.ST_Rock")')
+        """
+        from utils.unreal_connection_utils import get_unreal_engine_connection as get_unreal_connection
+
+        try:
+            unreal = get_unreal_connection()
+            if not unreal:
+                logger.error("Failed to connect to Unreal Engine")
+                return {"success": False, "message": "Failed to connect to Unreal Engine"}
+
+            params = {
+                "asset_path": asset_path,
+                "property_name": property_name,
+                "property_value": property_value
+            }
+
+            logger.info(f"Setting object property '{property_name}' on '{asset_path}'")
+            response = unreal.send_command("set_object_property", params)
+
+            if not response:
+                logger.error("No response from Unreal Engine")
+                return {"success": False, "message": "No response from Unreal Engine"}
+
+            logger.info(f"Set object property response: {response}")
+            return response
+
+        except Exception as e:
+            error_msg = f"Error setting object property: {e}"
+            logger.error(error_msg)
+            return {"success": False, "message": error_msg}
+
     @mcp.tool()
     def get_data_asset_metadata(
         ctx: Context,


### PR DESCRIPTION
create_data_asset only handles UDataAsset subclasses, blocking creation of plugin asset types (Voxel: UVoxelSurfaceTypeAsset, UVoxelMegaMaterial, UVoxelHeightmap) that have no dedicated factory tool.

New generic tools:
- create_asset(name, asset_class, folder_path): NewObject of ANY UObject class + package save. Resolves class by exact/U-prefixed/path. Refuses abstract classes and existing-asset clobber.
- set_object_property(asset_path, property_name, property_value): sets ANY property via FProperty::ImportText_Direct — handles object refs (by path), arrays, structs, enums, scalars. Anything ExportText round-trips.

Robust error handling (distinct messages): class not found, abstract, already-exists, NewObject failed, save failed, property not found, and the UE parser's own diagnostic (captured via FStringOutputDevice) on import failure.

C++: IProjectService + ProjectService + ProjectDataAssetService (CreateAsset, SetObjectProperty); FCreateAssetCommand + FSetObjectPropertyCommand + registration. Python: 2 @mcp.tool() in project_tools.py with property-text examples.

Tested before commit (rule): created UVoxelSurfaceTypeAsset + UVoxelMegaMaterial, set object-ref (ST.Material) + array-of-refs (MM.SurfaceTypes), verified error path on bogus class.