### PR TITLE
fix(material): SamplerType string parse + ParameterName on texture-ob…

### DIFF
--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Material/MaterialExpressionCreation.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Material/MaterialExpressionCreation.cpp
@@ -11,6 +11,7 @@
 #include "Materials/MaterialExpressionConstant3Vector.h"
 #include "Materials/MaterialExpressionConstant4Vector.h"
 #include "Materials/MaterialExpressionTextureSample.h"
+#include "Materials/MaterialExpressionTextureSampleParameter.h"
 #include "Materials/MaterialExpressionTextureSampleParameter2D.h"
 #include "Materials/MaterialExpressionScalarParameter.h"
 #include "Materials/MaterialExpressionVectorParameter.h"
@@ -56,6 +57,53 @@ UMaterialExpression* FMaterialExpressionService::CreateExpressionByType(UMateria
     NewExpression->UpdateMaterialExpressionGuid(true, true);
 
     return NewExpression;
+}
+
+// Parse an EMaterialSamplerType from a JSON "SamplerType"/"sampler_type" field.
+// Accepts a numeric index, a numeric string, or an enum name (case-insensitive,
+// with or without the "SAMPLERTYPE_" prefix, e.g. "Normal", "Masks", "LinearColor").
+// MCP clients pass the value as a string, so number-only parsing silently fell back
+// to SAMPLERTYPE_Color (0) — this is the canonical parser for that field.
+static bool TryParseSamplerTypeField(const TSharedPtr<FJsonObject>& Properties, EMaterialSamplerType& OutType)
+{
+    TSharedPtr<FJsonValue> Val = Properties->TryGetField(TEXT("SamplerType"));
+    if (!Val.IsValid())
+    {
+        Val = Properties->TryGetField(TEXT("sampler_type"));
+    }
+    if (!Val.IsValid())
+    {
+        return false;
+    }
+
+    if (Val->Type == EJson::Number)
+    {
+        OutType = (EMaterialSamplerType)(int32)Val->AsNumber();
+        return true;
+    }
+
+    if (Val->Type == EJson::String)
+    {
+        FString S = Val->AsString().TrimStartAndEnd();
+        if (S.IsNumeric())
+        {
+            OutType = (EMaterialSamplerType)FCString::Atoi(*S);
+            return true;
+        }
+        S.RemoveFromStart(TEXT("SAMPLERTYPE_"), ESearchCase::IgnoreCase);
+        if (S.Equals(TEXT("Color"), ESearchCase::IgnoreCase))            { OutType = SAMPLERTYPE_Color;            return true; }
+        if (S.Equals(TEXT("Grayscale"), ESearchCase::IgnoreCase))        { OutType = SAMPLERTYPE_Grayscale;        return true; }
+        if (S.Equals(TEXT("Alpha"), ESearchCase::IgnoreCase))            { OutType = SAMPLERTYPE_Alpha;            return true; }
+        if (S.Equals(TEXT("Normal"), ESearchCase::IgnoreCase))           { OutType = SAMPLERTYPE_Normal;           return true; }
+        if (S.Equals(TEXT("Masks"), ESearchCase::IgnoreCase) ||
+            S.Equals(TEXT("Mask"), ESearchCase::IgnoreCase))             { OutType = SAMPLERTYPE_Masks;            return true; }
+        if (S.Equals(TEXT("DistanceFieldFont"), ESearchCase::IgnoreCase)){ OutType = SAMPLERTYPE_DistanceFieldFont;return true; }
+        if (S.Equals(TEXT("LinearColor"), ESearchCase::IgnoreCase))      { OutType = SAMPLERTYPE_LinearColor;      return true; }
+        if (S.Equals(TEXT("LinearGrayscale"), ESearchCase::IgnoreCase))  { OutType = SAMPLERTYPE_LinearGrayscale;  return true; }
+        return false; // unknown name — leave caller's value untouched
+    }
+
+    return false;
 }
 
 bool FMaterialExpressionService::ApplyExpressionProperties(UMaterialExpression* Expression, const TSharedPtr<FJsonObject>& Properties, FString& OutError)
@@ -347,48 +395,63 @@ bool FMaterialExpressionService::ApplyExpressionProperties(UMaterialExpression* 
                 ? Properties->GetBoolField(TEXT("blend"))
                 : Properties->GetBoolField(TEXT("bBlend"));
         }
