### PR TITLE
Fix silent MCP TCP freezes with server-side timeouts and shared Python TCP client

### DIFF
--- a/Docs/known-issues.md
+++ b/Docs/known-issues.md
@@ -4,6 +4,27 @@ This file tracks MCP tool limitations discovered during development. When encoun
 
 ## Active Issues
 
+### MCP TCP Connection Freezes (Mitigated 2026-05-31)
+- **Affected**: All MCP servers communicating via TCP port 55557
+- **Previous Problem**: After long sessions, MCP tools could hang silently with no error returned to Cursor. Causes included:
+  - C++ server logging parse errors but never sending a response (client/server deadlock)
+  - `Future.Get()` blocking the server thread indefinitely when the game thread was stalled (modal dialogs, heavy compiles)
+  - Python async clients using `reader.read(49152)` with no timeout
+  - Single 8192-byte `Recv()` truncating large command payloads
+- **Fix Applied**:
+  - C++ server always returns JSON (success or error) and uses one-shot request/response per connection
+  - Multi-chunk JSON read on C++ (up to 256 KB commands) and Python (up to 4 MB responses)
+  - 120s command timeout on C++ `ExecuteCommand`; 130s timeout on Python clients
+  - Shared async TCP utility: `Python/utils/async_tcp_utils.py`
+- **120s Timeout Policy**: Commands exceeding 120 seconds return a timeout error instead of freezing MCP. Heavy operations (large Blueprint/Niagara compiles) may hit this limit — split work into smaller steps or compile manually in the editor.
+- **Recovery if timeout occurs**:
+  1. Check UE Output Log for `"Command timed out"` or stuck `"Executing command"`
+  2. Look for hidden modal dialogs in the editor (save prompts, Material/Niagara editor dialogs)
+  3. Restart Unreal Editor if the server thread remains wedged
+  4. Restart Python MCP servers in Cursor after UE restart
+- **Known Limitation**: A timed-out command may still complete on the game thread later (AsyncTask is not cancelled). The timeout unblocks the server thread so other MCP calls can proceed.
+- **Debug TCP logging**: Set `UNREAL_MCP_TCP_DEBUG=1` to enable `Python/tcp_debug.log` (disabled by default to avoid unbounded file growth).
+
 ### Struct Field GUID Middle Numbers Can Change When Structs Are Modified
 - **Affected**: `get_struct_pin_names`, `get_datatable_row_names`, DataTable operations
 - **Problem**: User-defined structs use GUID-based internal field names (e.g., `TestField1_2_1EAE0B8A4B971533B2AD21BF45BA9220`). The hex suffix (GUID) remains stable, but the middle number can change when the struct is modified (type changes, field additions/removals).

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/MCPServerRunnable.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/MCPServerRunnable.cpp
@@ -7,282 +7,269 @@
 #include "Dom/JsonValue.h"
 #include "Serialization/JsonSerializer.h"
 #include "Serialization/JsonReader.h"
+#include "Serialization/JsonWriter.h"
 #include "JsonObjectConverter.h"
-#include "Misc/ScopeLock.h"
 #include "HAL/PlatformTime.h"
 
