### PR TITLE
feat(editor): add open_level to switch the active editor world

### DIFF
--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Editor/OpenLevelCommand.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Editor/OpenLevelCommand.cpp
@@ -1,0 +1,133 @@
+#include "Commands/Editor/OpenLevelCommand.h"
+
+#include "Dom/JsonObject.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonWriter.h"
+#include "Editor.h"
+#include "Engine/World.h"
+#include "GameFramework/WorldSettings.h"
+#include "LevelEditorSubsystem.h"
+#include "UObject/UObjectGlobals.h"
+
+namespace
+{
+	FString SerializeJson_OpenLevel(const TSharedPtr<FJsonObject>& Obj)
+	{
+		FString Out;
+		TSharedRef<TJsonWriter<>> W = TJsonWriterFactory<>::Create(&Out);
+		FJsonSerializer::Serialize(Obj.ToSharedRef(), W);
+		return Out;
+	}
+
+	FString MakeErr_OpenLevel(const FString& Msg)
+	{
+		TSharedPtr<FJsonObject> Obj = MakeShared<FJsonObject>();
+		Obj->SetBoolField(TEXT("success"), false);
+		Obj->SetStringField(TEXT("error"), Msg);
+		return SerializeJson_OpenLevel(Obj);
+	}
+}
+
+FString FOpenLevelCommand::Execute(const FString& Parameters)
+{
+	TSharedPtr<FJsonObject> JsonObject;
+	TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Parameters);
+	if (!FJsonSerializer::Deserialize(Reader, JsonObject) || !JsonObject.IsValid())
+	{
+		return MakeErr_OpenLevel(TEXT("Invalid JSON parameters"));
+	}
+
+	FString LevelPath;
+	if (!JsonObject->TryGetStringField(TEXT("level_path"), LevelPath) || LevelPath.IsEmpty())
+	{
+		return MakeErr_OpenLevel(TEXT("Missing 'level_path' parameter"));
+	}
+	if (!LevelPath.StartsWith(TEXT("/Game")))
+	{
+		return MakeErr_OpenLevel(TEXT("'level_path' must start with /Game"));
+	}
+
+	if (!GEditor)
+	{
+		return MakeErr_OpenLevel(TEXT("GEditor is null — command requires editor context"));
+	}
+
+	ULevelEditorSubsystem* LES = GEditor->GetEditorSubsystem<ULevelEditorSubsystem>();
+	if (!LES)
+	{
+		return MakeErr_OpenLevel(TEXT("ULevelEditorSubsystem unavailable"));
+	}
+
+	// Resolve "/Game/Path/Name" -> object path "/Game/Path/Name.Name" (the World object).
+	FString ObjectPath = LevelPath;
+	{
+		int32 DotIdx;
+		if (!ObjectPath.FindChar('.', DotIdx))
+		{
+			int32 SlashIdx;
+			if (LevelPath.FindLastChar('/', SlashIdx))
+			{
+				ObjectPath = LevelPath + TEXT(".") + LevelPath.RightChop(SlashIdx + 1);
+			}
+		}
+	}
+
+	// Load the World as an OBJECT first — this does NOT switch the active editor world, so it
+	// is safe even for WP / malformed maps (mirrors FSetLevelWorldSettingsCommand). We only
+	// switch the active world (the leak-check-fatal path) AFTER confirming it is non-WP.
+	UWorld* World = LoadObject<UWorld>(nullptr, *ObjectPath);
+	if (!World)
+	{
+		return MakeErr_OpenLevel(FString::Printf(
+			TEXT("Could not load a World at '%s' (missing or malformed map). Not switching the editor world."),
+			*LevelPath));
+	}
+
+	// World Partition detection via the loaded WorldSettings (same accessor path the existing
+	// set_level_world_settings command uses). A WP target is refused: switching the active
+	// editor world into it can trip the engine map-load leak-check fatal
+	// (EditorServer.cpp "World Memory Leaks") — see game-design/tech/voxel.md anti-pattern.
+	const AWorldSettings* WS = World->GetWorldSettings(/*bCheckStreamingPersistent*/ false, /*bChecked*/ false);
+	const bool bIsPartitioned = (WS != nullptr && WS->GetWorldPartition() != nullptr);
+	if (bIsPartitioned)
+	{
+		TSharedPtr<FJsonObject> Obj = MakeShared<FJsonObject>();
+		Obj->SetBoolField(TEXT("success"), false);
+		Obj->SetBoolField(TEXT("was_world_partition"), true);
+		Obj->SetStringField(TEXT("level_path"), LevelPath);
+		Obj->SetStringField(TEXT("error"), FString::Printf(
+			TEXT("'%s' is a World Partition level. Refusing to switch the editor world into it via MCP — "
+				 "that can trigger the map-load leak-check fatal (EditorServer.cpp 'World Memory Leaks'). "
+				 "Open WP maps through the editor UI (File > Open Level)."), *LevelPath));
+		return SerializeJson_OpenLevel(Obj);
+	}
+
+	// Non-WP: safe to switch the active editor world.
+	const bool bOk = LES->LoadLevel(LevelPath);
+	if (!bOk)
+	{
+		return MakeErr_OpenLevel(FString::Printf(TEXT("LoadLevel failed for '%s'."), *LevelPath));
+	}
+
+	TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("level_path"), LevelPath);
+	Result->SetBoolField(TEXT("was_world_partition"), false);
+	Result->SetStringField(TEXT("message"), TEXT("Level opened as the active editor world"));
+	return SerializeJson_OpenLevel(Result);
+}
+
+FString FOpenLevelCommand::GetCommandName() const
+{
+	return TEXT("open_level");
+}
+
+bool FOpenLevelCommand::ValidateParams(const FString& Parameters) const
+{
+	TSharedPtr<FJsonObject> JsonObject;
+	TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Parameters);
+	if (!FJsonSerializer::Deserialize(Reader, JsonObject) || !JsonObject.IsValid()) return false;
+
+	FString LevelPath;
+	return JsonObject->TryGetStringField(TEXT("level_path"), LevelPath) && !LevelPath.IsEmpty();
+}

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EditorCommandRegistration.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EditorCommandRegistration.cpp
@@ -27,6 +27,7 @@
 #include "Commands/Editor/StopPIECommand.h"
 #include "Commands/Editor/CreateLevelCommand.h"
 #include "Commands/Editor/SetLevelWorldSettingsCommand.h"
