### PR TITLE
fix(deps): bump httpcore 1.0.7 -> 1.0.8 (fixes Python 3.14 import crash)

### DIFF
--- a/Python/uv.lock
+++ b/Python/uv.lock
@@ -540,15 +540,15 @@ wheels = [
 
 [[package]]
 name = "httpcore"
-version = "1.0.7"
+version = "1.0.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6a/41/d7d0a89eb493922c37d343b607bc1b5da7f5be7e383740b4753ad8943e90/httpcore-1.0.7.tar.gz", hash = "sha256:8551cb62a169ec7162ac7be8d4817d561f60e08eaa485234898414bb5a8a0b4c", size = 85196 }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/45/ad3e1b4d448f22c0cff4f5692f5ed0666658578e358b8d58a19846048059/httpcore-1.0.8.tar.gz", hash = "sha256:86e94505ed24ea06514883fd44d2bc02d90e77e7979c8eb71b90f41d364a1bad", size = 85385 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/f5/72347bc88306acb359581ac4d52f23c0ef445b57157adedb9aee0cd689d2/httpcore-1.0.7-py3-none-any.whl", hash = "sha256:a3fff8f43dc260d5bd363d9f9cf1830fa3a458b332856f34282de498ed420edd", size = 78551 },
+    { url = "https://files.pythonhosted.org/packages/18/8d/f052b1e336bb2c1fc7ed1aaed898aa570c0b61a09707b108979d9fc6e308/httpcore-1.0.8-py3-none-any.whl", hash = "sha256:5254cf149bcb5f75e9d1b2b9f729ea4a4b883d1ad7379fc632b727cec23674be", size = 78732 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

On **Python 3.14**, importing `httpcore` 1.0.7 crashes:

```
AttributeError: 'typing.Union' object has no attribute '__module__' and no __dict__ for setting new attributes
  ...httpcore/__init__.py:140
```

`uv.lock` pins `httpcore==1.0.7`, and since `uv run` / `uv sync` install from the lock, **every environment created on Python 3.14 hits this** (and `uv venv` with the current `requires-python = ">=3.10"` will pick the newest interpreter, which is now 3.14).

The practical impact: the **FastMCP-based** servers (`from fastmcp import ...`) import `httpx → httpcore` during FastMCP's startup version-check and **crash on launch**, so ~half the MCP servers (animation, blueprint, material, mesh, niagara, pcg, sound, statetree) never register their tools. The `mcp.server.fastmcp`-based servers don't make that import and are unaffected — which is why the failure looks partial.

`httpcore` **1.0.8** fixes exactly this (changelog: *"Fix `AttributeError` when importing on Python 3.14"*). `httpx` already constrains `httpcore==1.*`, so this is a drop-in bump with no other resolution changes.

## Change

One package in `uv.lock`: `httpcore` 1.0.7 → 1.0.8 (sdist + wheel + version). I edited only the `httpcore` stanza and left the lockfile at its existing revision, so the diff is limited to those 3 lines rather than a full lock regeneration.

## Verification

Isolated environments (`uv run --no-project --isolated --python 3.14`):

| Setup | Result |
|---|---|
| httpcore **1.0.7** + Python 3.14 | ❌ reproduces the `AttributeError` |
| httpcore **1.0.8** + Python 3.14 | ✅ imports cleanly |

After the bump, **all 15 MCP servers** initialize and respond to `tools/list` (verified via an MCP `initialize` + `tools/list` handshake against each).

## Test plan

- [x] Reproduce crash on 1.0.7 / Python 3.14
- [x] Confirm 1.0.8 imports on Python 3.14
- [x] All 15 servers boot + list tools after the change
- [ ] Maintainer: confirm you're OK keeping the lock at its current revision (vs. a full `uv lock` regeneration on your uv version)