-        // Handle SamplerType property (inherited from TextureSample)
-        if (Properties->HasField(TEXT("SamplerType")) || Properties->HasField(TEXT("sampler_type")))
+        // Handle SamplerType property (inherited from TextureSample) — string or numeric.
+        EMaterialSamplerType SamplerTypeValue;
+        if (TryParseSamplerTypeField(Properties, SamplerTypeValue))
         {
-            int32 SamplerTypeValue = Properties->HasField(TEXT("SamplerType"))
-                ? (int32)Properties->GetNumberField(TEXT("SamplerType"))
-                : (int32)Properties->GetNumberField(TEXT("sampler_type"));
-            ParticleSubUVExpr->SamplerType = (EMaterialSamplerType)SamplerTypeValue;
+            ParticleSubUVExpr->SamplerType = SamplerTypeValue;
         }
     }
-    // Handle TextureSample
+    // Handle TextureSample — also covers parameter subtypes that derive from it:
+    // TextureSampleParameter2D, TextureObjectParameter, etc.
     else if (UMaterialExpressionTextureSample* TextureSampleExpr = Cast<UMaterialExpressionTextureSample>(Expression))
     {
-        if (Properties->HasField(TEXT("texture")))
+        if (Properties->HasField(TEXT("texture")) || Properties->HasField(TEXT("Texture")))
         {
-            FString TexturePath = Properties->GetStringField(TEXT("texture"));
+            FString TexturePath = Properties->HasField(TEXT("texture"))
+                ? Properties->GetStringField(TEXT("texture"))
+                : Properties->GetStringField(TEXT("Texture"));
             UTexture* Texture = LoadObject<UTexture>(nullptr, *TexturePath);
             if (Texture)
             {
                 TextureSampleExpr->Texture = Texture;
             }
         }
-        // Handle SamplerType property
-        // Values: 0=Color, 1=Grayscale, 2=Alpha, 3=Normal, 4=Masks, 5=DistanceFieldFont, 6=LinearColor, 7=LinearGrayscale
-        if (Properties->HasField(TEXT("SamplerType")) || Properties->HasField(TEXT("sampler_type")))
-        {
-            int32 SamplerTypeValue = Properties->HasField(TEXT("SamplerType"))
-                ? (int32)Properties->GetNumberField(TEXT("SamplerType"))
-                : (int32)Properties->GetNumberField(TEXT("sampler_type"));
 
+        // ParameterName — only meaningful for parameter subtypes (TextureSampleParameter2D,
+        // TextureObjectParameter, ...). Without this, the param stays named "None" and
+        // Material Instances cannot override its texture by name.
+        if (Properties->HasField(TEXT("ParameterName")) || Properties->HasField(TEXT("parameter_name")))
+        {
+            if (UMaterialExpressionTextureSampleParameter* TexParam = Cast<UMaterialExpressionTextureSampleParameter>(Expression))
+            {
+                FString ParamName = Properties->HasField(TEXT("parameter_name"))
+                    ? Properties->GetStringField(TEXT("parameter_name"))
+                    : Properties->GetStringField(TEXT("ParameterName"));
+                TexParam->SetParameterName(FName(*ParamName));
+            }
+        }
+
+        // Handle SamplerType property — accepts an enum-name string ("Normal", "Masks",
+        // "LinearColor", ...) or a numeric index. Numeric-only parsing previously made
+        // string values silently fall back to SAMPLERTYPE_Color (0).
+        // Values: 0=Color, 1=Grayscale, 2=Alpha, 3=Normal, 4=Masks, 5=DistanceFieldFont, 6=LinearColor, 7=LinearGrayscale
+        EMaterialSamplerType SamplerTypeValue;
+        if (TryParseSamplerTypeField(Properties, SamplerTypeValue))
+        {
             // Use PreEditChange/PostEditChangeProperty for proper notification
             FProperty* SamplerTypeProp = TextureSampleExpr->GetClass()->FindPropertyByName(TEXT("SamplerType"));
             if (SamplerTypeProp)
             {
                 TextureSampleExpr->PreEditChange(SamplerTypeProp);
-                TextureSampleExpr->SamplerType = (EMaterialSamplerType)SamplerTypeValue;
+                TextureSampleExpr->SamplerType = SamplerTypeValue;
                 FPropertyChangedEvent PropertyChangedEvent(SamplerTypeProp);
                 TextureSampleExpr->PostEditChangeProperty(PropertyChangedEvent);
             }
             else
             {
                 // Fallback if property not found
-                TextureSampleExpr->SamplerType = (EMaterialSamplerType)SamplerTypeValue;
+                TextureSampleExpr->SamplerType = SamplerTypeValue;
             }
         }
     }

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Project/ProjectDataAssetService.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Project/ProjectDataAssetService.cpp
@@ -7,6 +7,11 @@
 #include "UObject/UnrealType.h"
 #include "Serialization/ObjectReader.h"
 #include "Misc/StringOutputDevice.h"
+#include "Editor.h"
+#include "GameFramework/Actor.h"
+#include "Components/ActorComponent.h"
+#include "Components/PrimitiveComponent.h"
+#include "UObject/Package.h"
 
 FProjectDataAssetService& FProjectDataAssetService::Get()
 {
@@ -353,6 +358,48 @@ bool FProjectDataAssetService::SetObjectProperty(const FString& AssetPath, const
     FPropertyChangedEvent ChangedEvent(Property);
     Asset->PostEditChangeProperty(ChangedEvent);
     Asset->MarkPackageDirty();
+
+    // Force a render-state refresh for level objects so the change shows live in
+    // the editor viewport. PostEditChangeProperty alone marks render state dirty
+    // on the component, but with viewport realtime off the swap (e.g. an
+    // OverrideMaterials change) won't appear until something redraws — hence the
+    // explicit MarkRenderStateDirty + RedrawLevelEditingViewports below.
+    if (UPrimitiveComponent* AsPrimitive = Cast<UPrimitiveComponent>(Asset))
+    {
+        AsPrimitive->MarkRenderStateDirty();
+    }
+    if (UActorComponent* AsComponent = Cast<UActorComponent>(Asset))
+    {
+        if (AActor* OwningActor = AsComponent->GetOwner())
+        {
+            OwningActor->MarkComponentsRenderStateDirty();
+        }
+    }
+    else if (AActor* AsActor = Cast<AActor>(Asset))
+    {
+        AsActor->MarkComponentsRenderStateDirty();
+    }
+
+    // Objects embedded in a level (actors/components) live in a map package, not a
+    // standalone saveable asset. UEditorAssetLibrary::SaveAsset can't save a map
+    // this way, so treating that as an error is wrong — the property IS set. Mark
+    // the map dirty (user saves the level) and redraw, then report success.
+    UPackage* OwningPackage = Asset->GetOutermost();
+    const bool bIsMapObject = OwningPackage && OwningPackage->ContainsMap();
+    if (bIsMapObject)
+    {
+        if (OwningPackage)
+        {
+            OwningPackage->MarkPackageDirty();
+        }
+        if (GEditor)
+        {
+            GEditor->RedrawLevelEditingViewports(true);
+        }
+        UE_LOG(LogTemp, Display, TEXT("MCP Project: Set '%s' = '%s' on level object '%s' (render refreshed; map left dirty for manual save)"),
+            *PropertyName, *ValueString, *AssetPath);
+        return true;
+    }
 
     if (!UEditorAssetLibrary::SaveAsset(AssetPath, false))
     {


### PR DESCRIPTION
…ject params; set_object_property render refresh for level objects

MaterialExpressionCreation.cpp:
- SamplerType now accepts enum-name strings ("Normal", "Masks", "LinearColor", ...) in addition to numeric indices. MCP clients pass property_value as a string, so the previous GetNumberField-only path silently coerced any string to SAMPLERTYPE_Color (0) — breaking normal maps and packed ORM masks fed into WorldAlignedTexture/WorldAlignedNormal.
- ParameterName is now applied to TextureSample-derived parameter nodes (TextureObjectParameter, TextureSampleParameter2D). Previously these stayed named "None", so Material Instances could not override their textures.

ProjectDataAssetService.cpp set_object_property:
- For level/map objects (actors, components): MarkRenderStateDirty + MarkComponentsRenderStateDirty + RedrawLevelEditingViewports so edits show live in the editor viewport.
- Skip UEditorAssetLibrary::SaveAsset for map-package objects (a level can't be saved that way) and report success — previously every component/actor edit returned "SaveAsset failed" even though the property was correctly set.

Validated live: built M_VoxelTriplanar (triplanar terrain master) + 6 MICs and swapped materials on a StaticMeshActor via set_object_property — viewport updated without restart, no false save error.