-// Buffer size for receiving data - renamed to avoid UE 5.7 template conflicts
-const int32 MCPBufferSize = 8192;
+namespace
+{
+constexpr int32 MCPRecvChunkSize = 8192;
+constexpr int32 MCPMaxMessageBytes = 256 * 1024;
+
+enum class EReadJsonResult
+{
+	Success,
+	Disconnected,
+	TooLarge,
+	ParseError
+};
+
+FString MakeErrorResponse(const FString& ErrorMessage)
+{
+	TSharedPtr<FJsonObject> ErrorJson = MakeShared<FJsonObject>();
+	ErrorJson->SetStringField(TEXT("status"), TEXT("error"));
+	ErrorJson->SetStringField(TEXT("error"), ErrorMessage);
+
+	FString ResultString;
+	TSharedRef<TJsonWriter<TCHAR, TCondensedJsonPrintPolicy<TCHAR>>> Writer =
+		TJsonWriterFactory<TCHAR, TCondensedJsonPrintPolicy<TCHAR>>::Create(&ResultString);
+	FJsonSerializer::Serialize(ErrorJson.ToSharedRef(), Writer.Get());
+	return ResultString;
+}
+
+bool TryParseJsonObject(const FString& JsonText, TSharedPtr<FJsonObject>& OutObject)
+{
+	TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(JsonText);
+	return FJsonSerializer::Deserialize(Reader, OutObject) && OutObject.IsValid();
+}
+
+FString BytesToUtf8String(const TArray<uint8>& Bytes)
+{
+	if (Bytes.Num() == 0)
+	{
+		return FString();
+	}
+
+	FUTF8ToTCHAR Converter(reinterpret_cast<const ANSICHAR*>(Bytes.GetData()), Bytes.Num());
+	return FString(Converter.Length(), Converter.Get());
+}
+
+EReadJsonResult ReadCompleteJsonMessage(TSharedPtr<FSocket> Socket, FString& OutMessage, FString& OutError)
+{
+	TArray<uint8> AccumulatedBytes;
+	AccumulatedBytes.Reserve(MCPRecvChunkSize);
+
+	uint8 Buffer[MCPRecvChunkSize];
+
+	while (AccumulatedBytes.Num() < MCPMaxMessageBytes)
+	{
+		int32 BytesRead = 0;
+		if (!Socket->Recv(Buffer, sizeof(Buffer), BytesRead))
+		{
+			const int32 LastError = static_cast<int32>(ISocketSubsystem::Get()->GetLastErrorCode());
+			if (LastError == SE_EWOULDBLOCK || LastError == SE_EINTR)
+			{
+				FPlatformProcess::Sleep(0.01f);
+				continue;
+			}
+
+			if (AccumulatedBytes.Num() == 0)
+			{
+				OutError = TEXT("Client disconnected before sending data");
+				return EReadJsonResult::Disconnected;
+			}
+
+			break;
+		}
+
+		if (BytesRead == 0)
+		{
+			if (AccumulatedBytes.Num() == 0)
+			{
+				OutError = TEXT("Client disconnected before sending data");
+				return EReadJsonResult::Disconnected;
+			}
+			break;
+		}
+
+		AccumulatedBytes.Append(Buffer, BytesRead);
+
+		FString ReceivedText = BytesToUtf8String(AccumulatedBytes);
+		ReceivedText.TrimStartAndEndInline();
+
+		TSharedPtr<FJsonObject> JsonObject;
+		if (TryParseJsonObject(ReceivedText, JsonObject))
+		{
+			OutMessage = ReceivedText;
+			return EReadJsonResult::Success;
+		}
+	}
+
+	if (AccumulatedBytes.Num() >= MCPMaxMessageBytes)
+	{
+		OutError = FString::Printf(TEXT("Message exceeds maximum size of %d bytes"), MCPMaxMessageBytes);
+		return EReadJsonResult::TooLarge;
+	}
+
+	FString ReceivedText = BytesToUtf8String(AccumulatedBytes);
+	ReceivedText.TrimStartAndEndInline();
+	if (ReceivedText.IsEmpty())
+	{
+		OutError = TEXT("Received empty message");
+	}
+	else
+	{
+		OutError = TEXT("Invalid JSON payload");
+	}
+	return EReadJsonResult::ParseError;
+}
+
+bool SendJsonResponse(TSharedPtr<FSocket> Socket, const FString& ResponseJson)
+{
+	FTCHARToUTF8 UTF8Response(*ResponseJson);
+	const int32 UTF8ByteLength = UTF8Response.Length();
+	int32 BytesSent = 0;
+
+	if (!Socket->Send(reinterpret_cast<const uint8*>(UTF8Response.Get()), UTF8ByteLength, BytesSent))
+	{
+		const int32 SendError = static_cast<int32>(ISocketSubsystem::Get()->GetLastErrorCode());
+		UE_LOG(LogTemp, Error, TEXT("MCPServerRunnable: Failed to send response. Error: %d"), SendError);
+		return false;
+	}
+
+	if (BytesSent != UTF8ByteLength)
+	{
+		UE_LOG(LogTemp, Warning, TEXT("MCPServerRunnable: Partial response sent (%d/%d bytes)"), BytesSent, UTF8ByteLength);
+		return false;
+	}
+
+	UE_LOG(LogTemp, Verbose, TEXT("MCPServerRunnable: Response sent successfully (%d bytes)"), BytesSent);
+	return true;
+}
+
+void ConfigureClientSocket(TSharedPtr<FSocket> ClientSocket)
+{
+	ClientSocket->SetNoDelay(true);
+
+	int32 SocketBufferSize = 65536;
+	int32 ActualSendBufferSize = 0;
+	int32 ActualReceiveBufferSize = 0;
+	ClientSocket->SetSendBufferSize(SocketBufferSize, ActualSendBufferSize);
+	ClientSocket->SetReceiveBufferSize(SocketBufferSize, ActualReceiveBufferSize);
+	ClientSocket->SetNonBlocking(false);
+}
+
+FString ProcessClientRequest(UUnrealMCPBridge* Bridge, const FString& ReceivedText)
+{
+	TSharedPtr<FJsonObject> JsonObject;
+	if (!TryParseJsonObject(ReceivedText, JsonObject))
+	{
+		UE_LOG(LogTemp, Warning, TEXT("MCPServerRunnable: Failed to parse JSON command"));
+		return MakeErrorResponse(TEXT("Invalid JSON payload"));
+	}
+
+	FString CommandType;
+	if (!JsonObject->TryGetStringField(TEXT("type"), CommandType))
+	{
+		TArray<FString> FieldNames;
+		JsonObject->Values.GetKeys(FieldNames);
+		const FString FieldList = FString::Join(FieldNames, TEXT(", "));
+		UE_LOG(LogTemp, Warning, TEXT("MCPServerRunnable: Missing 'type' field. Available fields: %s"), *FieldList);
+		return MakeErrorResponse(TEXT("Missing type field"));
+	}
+
+	TSharedPtr<FJsonObject> Params = MakeShared<FJsonObject>();
+	const TSharedPtr<FJsonObject>* ParamsPtr = nullptr;
+	if (JsonObject->TryGetObjectField(TEXT("params"), ParamsPtr) && ParamsPtr && ParamsPtr->IsValid())
+	{
+		Params = *ParamsPtr;
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: Executing command: %s"), *CommandType);
+	const double ExecuteStartTime = FPlatformTime::Seconds();
+	const FString Response = Bridge->ExecuteCommand(CommandType, Params);
+	UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: Command '%s' completed in %.3f seconds"), *CommandType, FPlatformTime::Seconds() - ExecuteStartTime);
+	return Response;
+}
+} // namespace
 
 FMCPServerRunnable::FMCPServerRunnable(UUnrealMCPBridge* InBridge, TSharedPtr<FSocket> InListenerSocket)
-    : Bridge(InBridge)
-    , ListenerSocket(InListenerSocket)
-    , bRunning(true)
+	: Bridge(InBridge)
+	, ListenerSocket(InListenerSocket)
+	, bRunning(true)
 {
-    UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: Created server runnable"));
+	UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: Created server runnable"));
 }
 
 FMCPServerRunnable::~FMCPServerRunnable()
 {
-    // Note: We don't delete the sockets here as they're owned by the bridge
+	// Note: We don't delete the sockets here as they're owned by the bridge
 }
 
 bool FMCPServerRunnable::Init()
 {
-    return true;
+	return true;
 }
 
 uint32 FMCPServerRunnable::Run()
 {
-    UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: Server thread starting..."));
-    
-    while (bRunning)
-    {
-        // UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: Waiting for client connection..."));
-        
-        bool bPending = false;
-        if (ListenerSocket->HasPendingConnection(bPending) && bPending)
-        {
-            UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: Client connection pending, accepting..."));
-            
-            ClientSocket = MakeShareable(ListenerSocket->Accept(TEXT("MCPClient")));
-            if (ClientSocket.IsValid())
-            {
-                UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: Client connection accepted"));
-                
-                // Log client connection details
-                TSharedRef<FInternetAddr> ClientAddr = ISocketSubsystem::Get()->CreateInternetAddr();
-                if (ClientSocket->GetPeerAddress(*ClientAddr))
-                {
-                    UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: Client connected from: %s"), *ClientAddr->ToString(true));
-                }
-                else
-                {
-                    UE_LOG(LogTemp, Warning, TEXT("MCPServerRunnable: Could not get client address"));
-                }
-                
-                // Set socket options to improve connection stability
-                bool bNoDelayResult = ClientSocket->SetNoDelay(true);
-                UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: SetNoDelay result: %s"), bNoDelayResult ? TEXT("Success") : TEXT("Failed"));
-                
-                int32 SocketBufferSize = 65536;  // 64KB buffer
-                int32 ActualSendBufferSize = 0;
-                int32 ActualReceiveBufferSize = 0;
-                
-                bool bSendBufferResult = ClientSocket->SetSendBufferSize(SocketBufferSize, ActualSendBufferSize);
-                bool bReceiveBufferResult = ClientSocket->SetReceiveBufferSize(SocketBufferSize, ActualReceiveBufferSize);
-                
-                UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: Buffer setup - SendBuffer: %s (requested: %d, actual: %d), ReceiveBuffer: %s (requested: %d, actual: %d)"), 
-                       bSendBufferResult ? TEXT("Success") : TEXT("Failed"), SocketBufferSize, ActualSendBufferSize,
-                       bReceiveBufferResult ? TEXT("Success") : TEXT("Failed"), SocketBufferSize, ActualReceiveBufferSize);
-                
-                // Set socket to non-blocking mode for better control
-                bool bNonBlockingResult = ClientSocket->SetNonBlocking(false);
-                UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: SetNonBlocking(false) result: %s"), bNonBlockingResult ? TEXT("Success") : TEXT("Failed"));
-                
-                uint8 Buffer[8192];
-                int32 ConnectionAttempts = 0;
-                double ConnectionStartTime = FPlatformTime::Seconds();
-                
-                while (bRunning)
-                {
-                    ConnectionAttempts++;
-                    int32 BytesRead = 0;
-                    
-                    // Log connection state before attempting to receive
-                    ESocketConnectionState ConnectionState = ClientSocket->GetConnectionState();
-                    FString ConnectionStateStr;
-                    switch (ConnectionState)
-                    {
-                        case SCS_NotConnected: ConnectionStateStr = TEXT("NotConnected"); break;
-                        case SCS_Connected: ConnectionStateStr = TEXT("Connected"); break;
-                        case SCS_ConnectionError: ConnectionStateStr = TEXT("ConnectionError"); break;
-                        default: ConnectionStateStr = TEXT("Unknown"); break;
-                    }
-                    
-                    // Check for pending data before attempting to receive
-                    uint32 PendingDataSize = 0;
-                    bool bHasPendingData = ClientSocket->HasPendingData(PendingDataSize);
-                    
-                    UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: Attempt %d - ConnectionState: %s, HasPendingData: %s, PendingSize: %d"), 
-                           ConnectionAttempts, *ConnectionStateStr, bHasPendingData ? TEXT("Yes") : TEXT("No"), PendingDataSize);
-                    
-                    bool bRecvResult = ClientSocket->Recv(Buffer, sizeof(Buffer), BytesRead);
-                    
-                    UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: Recv result - Success: %s, BytesRead: %d"), 
-                           bRecvResult ? TEXT("Yes") : TEXT("No"), BytesRead);
-                    
-                    if (bRecvResult)
-                    {
-                        if (BytesRead == 0)
-                        {
-                            double ConnectionDuration = FPlatformTime::Seconds() - ConnectionStartTime;
-                            UE_LOG(LogTemp, Warning, TEXT("MCPServerRunnable: Client disconnected (zero bytes) after %d attempts in %.3f seconds"), 
-                                   ConnectionAttempts, ConnectionDuration);
-                            
-                            // Check if this is a graceful disconnect or an error
-                            int32 LastError = (int32)ISocketSubsystem::Get()->GetLastErrorCode();
-                            UE_LOG(LogTemp, Warning, TEXT("MCPServerRunnable: Last socket error code: %d"), LastError);
-                            break;
-                        }
+	UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: Server thread starting..."));
 
-                        // Convert received data to string
-                        Buffer[BytesRead] = '\0';
-                        FString ReceivedText = UTF8_TO_TCHAR(Buffer);
-                        
-                        // Log first 200 characters to avoid spam with large payloads
-                        FString LogText = ReceivedText.Len() > 200 ? ReceivedText.Left(200) + TEXT("...") : ReceivedText;
-                        UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: Received %d bytes: %s"), BytesRead, *LogText);
+	while (bRunning)
+	{
+		bool bPending = false;
+		if (ListenerSocket->HasPendingConnection(bPending) && bPending)
+		{
+			ClientSocket = MakeShareable(ListenerSocket->Accept(TEXT("MCPClient")));
+			if (ClientSocket.IsValid())
+			{
+				UE_LOG(LogTemp, Verbose, TEXT("MCPServerRunnable: Client connection accepted"));
+				ConfigureClientSocket(ClientSocket);
 
-                        // Parse JSON
-                        TSharedPtr<FJsonObject> JsonObject;
-                        TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(ReceivedText);
-                        
-                        double ParseStartTime = FPlatformTime::Seconds();
-                        bool bParseSuccess = FJsonSerializer::Deserialize(Reader, JsonObject);
-                        double ParseDuration = FPlatformTime::Seconds() - ParseStartTime;
-                        
-                        if (bParseSuccess && JsonObject.IsValid())
-                        {
-                            UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: JSON parsed successfully in %.3f seconds"), ParseDuration);
-                            
-                            // Get command type
-                            FString CommandType;
-                            if (JsonObject->TryGetStringField(TEXT("type"), CommandType))
-                            {
-                                UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: Executing command: %s"), *CommandType);
-                                
-                                // Execute command with timing
-                                double ExecuteStartTime = FPlatformTime::Seconds();
-                                FString Response = Bridge->ExecuteCommand(CommandType, JsonObject->GetObjectField(TEXT("params")));
-                                double ExecuteDuration = FPlatformTime::Seconds() - ExecuteStartTime;
-                                
-                                UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: Command executed in %.3f seconds"), ExecuteDuration);
-                                
-                                // Log response for debugging
-                                UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: Response: %s"), *Response);
-                                
-                                // Convert to UTF-8 and get actual byte length
-                                FTCHARToUTF8 UTF8Response(*Response);
-                                int32 UTF8ByteLength = UTF8Response.Length();
-                                
-                                UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: Sending response (%d characters, %d UTF-8 bytes)"), Response.Len(), UTF8ByteLength);
-                                
-                                // Send response with correct byte length
-                                int32 BytesSent = 0;
-                                double SendStartTime = FPlatformTime::Seconds();
-                                bool bSendSuccess = ClientSocket->Send((const uint8*)UTF8Response.Get(), UTF8ByteLength, BytesSent);
-                                double SendDuration = FPlatformTime::Seconds() - SendStartTime;
-                                
-                                if (!bSendSuccess)
-                                {
-                                    int32 SendError = (int32)ISocketSubsystem::Get()->GetLastErrorCode();
-                                    UE_LOG(LogTemp, Error, TEXT("MCPServerRunnable: Failed to send response. Error: %d, Duration: %.3f seconds"), SendError, SendDuration);
-                                }
-                                else {
-                                    UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: Response sent successfully - %d bytes in %.3f seconds"), BytesSent, SendDuration);
-                                }
-                            }
-                            else
-                            {
-                                UE_LOG(LogTemp, Warning, TEXT("MCPServerRunnable: Missing 'type' field in command JSON"));
-                                
-                                // Log available fields for debugging
-                                TArray<FString> FieldNames;
-                                JsonObject->Values.GetKeys(FieldNames);
-                                FString FieldList = FString::Join(FieldNames, TEXT(", "));
-                                UE_LOG(LogTemp, Warning, TEXT("MCPServerRunnable: Available fields: %s"), *FieldList);
-                            }
-                        }
-                        else
-                        {
-                            UE_LOG(LogTemp, Error, TEXT("MCPServerRunnable: Failed to parse JSON in %.3f seconds. Raw data: %s"), ParseDuration, *ReceivedText);
-                            
-                            // Try to identify the issue
-                            if (ReceivedText.IsEmpty())
-                            {
-                                UE_LOG(LogTemp, Error, TEXT("MCPServerRunnable: Received empty string"));
-                            }
-                            else if (!ReceivedText.StartsWith(TEXT("{")))
-                            {
-                                UE_LOG(LogTemp, Error, TEXT("MCPServerRunnable: Data doesn't start with '{' - not valid JSON"));
-                            }
-                        }
-                    }
-                    else
-                    {
-                        int32 LastError = (int32)ISocketSubsystem::Get()->GetLastErrorCode();
-                        ESocketConnectionState CurrentState = ClientSocket->GetConnectionState();
-                        
-                        // Log detailed error information
-                        FString ErrorDescription;
-                        bool bShouldBreak = true;
-                        
-                        // Check for "would block" error which isn't a real error for non-blocking sockets
-                        if (LastError == SE_EWOULDBLOCK) 
-                        {
-                            ErrorDescription = TEXT("Socket would block (normal for non-blocking)");
-                            UE_LOG(LogTemp, Verbose, TEXT("MCPServerRunnable: %s, continuing..."), *ErrorDescription);
-                            bShouldBreak = false;
-                            // Small sleep to prevent tight loop when no data
-                            FPlatformProcess::Sleep(0.01f);
-                        }
-                        // Check for other transient errors we might want to tolerate
-                        else if (LastError == SE_EINTR) // Interrupted system call
-                        {
-                            ErrorDescription = TEXT("Socket read interrupted");
-                            UE_LOG(LogTemp, Warning, TEXT("MCPServerRunnable: %s, continuing..."), *ErrorDescription);
-                            bShouldBreak = false;
-                        }
-                        else 
-                        {
-                            // Map common error codes to descriptions
-                            switch (LastError)
-                            {
-                                case 0: // No error - normal graceful disconnection
-                                    ErrorDescription = TEXT("Graceful disconnection (no error)");
-                                    UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: Client disconnected gracefully after %d attempts. Connection completed successfully."), 
-                                           ConnectionAttempts);
-                                    break;
-                                case SE_ECONNRESET: ErrorDescription = TEXT("Connection reset by peer"); break;
-                                case SE_ECONNABORTED: ErrorDescription = TEXT("Connection aborted"); break;
-                                case SE_ENETDOWN: ErrorDescription = TEXT("Network is down"); break;
-                                case SE_ENETUNREACH: ErrorDescription = TEXT("Network unreachable"); break;
-                                case SE_ENOTCONN: ErrorDescription = TEXT("Socket not connected"); break;
-                                case SE_ESHUTDOWN: ErrorDescription = TEXT("Socket shutdown"); break;
-                                case SE_ETIMEDOUT: ErrorDescription = TEXT("Connection timed out"); break;
-                                default: 
-                                    ErrorDescription = FString::Printf(TEXT("Unknown error code %d"), LastError);
-                                    UE_LOG(LogTemp, Warning, TEXT("MCPServerRunnable: Client disconnected or error after %d attempts. Error: %s, ConnectionState: %d"), 
-                                           ConnectionAttempts, *ErrorDescription, (int32)CurrentState);
-                                    break;
-                            }
-                        }
-                        
-                        if (bShouldBreak)
-                        {
-                            break;
-                        }
-                    }
-                }
-            }
-            else
-            {
-                UE_LOG(LogTemp, Warning, TEXT("MCPServerRunnable: Failed to accept client connection"));
-            }
-        }
-        
-        // Small sleep to prevent tight loop
-        FPlatformProcess::Sleep(0.1f);
-    }
-    
-    UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: Server thread stopping"));
-    return 0;
+				FString ReceivedText;
+				FString ReadError;
+				const EReadJsonResult ReadResult = ReadCompleteJsonMessage(ClientSocket, ReceivedText, ReadError);
+
+				FString ResponseJson;
+				switch (ReadResult)
+				{
+				case EReadJsonResult::Success:
+					ResponseJson = ProcessClientRequest(Bridge, ReceivedText);
+					break;
+				case EReadJsonResult::Disconnected:
+					UE_LOG(LogTemp, Verbose, TEXT("MCPServerRunnable: %s"), *ReadError);
+					break;
+				case EReadJsonResult::TooLarge:
+				case EReadJsonResult::ParseError:
+				default:
+					UE_LOG(LogTemp, Warning, TEXT("MCPServerRunnable: %s"), *ReadError);
+					ResponseJson = MakeErrorResponse(ReadError);
+					break;
+				}
+
+				if (!ResponseJson.IsEmpty())
+				{
+					SendJsonResponse(ClientSocket, ResponseJson);
+				}
+
+				ClientSocket.Reset();
+			}
+			else
+			{
+				UE_LOG(LogTemp, Warning, TEXT("MCPServerRunnable: Failed to accept client connection"));
+			}
+		}
+
+		FPlatformProcess::Sleep(0.1f);
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: Server thread stopping"));
+	return 0;
 }
 
 void FMCPServerRunnable::Stop()
 {
-    bRunning = false;
+	bRunning = false;
 }
 
 void FMCPServerRunnable::Exit()