+#include "Commands/Editor/OpenLevelCommand.h"
 
 TArray<TSharedPtr<IUnrealMCPCommand>> FEditorCommandRegistration::RegisteredCommands;
 
@@ -74,6 +75,7 @@ void FEditorCommandRegistration::RegisterAllCommands()
     // Level management commands
     RegisterAndTrackCommand(MakeShared<FCreateLevelCommand>());
     RegisterAndTrackCommand(MakeShared<FSetLevelWorldSettingsCommand>());
+    RegisterAndTrackCommand(MakeShared<FOpenLevelCommand>());
 
     // Note: Additional editor commands are handled by legacy command system
     // and will be migrated to the new architecture in future iterations:

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Editor/OpenLevelCommand.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/Editor/OpenLevelCommand.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Commands/IUnrealMCPCommand.h"
+
+/**
+ * Open an EXISTING level (umap) as the ACTIVE editor world, by content path.
+ *
+ * The missing counterpart to FCreateLevelCommand (makes a NEW level active) and
+ * FSetLevelWorldSettingsCommand (edits a level WITHOUT switching the active world):
+ * this switches the editor's current world to an already-existing level — e.g. to leave
+ * the default startup map and work on a test level — which no other MCP tool can do.
+ *
+ * Params (JSON):
+ *   level_path (string, required) — package path of the level, e.g. "/Game/Tests/TestLevel_ColonyView"
+ *
+ * Returns success + level_path; on a World Partition target returns success=false +
+ * was_world_partition=true + a clear error.
+ *
+ * SAFETY: World Partition levels are REFUSED. Switching the active editor world INTO a WP
+ * map via code can trip the engine map-load leak-check fatal (EditorServer.cpp "World Memory
+ * Leaks"; the project has hit this — see game-design/tech/voxel.md anti-pattern). The target
+ * world is first loaded as an OBJECT (no world switch) to detect WP safely; only a non-WP
+ * level is then switched in via ULevelEditorSubsystem::LoadLevel.
+ *
+ * Side effect: a non-WP target becomes the active editor world.
+ */
+class UNREALMCP_API FOpenLevelCommand : public IUnrealMCPCommand
+{
+public:
+	FOpenLevelCommand() = default;
+	virtual FString Execute(const FString& Parameters) override;
+	virtual FString GetCommandName() const override;
+	virtual bool ValidateParams(const FString& Parameters) const override;
+};

--- a/Python/editor_tools/editor_tools.py
+++ b/Python/editor_tools/editor_tools.py
@@ -753,6 +753,43 @@ def register_editor_tools(mcp: FastMCP):
         return set_level_world_settings_impl(ctx, level_path, game_mode)
 
     @mcp.tool()
+    def open_level(
+        ctx: Context,
+        level_path: str
+    ) -> Dict[str, Any]:
+        """
+        Open an EXISTING level (umap) as the ACTIVE editor world, by content path.
+
+        The missing counterpart to create_level (makes a NEW level active) and
+        set_level_world_settings (edits a level WITHOUT switching worlds): this switches the
+        editor's current world to an already-existing level — e.g. to leave the default
+        startup map and work on a test level.
+
+        SAFETY: World Partition levels are REFUSED. Switching the active editor world into a
+        WP map via code can trigger the engine map-load leak-check fatal (EditorServer.cpp
+        "World Memory Leaks"). The target is first loaded as an object (no world switch) to
+        detect WP; only a non-WP level is then opened. Open WP maps via the editor UI
+        (File > Open Level).
+
+        Args:
+            level_path: Package path of the level (e.g., "/Game/Tests/TestLevel_ColonyView")
+
+        Returns:
+            Dict containing:
+            - success: Whether the level was opened
+            - level_path: The level path
+            - was_world_partition: True when refused because the target is a WP level
+            - error: Message when refused/failed
+
+        Side effect:
+            A non-WP target becomes the editor's active world.
+
+        Examples:
+            open_level(level_path="/Game/Tests/TestLevel_ColonyView")
+        """
+        return send_unreal_command("open_level", {"level_path": level_path})
+
+    @mcp.tool()
     def create_render_target(
         ctx: Context,
         name: str,


### PR DESCRIPTION
create_level makes a NEW level active and set_level_world_settings loads a level as an object WITHOUT switching worlds, but nothing could open an EXISTING level as the active editor world — so an agent could not leave the default startup map to work on a test level without a human clicking File > Open Level.

open_level first LoadObject<UWorld>s the target (no world switch — safe even for WP/malformed maps, mirroring set_level_world_settings) to detect World Partition, then REFUSES WP levels with a clear error (switching the active world into a WP map can trip the engine map-load leak-check fatal, EditorServer.cpp 'World Memory Leaks'); non-WP levels are switched in via ULevelEditorSubsystem::LoadLevel.

Tested live: /Game/Tests/TestLevel_ColonyView (non-WP) switches the active world; /Game/TopDown/Lvl_TopDown (WP) is refused with was_world_partition=true and the editor survives, still on the test level.