### PR TITLE
fix(mac): resolve clang -Werror build failures on macOS

### DIFF
--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/BlueprintAction/UnrealMCPBlueprintActionCommands.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/BlueprintAction/UnrealMCPBlueprintActionCommands.cpp
@@ -63,7 +63,18 @@
 // Utility to convert CamelCase function names to Title Case (e.g., "GetActorLocation" -> "Get Actor Location")
 static FString ConvertCamelCaseToTitleCase(const FString& InFunctionName)
 {
-    
+    FString Out;
+    Out.Reserve(InFunctionName.Len() * 2);
+    for (int32 i = 0; i < InFunctionName.Len(); ++i)
+    {
+        const TCHAR Ch = InFunctionName[i];
+        if (i > 0 && FChar::IsUpper(Ch) && !FChar::IsUpper(InFunctionName[i - 1]))
+        {
+            Out.AppendChar(TEXT(' '));
+        }
+        Out.AppendChar(Ch);
+    }
+    return Out;
 }
 
 // Phase 2 includes removed - using universal dynamic creation via Blueprint Action Database

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Editor/SetLevelWorldSettingsCommand.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Editor/SetLevelWorldSettingsCommand.cpp
@@ -11,7 +11,7 @@
 
 namespace
 {
-	FString MakeErr(const FString& Msg)
+	FString MakeWorldSettingsErr(const FString& Msg)
 	{
 		TSharedPtr<FJsonObject> Obj = MakeShared<FJsonObject>();
 		Obj->SetBoolField(TEXT("success"), false);
@@ -69,13 +69,13 @@ FString FSetLevelWorldSettingsCommand::Execute(const FString& Parameters)
 	TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Parameters);
 	if (!FJsonSerializer::Deserialize(Reader, JsonObject) || !JsonObject.IsValid())
 	{
-		return MakeErr(TEXT("Invalid JSON parameters"));
+		return MakeWorldSettingsErr(TEXT("Invalid JSON parameters"));
 	}
 
 	FString LevelPath;
 	if (!JsonObject->TryGetStringField(TEXT("level_path"), LevelPath) || LevelPath.IsEmpty())
 	{
-		return MakeErr(TEXT("Missing 'level_path' parameter"));
+		return MakeWorldSettingsErr(TEXT("Missing 'level_path' parameter"));
 	}
 
 	FString GameModePath;
@@ -83,30 +83,30 @@ FString FSetLevelWorldSettingsCommand::Execute(const FString& Parameters)
 
 	if (!GEditor)
 	{
-		return MakeErr(TEXT("GEditor is null — command requires editor context"));
+		return MakeWorldSettingsErr(TEXT("GEditor is null — command requires editor context"));
 	}
 
 	ULevelEditorSubsystem* LES = GEditor->GetEditorSubsystem<ULevelEditorSubsystem>();
 	if (!LES)
 	{
-		return MakeErr(TEXT("ULevelEditorSubsystem unavailable"));
+		return MakeWorldSettingsErr(TEXT("ULevelEditorSubsystem unavailable"));
 	}
 
 	if (!LES->LoadLevel(LevelPath))
 	{
-		return MakeErr(FString::Printf(TEXT("Failed to load level at %s"), *LevelPath));
+		return MakeWorldSettingsErr(FString::Printf(TEXT("Failed to load level at %s"), *LevelPath));
 	}
 
 	UWorld* World = GEditor->GetEditorWorldContext().World();
 	if (!World)
 	{
-		return MakeErr(TEXT("Editor world is null after LoadLevel"));
+		return MakeWorldSettingsErr(TEXT("Editor world is null after LoadLevel"));
 	}
 
 	AWorldSettings* WS = World->GetWorldSettings();
 	if (!WS)
 	{
-		return MakeErr(TEXT("WorldSettings is null"));
+		return MakeWorldSettingsErr(TEXT("WorldSettings is null"));
 	}
 
 	bool bChanged = false;
@@ -124,7 +124,7 @@ FString FSetLevelWorldSettingsCommand::Execute(const FString& Parameters)
 			UClass* GMClass = ResolveGameModeClass(GameModePath);
 			if (!GMClass)
 			{
-				return MakeErr(FString::Printf(
+				return MakeWorldSettingsErr(FString::Printf(
 					TEXT("Could not resolve GameMode class from path: %s"), *GameModePath));
 			}
 			WS->DefaultGameMode = GMClass;

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/BlueprintAction/BlueprintPinSearchService.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/BlueprintAction/BlueprintPinSearchService.cpp
@@ -317,12 +317,12 @@ FString FBlueprintPinSearchService::GetActionsForPin(
                 continue;
             }
             FString PropName = Property->GetName();
-            FString PinType = Property->GetCPPType();
+            FString PropertyPinType = Property->GetCPPType();
             FString Category = TEXT("Native Property");
-            FString Keywords = FString::Printf(TEXT("property variable %s %s native"), *PropName, *PinType);
+            FString Keywords = FString::Printf(TEXT("property variable %s %s native"), *PropName, *PropertyPinType);
             FString Tooltip = FString::Printf(TEXT("Access the %s property on %s"), *PropName, *TargetClass->GetName());
             // Apply search filter
-            if (!SearchFilter.IsEmpty() && !(PropName.ToLower().Contains(SearchFilter.ToLower()) || PinType.ToLower().Contains(SearchFilter.ToLower()) || Keywords.ToLower().Contains(SearchFilter.ToLower())))
+            if (!SearchFilter.IsEmpty() && !(PropName.ToLower().Contains(SearchFilter.ToLower()) || PropertyPinType.ToLower().Contains(SearchFilter.ToLower()) || Keywords.ToLower().Contains(SearchFilter.ToLower())))
             {
                 continue;
             }
@@ -334,7 +334,7 @@ FString FBlueprintPinSearchService::GetActionsForPin(
                 GetterObj->SetStringField(TEXT("tooltip"), Tooltip);
                 GetterObj->SetStringField(TEXT("category"), Category);
                 GetterObj->SetStringField(TEXT("variable_name"), PropName);
-                GetterObj->SetStringField(TEXT("pin_type"), PinType);
+                GetterObj->SetStringField(TEXT("pin_type"), PropertyPinType);
                 GetterObj->SetStringField(TEXT("function_name"), FString::Printf(TEXT("Get %s"), *DisplayName));
                 GetterObj->SetBoolField(TEXT("is_native_property"), true);
                 ActionsArray.Add(MakeShared<FJsonValueObject>(GetterObj));
@@ -349,7 +349,7 @@ FString FBlueprintPinSearchService::GetActionsForPin(
                 SetterObj->SetStringField(TEXT("tooltip"), Tooltip);
                 SetterObj->SetStringField(TEXT("category"), Category);
                 SetterObj->SetStringField(TEXT("variable_name"), PropName);
-                SetterObj->SetStringField(TEXT("pin_type"), PinType);
+                SetterObj->SetStringField(TEXT("pin_type"), PropertyPinType);
                 SetterObj->SetStringField(TEXT("function_name"), FString::Printf(TEXT("Set %s"), *DisplayName));
                 SetterObj->SetBoolField(TEXT("is_native_property"), true);
                 ActionsArray.Add(MakeShared<FJsonValueObject>(SetterObj));

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/BlueprintNode/BlueprintNodeQueryService.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/BlueprintNode/BlueprintNodeQueryService.cpp
@@ -177,7 +177,7 @@ bool FBlueprintNodeQueryService::FindBlueprintNodes(UBlueprint* Blueprint, const
                     FString NodeId = GetSafeNodeIdForQuery(Node, NodeTitle);
 
                     // Get node type
-                    FString NodeType = Node->GetClass()->GetName();
+                    FString NodeClassName = Node->GetClass()->GetName();
 
                     // Get node position
                     FVector2D Position(Node->NodePosX, Node->NodePosY);
@@ -186,7 +186,7 @@ bool FBlueprintNodeQueryService::FindBlueprintNodes(UBlueprint* Blueprint, const
                     TArray<FBlueprintPinInfo> PinInfos = GetNodePinInfo(Node);
 
                     // Create node info and set IsPure flag
-                    FBlueprintNodeInfo NodeInfo(NodeId, NodeTitle, NodeType, Position, PinInfos);
+                    FBlueprintNodeInfo NodeInfo(NodeId, NodeTitle, NodeClassName, Position, PinInfos);
                     NodeInfo.IsPure = IsNodePure(Node);
                     OutNodeInfos.Add(NodeInfo);
                 }
@@ -214,7 +214,7 @@ bool FBlueprintNodeQueryService::FindBlueprintNodes(UBlueprint* Blueprint, const
                             FString NodeId = GetSafeNodeIdForQuery(Node, NodeTitle);
 
                             // Get node type
-                            FString NodeType = Node->GetClass()->GetName();
+                            FString NodeClassName = Node->GetClass()->GetName();
 
                             // Get node position
                             FVector2D Position(Node->NodePosX, Node->NodePosY);
@@ -223,7 +223,7 @@ bool FBlueprintNodeQueryService::FindBlueprintNodes(UBlueprint* Blueprint, const
                             TArray<FBlueprintPinInfo> PinInfos = GetNodePinInfo(Node);
 
                             // Create node info and set IsPure flag
-                            FBlueprintNodeInfo NodeInfo(NodeId, NodeTitle, NodeType, Position, PinInfos);
+                            FBlueprintNodeInfo NodeInfo(NodeId, NodeTitle, NodeClassName, Position, PinInfos);
                             NodeInfo.IsPure = IsNodePure(Node);
                             OutNodeInfos.Add(NodeInfo);
                         }

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/UnrealMCPBridge.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/UnrealMCPBridge.cpp
@@ -249,7 +249,7 @@ FString UUnrealMCPBridge::ExecuteCommand(const FString& CommandType, const TShar
             else
             {
                 // Define command arrays for better maintenance
-                static const TArray<FString> EditorCommands = {
+                static const TArray<FString> EditorCommandsList = {
                     TEXT("spawn_actor"),
                     TEXT("create_actor"),
                     TEXT("delete_actor"),
@@ -352,7 +352,7 @@ FString UUnrealMCPBridge::ExecuteCommand(const FString& CommandType, const TShar
                     }
                 }
                 // Fall back to legacy command handlers
-                else if (EditorCommands.Contains(CommandType))
+                else if (EditorCommandsList.Contains(CommandType))
                 {
                     ResultJson = this->EditorCommands->HandleCommand(CommandType, Params);
                 }

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/UnrealMCP.Build.cs
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/UnrealMCP.Build.cs
@@ -21,7 +21,6 @@ public class UnrealMCP : ModuleRules
 		PrivateIncludePaths.AddRange(
 			new string[] {
 				// ... add other private include paths required here ...
-				"Runtime/AdvancedWidgets/Public"
 			}
 		);
 


### PR DESCRIPTION
## Summary

The plugin fails to compile on macOS (UE 5.7 / Xcode 26.5 / arm64) because Mac clang escalates several diagnostics to errors that MSVC tolerates. This PR fixes each issue at its root rather than relaxing warning levels in `Build.cs`.

## What changed

- **`ConvertCamelCaseToTitleCase` had an empty body** — triggered `-Werror,-Wreturn-type`. Implemented the conversion (inserts a space before any uppercase letter that follows a lowercase one).
- **Phantom `PrivateIncludePaths` entry** — `Runtime/AdvancedWidgets/Public` does not exist; `AdvancedWidgets` is already a private dependency module. Removed the bad path.
- **`MakeErr` redefinition** — two files (`SetLevelWorldSettingsCommand.cpp`, `SetBlueprintParentClassCommand.cpp`) both defined a free function `MakeErr` in an anonymous namespace. Unreal's unity build concatenates them into one TU, causing a redefinition error. Renamed the WorldSettings version to `MakeWorldSettingsErr`.
- **Four `-Werror,-Wshadow` errors**:
  - `UnrealMCPBridge.cpp`: local `static const TArray<FString> EditorCommands` shadowed the `EditorCommands` member (`TSharedPtr<FUnrealMCPEditorCommands>`). Renamed local → `EditorCommandsList` (matches the existing `*List` naming for sibling locals).
  - `BlueprintPinSearchService.cpp`: inner-loop `FString PinType` shadowed the function parameter `PinType`. Renamed → `PropertyPinType`.
  - `BlueprintNodeQueryService.cpp`: two inner-loop `FString NodeType` declarations shadowed the function parameter `NodeType`. Renamed → `NodeClassName` (more descriptive — these hold `Node->GetClass()->GetName()`, not the high-level node-type filter).

## Verification

Rebuilt cleanly from scratch on:
- UE 5.7
- Xcode 26.5 (Apple clang)
- macOS 15 (arm64)

Result: `Succeeded`. No new errors; only pre-existing deprecation warnings remain (unrelated to this PR).

## Test plan

- [x] Clean rebuild of `RhyaTowerOfWishesEditor Mac Development` target succeeds
- [x] Plugin links to `UnrealEditor-UnrealMCP.dylib` without errors
- [ ] Maintainer review of the rename choices (happy to adjust names if you prefer different conventions)