@@ -291,156 +278,89 @@ void FMCPServerRunnable::Exit()
 
 void FMCPServerRunnable::HandleClientConnection(TSharedPtr<FSocket> InClientSocket)
 {
-    if (!InClientSocket.IsValid())
-    {
-        UE_LOG(LogTemp, Error, TEXT("MCPServerRunnable: Invalid client socket passed to HandleClientConnection"));
-        return;
-    }
+	if (!InClientSocket.IsValid())
+	{
+		UE_LOG(LogTemp, Error, TEXT("MCPServerRunnable: Invalid client socket passed to HandleClientConnection"));
+		return;
+	}
 
-    UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: Starting to handle client connection"));
-    
-    // Set socket options for better connection stability
-    InClientSocket->SetNonBlocking(false);
-    UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: Set socket to blocking mode"));
-    
-    // Properly read full message with timeout
-    const int32 MaxBufferSize = 4096;
-    uint8 Buffer[MaxBufferSize];
-    FString MessageBuffer;
-    
-    UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: Starting message receive loop"));
-    
-    while (bRunning && InClientSocket.IsValid())
-    {
-        // Log socket state
-        bool bIsConnected = InClientSocket->GetConnectionState() == SCS_Connected;
-        UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: Socket state - Connected: %s"), 
-               bIsConnected ? TEXT("true") : TEXT("false"));
-        
-        // Log pending data status before receive
-        uint32 PendingDataSize = 0;
-        bool HasPendingData = InClientSocket->HasPendingData(PendingDataSize);
-        UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: Before Recv - HasPendingData=%s, Size=%d"), 
-               HasPendingData ? TEXT("true") : TEXT("false"), PendingDataSize);
-        
-        // Try to receive data with timeout
-        int32 BytesRead = 0;
-        bool bReadSuccess = false;
-        
-        UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: Attempting to receive data..."));
-        bReadSuccess = InClientSocket->Recv(Buffer, MaxBufferSize, BytesRead, ESocketReceiveFlags::None);
-        
-        UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: Recv attempt complete - Success=%s, BytesRead=%d"), 
-               bReadSuccess ? TEXT("true") : TEXT("false"), BytesRead);
-        
-        if (BytesRead > 0)
-        {
-            // Log raw data for debugging
-            FString HexData;
-            for (int32 i = 0; i < FMath::Min(BytesRead, 50); ++i)
-            {
-                HexData += FString::Printf(TEXT("%02X "), Buffer[i]);
-            }
-            UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: Raw data (first 50 bytes hex): %s%s"), 
-                   *HexData, BytesRead > 50 ? TEXT("...") : TEXT(""));
-            
-            // Convert and log received data
-            Buffer[BytesRead] = 0; // Null terminate
-            FString ReceivedData = UTF8_TO_TCHAR(Buffer);
-            UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: Received data as string: '%s'"), *ReceivedData);
-            
-            // Append to message buffer
-            MessageBuffer.Append(ReceivedData);
-            
-            // Process complete messages (messages are terminated with newline)
-            if (MessageBuffer.Contains(TEXT("\n")))
-            {
-                UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: Newline detected in buffer, processing messages"));
-                
-                TArray<FString> Messages;
-                MessageBuffer.ParseIntoArray(Messages, TEXT("\n"), true);
-                
-                UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: Found %d message(s) in buffer"), Messages.Num());
-                
-                // Process all complete messages
-                for (int32 i = 0; i < Messages.Num() - 1; ++i)
-                {
-                    UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: Processing message %d: '%s'"), 
-                           i + 1, *Messages[i]);
-                    ProcessMessage(InClientSocket, Messages[i]);
-                }
-                
-                // Keep any incomplete message in the buffer
-                MessageBuffer = Messages.Last();
-                UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: Remaining buffer after processing: %s"), 
-                       *MessageBuffer);
-            }
-            else
-            {
-                UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: No complete message yet (no newline detected)"));
-            }
-        }
-        else if (!bReadSuccess)
-        {
-            UE_LOG(LogTemp, Warning, TEXT("MCPServerRunnable: Connection closed or error occurred - Last error: %d"), 
-                   (int32)ISocketSubsystem::Get()->GetLastErrorCode());
-            break;
-        }
-        
-        // Small sleep to prevent tight loop
-        FPlatformProcess::Sleep(0.01f);
-    }
-    
-    UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: Exited message receive loop"));
+	UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: Starting to handle client connection"));
+
+	InClientSocket->SetNonBlocking(false);
+
+	const int32 MaxBufferSize = 4096;
+	uint8 Buffer[MaxBufferSize];
+	FString MessageBuffer;
+
+	while (bRunning && InClientSocket.IsValid())
+	{
+		int32 BytesRead = 0;
+		const bool bReadSuccess = InClientSocket->Recv(Buffer, MaxBufferSize, BytesRead, ESocketReceiveFlags::None);
+
+		if (BytesRead > 0)
+		{
+			Buffer[BytesRead] = 0;
+			MessageBuffer.Append(UTF8_TO_TCHAR(Buffer));
+
+			if (MessageBuffer.Contains(TEXT("\n")))
+			{
+				TArray<FString> Messages;
+				MessageBuffer.ParseIntoArray(Messages, TEXT("\n"), true);
+
+				for (int32 i = 0; i < Messages.Num() - 1; ++i)
+				{
+					ProcessMessage(InClientSocket, Messages[i]);
+				}
+
+				MessageBuffer = Messages.Last();
+			}
+		}
+		else if (!bReadSuccess)
+		{
+			UE_LOG(LogTemp, Warning, TEXT("MCPServerRunnable: Connection closed or error occurred - Last error: %d"),
+				static_cast<int32>(ISocketSubsystem::Get()->GetLastErrorCode()));
+			break;
+		}
+
+		FPlatformProcess::Sleep(0.01f);
+	}
 }
 
 void FMCPServerRunnable::ProcessMessage(TSharedPtr<FSocket> Client, const FString& Message)
 {
-    UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: Processing message: %s"), *Message);
-    
-    // Parse message as JSON
-    TSharedPtr<FJsonObject> JsonMessage;
-    TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Message);
-    
-    if (!FJsonSerializer::Deserialize(Reader, JsonMessage) || !JsonMessage.IsValid())
-    {
-        UE_LOG(LogTemp, Warning, TEXT("MCPServerRunnable: Failed to parse message as JSON"));
-        return;
-    }
-    
-    // Extract command type and parameters using MCP protocol format
-    FString CommandType;
-    TSharedPtr<FJsonObject> Params = MakeShareable(new FJsonObject());
-    
-    if (!JsonMessage->TryGetStringField(TEXT("command"), CommandType))
-    {
-        UE_LOG(LogTemp, Warning, TEXT("MCPServerRunnable: Message missing 'command' field"));
-        return;
-    }
-    
-    // Parameters are optional in MCP protocol
-    if (JsonMessage->HasField(TEXT("params")))
-    {
-        TSharedPtr<FJsonValue> ParamsValue = JsonMessage->TryGetField(TEXT("params"));
-        if (ParamsValue.IsValid() && ParamsValue->Type == EJson::Object)
-        {
-            Params = ParamsValue->AsObject();
-        }
-    }
-    
-    UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: Executing command: %s"), *CommandType);
-    
-    // Execute command
-    FString Response = Bridge->ExecuteCommand(CommandType, Params);
-    
-    // Send response with newline terminator
-    Response += TEXT("\n");
-    int32 BytesSent = 0;
-    
-    UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: Sending response: %s"), *Response);
-    
-    if (!Client->Send((uint8*)TCHAR_TO_UTF8(*Response), Response.Len(), BytesSent))
-    {
-        UE_LOG(LogTemp, Error, TEXT("MCPServerRunnable: Failed to send response"));
-    }
-} 
+	TSharedPtr<FJsonObject> JsonMessage;
+	TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Message);
+
+	if (!FJsonSerializer::Deserialize(Reader, JsonMessage) || !JsonMessage.IsValid())
+	{
+		UE_LOG(LogTemp, Warning, TEXT("MCPServerRunnable: Failed to parse message as JSON"));
+		return;
+	}
+
+	FString CommandType;
+	TSharedPtr<FJsonObject> Params = MakeShareable(new FJsonObject());
+
+	if (!JsonMessage->TryGetStringField(TEXT("command"), CommandType))
+	{
+		UE_LOG(LogTemp, Warning, TEXT("MCPServerRunnable: Message missing 'command' field"));
+		return;
+	}
+
+	if (JsonMessage->HasField(TEXT("params")))
+	{
+		const TSharedPtr<FJsonValue> ParamsValue = JsonMessage->TryGetField(TEXT("params"));
+		if (ParamsValue.IsValid() && ParamsValue->Type == EJson::Object)
+		{
+			Params = ParamsValue->AsObject();
+		}
+	}
+
+	FString Response = Bridge->ExecuteCommand(CommandType, Params);
+	Response += TEXT("\n");
+	int32 BytesSent = 0;
+
+	if (!Client->Send(reinterpret_cast<uint8*>(TCHAR_TO_UTF8(*Response)), Response.Len(), BytesSent))
+	{
+		UE_LOG(LogTemp, Error, TEXT("MCPServerRunnable: Failed to send response"));
+	}
+}

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/UnrealMCPBridge.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/UnrealMCPBridge.cpp
@@ -456,5 +456,12 @@ FString UUnrealMCPBridge::ExecuteCommand(const FString& CommandType, const TShar
         AsyncTask(ENamedThreads::GameThread, MoveTemp(ExecuteLambda));
     }
 
-    return Future.Get();
+    static constexpr double CommandTimeoutSeconds = 120.0;
+    if (Future.WaitFor(FTimespan::FromSeconds(CommandTimeoutSeconds)))
+    {
+        return Future.Get();
+    }
+
+    UE_LOG(LogTemp, Error, TEXT("UnrealMCPBridge: Command '%s' timed out after %.0f seconds"), *CommandType, CommandTimeoutSeconds);
+    return TEXT("{\"status\":\"error\",\"error\":\"Command timed out after 120 seconds\"}");
 }

--- a/Python/animation_mcp_server.py
+++ b/Python/animation_mcp_server.py
@@ -7,59 +7,14 @@ including creating animation blueprints, state machines, states, transitions,
 animation layers, and animation variables.
 """
 
-import asyncio
-import json
 from typing import Any, Dict, List
 
 from fastmcp import FastMCP
 
+from utils.async_tcp_utils import send_tcp_command
+
 # Initialize FastMCP app
 app = FastMCP("Animation Blueprint MCP Server")
-
-# TCP connection settings
-TCP_HOST = "127.0.0.1"
-TCP_PORT = 55557
-
-
-async def send_tcp_command(command_type: str, params: Dict[str, Any]) -> Dict[str, Any]:
-    """Send a command to the Unreal Engine TCP server."""
-    try:
-        # Create the command payload
-        command_data = {
-            "type": command_type,
-            "params": params
-        }
-
-        # Convert to JSON string
-        json_data = json.dumps(command_data)
-
-        # Connect to TCP server
-        reader, writer = await asyncio.open_connection(TCP_HOST, TCP_PORT)
-
-        # Send command
-        writer.write(json_data.encode('utf-8'))
-        writer.write(b'\n')  # Add newline delimiter
-        await writer.drain()
-
-        # Read response
-        response_data = await reader.read(49152)  # Read up to 48KB
-        response_str = response_data.decode('utf-8').strip()
-
-        # Close connection
-        writer.close()
-        await writer.wait_closed()
-
-        # Parse JSON response
-        if response_str:
-            try:
-                return json.loads(response_str)
-            except json.JSONDecodeError as json_err:
-                return {"success": False, "error": f"JSON decode error: {str(json_err)}, Response: {response_str[:200]}"}
-        else:
-            return {"success": False, "error": "Empty response from server"}
-
-    except Exception as e:
-        return {"success": False, "error": f"TCP communication error: {str(e)}"}
 
 
 # ============================================================================

--- a/Python/blueprint_mcp_server.py
+++ b/Python/blueprint_mcp_server.py
@@ -1,44 +1,13 @@
 #!/usr/bin/env python3
 """Blueprint MCP Server for Unreal Engine Blueprint operations."""
 
-import asyncio
-import json
 from typing import Any, Dict, List
 
 from fastmcp import FastMCP
 
+from utils.async_tcp_utils import send_tcp_command
+
 app = FastMCP("Blueprint MCP Server")
-
-TCP_HOST = "127.0.0.1"
-TCP_PORT = 55557
-
-
-async def send_tcp_command(command_type: str, params: Dict[str, Any]) -> Dict[str, Any]:
-    """Send a command to the Unreal Engine TCP server."""
-    try:
-        command_data = {"type": command_type, "params": params}
-        json_data = json.dumps(command_data)
-
-        reader, writer = await asyncio.open_connection(TCP_HOST, TCP_PORT)
-        writer.write(json_data.encode('utf-8'))
-        writer.write(b'\n')
-        await writer.drain()
-
-        response_data = await reader.read(49152)
-        response_str = response_data.decode('utf-8').strip()
-
-        writer.close()
-        await writer.wait_closed()
-
-        if response_str:
-            try:
-                return json.loads(response_str)
-            except json.JSONDecodeError as json_err:
-                return {"success": False, "error": f"JSON decode error: {str(json_err)}"}
-        else:
-            return {"success": False, "error": "Empty response from server"}
-    except Exception as e:
-        return {"success": False, "error": f"TCP communication error: {str(e)}"}
 
 
 @app.tool()

--- a/Python/material_mcp_server.py
+++ b/Python/material_mcp_server.py
@@ -4,59 +4,14 @@ Material MCP Server - Material and Material Instance tools for Unreal Engine.
 Includes: create_material, create_material_instance, set parameters, batch ops.
 """
 
-import asyncio
-import json
 from typing import Any, Dict, List
 
 from fastmcp import FastMCP
 
+from utils.async_tcp_utils import send_tcp_command
+
 # Initialize FastMCP app
 app = FastMCP("Material MCP Server")
-
-# TCP connection settings
-TCP_HOST = "127.0.0.1"
-TCP_PORT = 55557
-
-
-async def send_tcp_command(command_type: str, params: Dict[str, Any]) -> Dict[str, Any]:
-    """Send a command to the Unreal Engine TCP server."""
-    try:
-        # Create the command payload
-        command_data = {
-            "type": command_type,
-            "params": params
-        }
-
-        # Convert to JSON string
-        json_data = json.dumps(command_data)
-
-        # Connect to TCP server
-        reader, writer = await asyncio.open_connection(TCP_HOST, TCP_PORT)
-
-        # Send command
-        writer.write(json_data.encode('utf-8'))
-        writer.write(b'\n')  # Add newline delimiter
-        await writer.drain()
-
-        # Read response
-        response_data = await reader.read(49152)  # Read up to 48KB
-        response_str = response_data.decode('utf-8').strip()
-
-        # Close connection
-        writer.close()
-        await writer.wait_closed()
-
-        # Parse JSON response
-        if response_str:
-            try:
-                return json.loads(response_str)
-            except json.JSONDecodeError as json_err:
-                return {"success": False, "error": f"JSON decode error: {str(json_err)}, Response: {response_str[:200]}"}
-        else:
-            return {"success": False, "error": "Empty response from server"}
-
-    except Exception as e:
-        return {"success": False, "error": f"TCP communication error: {str(e)}"}
 
 
 # ============================================================================

--- a/Python/mesh_mcp_server.py
+++ b/Python/mesh_mcp_server.py
@@ -4,50 +4,14 @@ Mesh MCP Server - Static Mesh operations for Unreal Engine.
 Includes: LOD management, mesh metadata, mesh properties.
 """
 
-import asyncio
-import json
 from typing import Any, Dict, List
 
 from fastmcp import FastMCP
 
+from utils.async_tcp_utils import send_tcp_command
+
 # Initialize FastMCP app
 app = FastMCP("Mesh MCP Server")
-
-# TCP connection settings
-TCP_HOST = "127.0.0.1"
-TCP_PORT = 55557
-
-
-async def send_tcp_command(command_type: str, params: Dict[str, Any]) -> Dict[str, Any]:
-    """Send a command to the Unreal Engine TCP server."""
-    try:
-        command_data = {
-            "type": command_type,
-            "params": params
-        }
-        json_data = json.dumps(command_data)
-
-        reader, writer = await asyncio.open_connection(TCP_HOST, TCP_PORT)
-        writer.write(json_data.encode('utf-8'))
-        writer.write(b'\n')
-        await writer.drain()
-
-        response_data = await reader.read(49152)
-        response_str = response_data.decode('utf-8').strip()
-
-        writer.close()
-        await writer.wait_closed()
-
-        if response_str:
-            try:
-                return json.loads(response_str)
-            except json.JSONDecodeError as json_err:
-                return {"success": False, "error": f"JSON decode error: {str(json_err)}, Response: {response_str[:200]}"}
-        else:
-            return {"success": False, "error": "Empty response from server"}
-
-    except Exception as e:
-        return {"success": False, "error": f"TCP communication error: {str(e)}"}
 
 
 # ============================================================================

--- a/Python/niagara_mcp_server.py
+++ b/Python/niagara_mcp_server.py
@@ -7,59 +7,14 @@ including creating systems, managing emitters, setting parameters, and
 configuring renderers.
 """
 
-import asyncio
-import json
 from typing import Any, Dict, List
 
 from fastmcp import FastMCP
 
+from utils.async_tcp_utils import send_tcp_command
+
 # Initialize FastMCP app
 app = FastMCP("Niagara MCP Server")
-
-# TCP connection settings
-TCP_HOST = "127.0.0.1"
-TCP_PORT = 55557
-
-
-async def send_tcp_command(command_type: str, params: Dict[str, Any]) -> Dict[str, Any]:
-    """Send a command to the Unreal Engine TCP server."""
-    try:
-        # Create the command payload
-        command_data = {
-            "type": command_type,
-            "params": params
-        }
-
-        # Convert to JSON string
-        json_data = json.dumps(command_data)
-
-        # Connect to TCP server
-        reader, writer = await asyncio.open_connection(TCP_HOST, TCP_PORT)
-
-        # Send command
-        writer.write(json_data.encode('utf-8'))
-        writer.write(b'\n')  # Add newline delimiter
-        await writer.drain()
-
-        # Read response
-        response_data = await reader.read(49152)  # Read up to 48KB
-        response_str = response_data.decode('utf-8').strip()
-
-        # Close connection
-        writer.close()
-        await writer.wait_closed()
-
-        # Parse JSON response
-        if response_str:
-            try:
-                return json.loads(response_str)
-            except json.JSONDecodeError as json_err:
-                return {"success": False, "error": f"JSON decode error: {str(json_err)}, Response: {response_str[:200]}"}
-        else:
-            return {"success": False, "error": "Empty response from server"}
-
-    except Exception as e:
-        return {"success": False, "error": f"TCP communication error: {str(e)}"}
 
 
 # ============================================================================

--- a/Python/pcg_mcp_server.py
+++ b/Python/pcg_mcp_server.py
@@ -6,52 +6,14 @@ Includes: create_pcg_graph, add_pcg_node, connect_pcg_nodes, set_pcg_node_proper
            spawn_pcg_actor, execute_pcg_graph.
 """
 
-import asyncio
-import json
 from typing import Any, Dict
 
 from fastmcp import FastMCP
 
+from utils.async_tcp_utils import send_tcp_command
+
 # Initialize FastMCP app
 app = FastMCP("PCG MCP Server")
-
-# TCP connection settings
-TCP_HOST = "127.0.0.1"
-TCP_PORT = 55557
-
-
-async def send_tcp_command(command_type: str, params: Dict[str, Any]) -> Dict[str, Any]:
-    """Send a command to the Unreal Engine TCP server."""
-    try:
-        command_data = {
-            "type": command_type,
-            "params": params
-        }
-
-        json_data = json.dumps(command_data)
-
-        reader, writer = await asyncio.open_connection(TCP_HOST, TCP_PORT)
-
-        writer.write(json_data.encode('utf-8'))
-        writer.write(b'\n')
-        await writer.drain()
-
-        response_data = await reader.read(49152)
-        response_str = response_data.decode('utf-8').strip()
-
-        writer.close()
-        await writer.wait_closed()
-
-        if response_str:
-            try:
-                return json.loads(response_str)
-            except json.JSONDecodeError as json_err:
-                return {"success": False, "error": f"JSON decode error: {str(json_err)}, Response: {response_str[:200]}"}
-        else:
-            return {"success": False, "error": "Empty response from server"}
-
-    except Exception as e:
-        return {"success": False, "error": f"TCP communication error: {str(e)}"}
 
 
 # ============================================================================

--- a/Python/sound_mcp_server.py
+++ b/Python/sound_mcp_server.py
@@ -6,59 +6,14 @@ This server provides MCP tools for audio/sound operations in Unreal Engine,
 including Sound Waves, Sound Cues, MetaSounds, and audio spatialization.
 """
 
-import asyncio
-import json
 from typing import Any, Dict, List
 
 from fastmcp import FastMCP
 
+from utils.async_tcp_utils import send_tcp_command
+
 # Initialize FastMCP app
 app = FastMCP("Sound MCP Server")
-
-# TCP connection settings
-TCP_HOST = "127.0.0.1"
-TCP_PORT = 55557
-
-
-async def send_tcp_command(command_type: str, params: Dict[str, Any]) -> Dict[str, Any]:
-    """Send a command to the Unreal Engine TCP server."""
-    try:
-        # Create the command payload
-        command_data = {
-            "type": command_type,
-            "params": params
-        }
-
-        # Convert to JSON string
-        json_data = json.dumps(command_data)
-
-        # Connect to TCP server
-        reader, writer = await asyncio.open_connection(TCP_HOST, TCP_PORT)
-
-        # Send command
-        writer.write(json_data.encode('utf-8'))
-        writer.write(b'\n')  # Add newline delimiter
-        await writer.drain()
-
-        # Read response
-        response_data = await reader.read(49152)  # Read up to 48KB
-        response_str = response_data.decode('utf-8').strip()
-
-        # Close connection
-        writer.close()
-        await writer.wait_closed()
-
-        # Parse JSON response
-        if response_str:
-            try:
-                return json.loads(response_str)
-            except json.JSONDecodeError as json_err:
-                return {"success": False, "error": f"JSON decode error: {str(json_err)}, Response: {response_str[:200]}"}
-        else:
-            return {"success": False, "error": "Empty response from server"}
-
-    except Exception as e:
-        return {"success": False, "error": f"TCP communication error: {str(e)}"}
 
 
 # ============================================================================

--- a/Python/statetree_mcp_server.py
+++ b/Python/statetree_mcp_server.py
@@ -7,59 +7,14 @@ enabling AI assistants to programmatically create, modify, and manage
 StateTree assets for AI behavior trees.
 """
 
-import asyncio
-import json
 from typing import Any, Dict, List
 
 from fastmcp import FastMCP
 
+from utils.async_tcp_utils import send_tcp_command
+
 # Initialize FastMCP app
 app = FastMCP("StateTree MCP Server")
-
-# TCP connection settings
-TCP_HOST = "127.0.0.1"
-TCP_PORT = 55557
-
-
-async def send_tcp_command(command_type: str, params: Dict[str, Any]) -> Dict[str, Any]:
-    """Send a command to the Unreal Engine TCP server."""
-    try:
-        # Create the command payload
-        command_data = {
-            "type": command_type,
-            "params": params
-        }
-
-        # Convert to JSON string
-        json_data = json.dumps(command_data)
-
-        # Connect to TCP server
-        reader, writer = await asyncio.open_connection(TCP_HOST, TCP_PORT)
-
-        # Send command
-        writer.write(json_data.encode('utf-8'))
-        writer.write(b'\n')  # Add newline delimiter
-        await writer.drain()
-
-        # Read response
-        response_data = await reader.read(49152)  # Read up to 48KB
-        response_str = response_data.decode('utf-8').strip()
-
-        # Close connection
-        writer.close()
-        await writer.wait_closed()
-
-        # Parse JSON response
-        if response_str:
-            try:
-                return json.loads(response_str)
-            except json.JSONDecodeError as json_err:
-                return {"success": False, "error": f"JSON decode error: {str(json_err)}, Response: {response_str[:200]}"}
-        else:
-            return {"success": False, "error": "Empty response from server"}
-
-    except Exception as e:
-        return {"success": False, "error": f"TCP communication error: {str(e)}"}
 
 
 # ============================================================================

--- a/Python/test_compile_errors.py
+++ b/Python/test_compile_errors.py
@@ -5,45 +5,9 @@ Test script to verify enhanced Blueprint compilation error reporting.
 
 import asyncio
 import json
-import socket
 
-TCP_HOST = "127.0.0.1"
-TCP_PORT = 55557
+from utils.async_tcp_utils import send_tcp_command
 
-async def send_tcp_command(command_type: str, params: dict):
-    """Send a command to the Unreal Engine TCP server."""
-    try:
-        command_data = {
-            "type": command_type,
-            "params": params
-        }
-        
-        json_data = json.dumps(command_data)
-        
-        reader, writer = await asyncio.open_connection(TCP_HOST, TCP_PORT)
-        
-        writer.write(json_data.encode('utf-8'))
-        writer.write(b'\n')
-        await writer.drain()
-        
-        response_data = await reader.read(49152)  # Read up to 48KB for detailed errors
-        response_str = response_data.decode('utf-8').strip()
-        
-        writer.close()
-        await writer.wait_closed()
-        
-        if response_str:
-            try:
-                return json.loads(response_str)
-            except json.JSONDecodeError as json_err:
-                print(f"JSON Decode Error: {json_err}")
-                print(f"Response (first 500 chars): {response_str[:500]}")
-                return {"success": False, "error": f"JSON decode error: {str(json_err)}"}
-        else:
-            return {"success": False, "error": "Empty response from server"}
-            
-    except Exception as e:
-        return {"success": False, "error": f"TCP communication error: {str(e)}"}
 
 async def test_compile_blueprint(blueprint_name: str):
     """Test compiling a Blueprint and display error details."""

--- a/Python/utils/async_tcp_utils.py
+++ b/Python/utils/async_tcp_utils.py
@@ -1,0 +1,98 @@
+"""
+Async TCP client for Unreal MCP servers.
+
+Provides timeout-protected, incremental JSON reads so MCP tools never hang silently.
+"""
+
+import asyncio
+import json
+import logging
+from typing import Any, Dict
+
+logger = logging.getLogger("UnrealMCP")
+
+UNREAL_HOST = "127.0.0.1"
+UNREAL_PORT = 55557
+DEFAULT_COMMAND_TIMEOUT = 130.0
+MAX_RESPONSE_BYTES = 4 * 1024 * 1024
+RECV_CHUNK_SIZE = 8192
+
+
+async def _read_complete_json(reader: asyncio.StreamReader, max_bytes: int) -> bytes:
+    """Read from the socket until a complete JSON document is received."""
+    chunks = []
+    total_bytes = 0
+
+    while total_bytes < max_bytes:
+        chunk = await reader.read(RECV_CHUNK_SIZE)
+        if not chunk:
+            if not chunks:
+                raise ConnectionError("Connection closed before receiving data")
+            break
+
+        chunks.append(chunk)
+        total_bytes += len(chunk)
+        data = b"".join(chunks)
+
+        try:
+            json.loads(data.decode("utf-8"))
+            return data
+        except json.JSONDecodeError:
+            continue
+
+    if total_bytes >= max_bytes:
+        raise ValueError(f"Response exceeds maximum size of {max_bytes} bytes")
+
+    data = b"".join(chunks)
+    json.loads(data.decode("utf-8"))
+    return data
+
+
+async def _send_tcp_command_impl(command_type: str, params: Dict[str, Any]) -> Dict[str, Any]:
+    command_data = {"type": command_type, "params": params}
+    json_data = json.dumps(command_data)
+
+    reader, writer = await asyncio.open_connection(UNREAL_HOST, UNREAL_PORT)
+    try:
+        writer.write(json_data.encode("utf-8"))
+        await writer.drain()
+
+        response_data = await _read_complete_json(reader, MAX_RESPONSE_BYTES)
+        response_str = response_data.decode("utf-8").strip()
+
+        if not response_str:
+            return {"success": False, "error": "Empty response from server"}
+
+        try:
+            return json.loads(response_str)
+        except json.JSONDecodeError as json_err:
+            return {
+                "success": False,
+                "error": f"JSON decode error: {str(json_err)}, Response: {response_str[:200]}",
+            }
+    finally:
+        writer.close()
+        try:
+            await writer.wait_closed()
+        except Exception:
+            pass
+
+
+async def send_tcp_command(
+    command_type: str,
+    params: Dict[str, Any] = None,
+    timeout: float = DEFAULT_COMMAND_TIMEOUT,
+) -> Dict[str, Any]:
+    """Send a command to the Unreal Engine TCP server with a hard timeout."""
+    try:
+        return await asyncio.wait_for(
+            _send_tcp_command_impl(command_type, params or {}),
+            timeout=timeout,
+        )
+    except asyncio.TimeoutError:
+        return {
+            "success": False,
+            "error": f"TCP communication timed out after {timeout} seconds",
+        }
+    except Exception as e:
+        return {"success": False, "error": f"TCP communication error: {str(e)}"}

--- a/Python/utils/unreal_connection_utils.py
+++ b/Python/utils/unreal_connection_utils.py
@@ -5,9 +5,10 @@ This module provides helper functions for common operations with Unreal Engine c
 """
 
 import logging
+import os
 import socket
 import json
-from typing import Dict, List, Any, Optional
+from typing import Dict, Any, Optional
 
 # Get logger
 logger = logging.getLogger("UnrealMCP")
@@ -15,223 +16,191 @@ logger = logging.getLogger("UnrealMCP")
 # Configuration
 UNREAL_HOST = "127.0.0.1"
 UNREAL_PORT = 55557
+DEFAULT_COMMAND_TIMEOUT = 130.0
+MAX_RESPONSE_BYTES = 4 * 1024 * 1024
+RECV_CHUNK_SIZE = 8192
+CONNECT_TIMEOUT = 8.0
+
+
+def _tcp_debug_enabled() -> bool:
+    return os.environ.get("UNREAL_MCP_TCP_DEBUG", "").strip() == "1"
+
+
+def _write_tcp_debug(message: str) -> None:
+    if not _tcp_debug_enabled():
+        return
+
+    debug_log_path = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        "tcp_debug.log",
+    )
+    with open(debug_log_path, "a", encoding="utf-8") as f:
+        f.write(message)
+
 
 class UnrealConnection:
     """Connection to an Unreal Engine instance."""
-    
+
     def __init__(self):
         """Initialize the connection."""
         self.socket = None
         self.connected = False
-    
+
     def connect(self) -> bool:
         """Connect to the Unreal Engine instance."""
         try:
-            # Close any existing socket
             if self.socket:
                 try:
                     self.socket.close()
-                except:
+                except Exception:
                     pass
                 self.socket = None
-            
+
             logger.info(f"Connecting to Unreal at {UNREAL_HOST}:{UNREAL_PORT}...")
             self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            self.socket.settimeout(8)  # 30 second timeout for complex operations
-            
-            # Set socket options for better stability
+            self.socket.settimeout(CONNECT_TIMEOUT)
+
             self.socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
             self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
-            
-            # Set larger buffer sizes
             self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 65536)
             self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, 65536)
-            
+
             self.socket.connect((UNREAL_HOST, UNREAL_PORT))
             self.connected = True
             logger.info("Connected to Unreal Engine")
             return True
-            
+
         except socket.timeout:
             logger.error(f"Connection timeout to Unreal Engine at {UNREAL_HOST}:{UNREAL_PORT}")
             self.connected = False
             return False
         except ConnectionRefusedError:
-            logger.error(f"Connection refused by Unreal Engine at {UNREAL_HOST}:{UNREAL_PORT} - is Unreal Engine running?")
+            logger.error(
+                f"Connection refused by Unreal Engine at {UNREAL_HOST}:{UNREAL_PORT} - is Unreal Engine running?"
+            )
             self.connected = False
             return False
         except Exception as e:
             logger.error(f"Failed to connect to Unreal: {e}")
             self.connected = False
             return False
-    
+
     def disconnect(self):
         """Disconnect from the Unreal Engine instance."""
         if self.socket:
             try:
                 self.socket.close()
-            except:
+            except Exception:
                 pass
         self.socket = None
         self.connected = False
 
-    def receive_full_response(self, sock, buffer_size=4096) -> bytes:
+    def receive_full_response(self, sock, buffer_size=RECV_CHUNK_SIZE) -> bytes:
         """Receive a complete response from Unreal, handling chunked data."""
         chunks = []
-        sock.settimeout(30)  # 30 second timeout for complex operations
-        import os
-        debug_log_path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "tcp_debug.log")
-        
+        total_bytes = 0
+        sock.settimeout(DEFAULT_COMMAND_TIMEOUT)
+
+        _write_tcp_debug(f"\n=== RECEIVE START ===\n")
+
         try:
-            import datetime
-            with open(debug_log_path, "a", encoding="utf-8") as f:
-                f.write(f"\n\n=== RECEIVE START: {datetime.datetime.now()} ===\n")
-            
-            while True:
+            while total_bytes < MAX_RESPONSE_BYTES:
+                _write_tcp_debug(f"Calling sock.recv({buffer_size})...\n")
+                chunk = sock.recv(buffer_size)
+                _write_tcp_debug(f"Received chunk: {len(chunk) if chunk else 0} bytes\n")
+
+                if not chunk:
+                    if not chunks:
+                        raise Exception("Connection closed before receiving data")
+                    break
+
+                chunks.append(chunk)
+                total_bytes += len(chunk)
+                data = b"".join(chunks)
+                decoded_data = data.decode("utf-8")
+                _write_tcp_debug(f"Total data so far: {len(data)} bytes\n")
+
                 try:
-                    with open(debug_log_path, "a", encoding="utf-8") as f:
-                        f.write(f"Calling sock.recv({buffer_size})...\n")
-                    
-                    chunk = sock.recv(buffer_size)
-                    
-                    with open(debug_log_path, "a", encoding="utf-8") as f:
-                        f.write(f"Received chunk: {len(chunk) if chunk else 0} bytes\n")
-                    
-                    if not chunk:
-                        if not chunks:
-                            with open(debug_log_path, "a", encoding="utf-8") as f:
-                                f.write("ERROR: Connection closed before receiving data\n")
-                            raise Exception("Connection closed before receiving data")
-                        with open(debug_log_path, "a", encoding="utf-8") as f:
-                            f.write("No more chunks, breaking...\n")
-                        break
-                    chunks.append(chunk)
-                    
-                    # Process the data received so far
-                    data = b''.join(chunks)
-                    decoded_data = data.decode('utf-8')
-                    
-                    with open(debug_log_path, "a", encoding="utf-8") as f:
-                        f.write(f"Total data so far: {len(data)} bytes\n")
-                        f.write(f"Decoded preview: {decoded_data[:200]}...\n")
-                    
-                    # Try to parse as JSON to check if complete
-                    try:
-                        json.loads(decoded_data)
-                        logger.info(f"Received complete response ({len(data)} bytes)")
-                        with open(debug_log_path, "a", encoding="utf-8") as f:
-                            f.write(f"SUCCESS: Complete JSON received!\n")
-                            f.write(f"Full response: {decoded_data}\n")
-                        return data
-                    except json.JSONDecodeError as je:
-                        # Not complete JSON yet, continue reading
-                        logger.debug(f"Received partial response, waiting for more data...")
-                        with open(debug_log_path, "a", encoding="utf-8") as f:
-                            f.write(f"Partial JSON (error: {je}), continuing...\n")
-                        continue
-                    except Exception as e:
-                        logger.warning(f"Error processing response chunk: {str(e)}")
-                        with open(debug_log_path, "a", encoding="utf-8") as f:
-                            f.write(f"ERROR processing chunk: {e}\n")
-                        continue
-                        
-                except socket.timeout as st:
-                    with open(debug_log_path, "a", encoding="utf-8") as f:
-                        f.write(f"SOCKET TIMEOUT in recv loop after {len(chunks)} chunks\n")
-                    raise st
-                except Exception as ex:
-                    with open(debug_log_path, "a", encoding="utf-8") as f:
-                        f.write(f"EXCEPTION in recv loop: {ex}\n")
-                    raise ex
-                    
+                    json.loads(decoded_data)
+                    logger.info(f"Received complete response ({len(data)} bytes)")
+                    _write_tcp_debug("SUCCESS: Complete JSON received\n")
+                    return data
+                except json.JSONDecodeError:
+                    logger.debug("Received partial response, waiting for more data...")
+                    continue
+
+            if total_bytes >= MAX_RESPONSE_BYTES:
+                raise Exception(f"Response exceeds maximum size of {MAX_RESPONSE_BYTES} bytes")
+
+            data = b"".join(chunks)
+            json.loads(data.decode("utf-8"))
+            return data
+
         except socket.timeout:
             logger.warning(f"Socket timeout during receive after {len(chunks)} chunks")
-            with open(debug_log_path, "a", encoding="utf-8") as f:
-                f.write(f"TIMEOUT: After {len(chunks)} chunks\n")
-            if chunks:
-                # If we have some data already, try to use it
-                data = b''.join(chunks)
-                logger.info(f"Received {len(data)} bytes before timeout")
-                with open(debug_log_path, "a", encoding="utf-8") as f:
-                    f.write(f"Attempting to use partial data: {len(data)} bytes\n")
-                    f.write(f"Partial data: {data.decode('utf-8', errors='replace')}\n")
-                try:
-                    json.loads(data.decode('utf-8'))
-                    logger.info(f"Using partial response after timeout ({len(data)} bytes)")
-                    with open(debug_log_path, "a", encoding="utf-8") as f:
-                        f.write(f"SUCCESS: Partial data is valid JSON!\n")
-                    return data
-                except Exception as parse_error:
-                    logger.warning(f"Partial data is not valid JSON: {parse_error}")
-                    with open(debug_log_path, "a", encoding="utf-8") as f:
-                        f.write(f"ERROR: Partial data is not valid JSON: {parse_error}\n")
-            raise Exception(f"Timeout receiving Unreal response after 30 seconds (received {len(chunks)} chunks)")
+            raise Exception(
+                f"Timeout receiving Unreal response after {DEFAULT_COMMAND_TIMEOUT} seconds "
+                f"(received {len(chunks)} chunks)"
+            )
         except Exception as e:
             logger.error(f"Error during receive: {str(e)}")
-            with open(debug_log_path, "a", encoding="utf-8") as f:
-                f.write(f"FATAL ERROR: {e}\n")
+            _write_tcp_debug(f"FATAL ERROR: {e}\n")
             raise
-    
+
     def send_command(self, command: str, params: Dict[str, Any] = None) -> Optional[Dict[str, Any]]:
         """Send a command to Unreal Engine and get the response."""
-        # Always reconnect for each command, since Unreal closes the connection after each command
         if self.socket:
             try:
                 self.socket.close()
-            except:
+            except Exception:
                 pass
             self.socket = None
             self.connected = False
-        
+
         if not self.connect():
             logger.error("Failed to connect to Unreal Engine for command")
             return None
-        
+
         try:
-            # Match Unity's command format exactly
             command_obj = {
-                "type": command,  # Use "type" instead of "command"
-                "params": params or {}  # Use Unity's params or {} pattern
+                "type": command,
+                "params": params or {},
             }
-            
-            # Send without newline, exactly like Unity
+
             command_json = json.dumps(command_obj)
             logger.info(f"Sending command: {command_json}")
-            self.socket.sendall(command_json.encode('utf-8'))
-            
-            # Read response using improved handler
+            self.socket.sendall(command_json.encode("utf-8"))
+
             response_data = self.receive_full_response(self.socket)
-            response = json.loads(response_data.decode('utf-8'))
-            
-            # Log complete response for debugging
+            response = json.loads(response_data.decode("utf-8"))
             logger.info(f"Complete response from Unreal: {response}")
-            
-            # Always close the connection after command is complete
+
             try:
                 self.socket.close()
-            except:
+            except Exception:
                 pass
             self.socket = None
             self.connected = False
-            
+
             return response
-            
+
         except Exception as e:
             logger.error(f"Error sending command: {e}")
-            # Always reset connection state on any error
             self.connected = False
             try:
                 self.socket.close()
-            except:
+            except Exception:
                 pass
             self.socket = None
             return {
                 "status": "error",
-                "error": str(e)
+                "error": str(e),
             }
+
 
 # Global connection state
 _unreal_connection: UnrealConnection = None
+
 
 def get_unreal_engine_connection():
     """Get a connection to Unreal Engine."""
@@ -244,73 +213,68 @@ def get_unreal_engine_connection():
         logger.error(f"Error getting Unreal connection: {e}")
         return None
 
+
 def send_unreal_command(command_name: str, params: Dict[str, Any]) -> Dict[str, Any]:
     """Send a command to Unreal Engine with proper error handling."""
     try:
         unreal = get_unreal_engine_connection()
         if not unreal:
             return {"status": "error", "error": "Failed to connect to Unreal Engine"}
-        
+
         logger.info(f"Sending command '{command_name}' with params: {params}")
         response = unreal.send_command(command_name, params)
-        
+
         if not response:
             logger.error(f"No response from Unreal Engine for command '{command_name}'")
             return {"status": "error", "error": "No response from Unreal Engine"}
-        
+
         logger.info(f"Command '{command_name}' response: {response}")
-        
-        # Handle nested error objects from C++ MCPErrorHandler
+
         if response.get("success") is False:
             error_field = response.get("error")
             error_message = "Unknown Unreal error"
-            
+
             if isinstance(error_field, dict):
-                # This is a nested error object from C++ MCPErrorHandler
-                # Extract the actual error message from the nested structure
-                error_message = (error_field.get("errorMessage") or 
-                               error_field.get("errorDetails") or 
-                               error_field.get("message") or 
-                               "Unknown nested error")
+                error_message = (
+                    error_field.get("errorMessage")
+                    or error_field.get("errorDetails")
+                    or error_field.get("message")
+                    or "Unknown nested error"
+                )
                 logger.error(f"Unreal nested error: {error_message}")
             elif isinstance(error_field, str):
-                # Simple string error message
                 error_message = error_field
                 logger.error(f"Unreal string error: {error_message}")
             else:
-                # Fallback to message field or default
                 error_message = response.get("message", "Unknown Unreal error")
                 logger.error(f"Unreal fallback error: {error_message}")
-            
-            # Convert to standard error format
+
             return {
                 "status": "error",
-                "error": error_message
+                "error": error_message,
             }
-        
+
         return response
-        
+
     except Exception as e:
         error_msg = f"Error executing Unreal command '{command_name}': {e}"
         logger.error(error_msg)
         return {"status": "error", "error": error_msg}
 
+
 # Cache for project info to avoid repeated TCP calls
 _project_info_cache: Dict[str, Any] = {}
+
 
 def get_project_module_name() -> str:
     """
     Get the current Unreal project's module name dynamically.
-
-    This queries Unreal Engine for the project name, which is typically
-    used as the C++ module name (e.g., for /Script/{ModuleName} paths).
 
     Returns:
         The project module name, or "MyGame" as fallback if unable to query.
     """
     global _project_info_cache
 
-    # Return cached value if available
     if "module_name" in _project_info_cache:
         return _project_info_cache["module_name"]
 
@@ -325,7 +289,6 @@ def get_project_module_name() -> str:
     except Exception as e:
         logger.warning(f"Failed to get project module name from Unreal: {e}")
 
-    # Fallback
     logger.warning("Using fallback module name 'MyGame'")
     return "MyGame"
 
@@ -339,10 +302,8 @@ def get_project_module_path() -> str:
     """
     global _project_info_cache
 
-    # Return cached value if available
     if "module_path" in _project_info_cache:
         return _project_info_cache["module_path"]
 
-    # This will populate the cache
     module_name = get_project_module_name()
     return _project_info_cache.get("module_path", f"/Script/{module_name}")


### PR DESCRIPTION
## Merge request title

**Fix silent MCP TCP freezes with server-side timeouts and shared Python TCP client**

---

## Description

### Summary

Fixes a long-running issue where MCP tools stop responding after extended use with no error returned to Cursor. The root cause was a combination of silent deadlocks on the C++ TCP server, an unbounded blocking wait on the game thread, and Python clients that could hang forever on read.

### Problem

- **C++ server** logged JSON parse failures and missing `type` fields but never sent a response, leaving Python blocked on read.
- **Single 8192-byte `Recv()`** could truncate large commands and trigger the same deadlock.
- **`ExecuteCommand`** used `Future.Get()` with no timeout, so one blocked game-thread operation (modal dialog, heavy compile) could freeze all MCP traffic.
- **Python async MCP servers** duplicated `send_tcp_command()` with `reader.read(49152)` and no timeout.

### Changes

**C++ (`MCPServerRunnable.cpp`)**
- Multi-chunk JSON read (up to 256 KB per command)
- Always return JSON on success or error (parse failure, missing `type`, oversize payload)
- One-shot request/response per connection
- Reduced routine recv logging to `Verbose`

**C++ (`UnrealMCPBridge.cpp`)**
- 120s timeout via `Future.WaitFor()` before `Future.Get()`

**Python**
- New shared module: `Python/utils/async_tcp_utils.py` (130s timeout, incremental JSON read, 4 MB response cap)
- Replaced duplicated `send_tcp_command` in 9 MCP server files
- Updated `unreal_connection_utils.py` to 130s timeout; gated `tcp_debug.log` behind `UNREAL_MCP_TCP_DEBUG=1`

**Docs**
- Documented fix, timeout policy, recovery steps, and known limitations in `Docs/known-issues.md`

### Behavior after merge

| Scenario | Before | After |
|----------|--------|-------|
| Malformed JSON | Silent hang | Error JSON within ~1s |
| Game thread blocked >120s | All MCP frozen | Timeout error; server thread unblocks |
| Python client waiting on UE | Hang forever | Timeout error after ~130s |
| Heavy compile >120s | Hang or freeze | Timeout error (by design) |

### Known limitations

- 120s command timeout may affect large Blueprint/Niagara compiles; split work or compile in-editor if needed.
- Timed-out `AsyncTask` work may still complete later on the game thread; timeout unblocks the server thread only.
- Server remains single-threaded; parallel MCP calls are serialized (acceptable for this fix).