### PR TITLE
feat(material): support UE 5.7 Nanite tessellation Displacement output

### DIFF
--- a/Docs/Material-Tools.md
+++ b/Docs/Material-Tools.md
@@ -256,8 +256,10 @@ Connect a material expression to a material output property.
 |-----------|------|----------|-------------|
 | `material_path` | string | ✅ | Path to the material |
 | `expression_id` | string | ✅ | GUID of the source expression |
-| `material_property` | string | ✅ | Target property: `"BaseColor"`, `"Metallic"`, `"Roughness"`, `"Normal"`, `"EmissiveColor"`, `"Opacity"`, `"OpacityMask"`, `"WorldPositionOffset"`, etc. |
+| `material_property` | string | ✅ | Target property: `"BaseColor"`, `"Metallic"`, `"Roughness"`, `"Normal"`, `"EmissiveColor"`, `"Opacity"`, `"OpacityMask"`, `"WorldPositionOffset"`, `"Displacement"`, etc. |
 | `output_index` | number | | Output index on source expression (default: 0) |
+
+> **`"Displacement"` (UE 5.7 Nanite tessellation):** wires the source to the material's scalar Displacement output. It only does anything once tessellation is enabled — call `set_material_properties(enable_tessellation=True)` (and optionally set `displacement_magnitude` / `displacement_center`) on the same material.
 
 ---
 
@@ -283,6 +285,9 @@ Set properties on an existing base Material (blend mode, shading model, usage fl
 | `blend_mode` | string | | `"Opaque"`, `"Masked"`, `"Translucent"`, `"Additive"`, `"Modulate"`, `"AlphaComposite"` |
 | `shading_model` | string | | `"Unlit"`, `"DefaultLit"`, `"Subsurface"`, `"ClearCoat"`, `"Hair"`, `"Cloth"`, `"Eye"`, etc. |
 | `two_sided` | boolean | | Whether the material renders on both sides |
+| `enable_tessellation` | boolean | | Enable UE 5.7 Nanite tessellation. Required for the Displacement output to take effect |
+| `displacement_magnitude` | number | | Nanite displacement height (`FDisplacementScaling.Magnitude`, default 4.0). Read per-surface by `GetDisplacementScaling().Magnitude` |
+| `displacement_center` | number | | Sample value [0..1] mapping to zero displacement (`FDisplacementScaling.Center`, default 0.5) |
 | `used_with_niagara_sprites` | boolean | | Enable for Niagara sprite particles |
 | `used_with_niagara_ribbons` | boolean | | Enable for Niagara ribbon particles |
 

--- a/Docs/known-issues.md
+++ b/Docs/known-issues.md
@@ -25,6 +25,17 @@ This file tracks MCP tool limitations discovered during development. When encoun
 - **Known Limitation**: A timed-out command may still complete on the game thread later (AsyncTask is not cancelled). The timeout unblocks the server thread so other MCP calls can proceed.
 - **Debug TCP logging**: Set `UNREAL_MCP_TCP_DEBUG=1` to enable `Python/tcp_debug.log` (disabled by default to avoid unbounded file growth).
 
+### Material-Output Property List Is Duplicated Across 4 Files (Refactor Candidate)
+- **Affected**: `connect_expression_to_material_output`, `get_material_expression_metadata`, `compile_material`, `delete_material_expression`
+- **Problem**: The set of supported `EMaterialProperty` outputs is hand-maintained as **7 separate hard-coded lists** across 4 files:
+  - `MaterialExpressionCore.cpp` — `GetMaterialPropertyFromString` (string→enum for connect)
+  - `MaterialExpressionConnection.cpp` — `NameToMaterialPropertyStrict` (SetMaterialAttributes pins)
+  - `MaterialExpressionMetadata.cpp` — `AddOutputIfConnected` (material_outputs), orphan `CheckMaterialOutput`, `TraceFlow`
+  - `MaterialExpressionManagement.cpp` — `DisconnectFromOutput` (delete path), orphan `CheckMaterialOutput` (compile)
+- **Impact**: Adding a new output (e.g. Displacement in UE 5.7) requires touching all 7 or things silently break — a node wired to a missing output is mis-flagged as an orphan (`compile_material`), invisible in `material_outputs`, or left dangling on delete. The lists are also already inconsistent (`DisconnectFromOutput` omits Refraction/SubsurfaceColor that the others include).
+- **Fix (deferred)**: Extract one shared `static const TArray<TPair<EMaterialProperty, FString>>` (or iterate the engine's `FMaterialAttributeDefinitionMap`) and drive all sites from it.
+- **Workaround**: When adding an output, grep `MP_AmbientOcclusion` as a sentinel — every match needs the new property added beside it.
+
 ### Struct Field GUID Middle Numbers Can Change When Structs Are Modified
 - **Affected**: `get_struct_pin_names`, `get_datatable_row_names`, DataTable operations
 - **Problem**: User-defined structs use GUID-based internal field names (e.g., `TestField1_2_1EAE0B8A4B971533B2AD21BF45BA9220`). The hex suffix (GUID) remains stable, but the middle number can change when the struct is modified (type changes, field additions/removals).

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Material/SetMaterialPropertiesCommand.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Material/SetMaterialPropertiesCommand.cpp
@@ -124,6 +124,37 @@ FString FSetMaterialPropertiesCommand::Execute(const FString& Parameters)
         UE_LOG(LogTemp, Log, TEXT("Set TwoSided to %s"), bTwoSided ? TEXT("true") : TEXT("false"));
     }
 
+    // ── UE 5.7 Nanite tessellation / displacement ──────────────────────────────────────────
+    // Optional: enable_tessellation. NOTE: required for the Displacement output to do anything
+    // (the engine gates DisplacementScaling/DisplacementFade editing behind bEnableTessellation).
+    bool bEnableTess;
+    if (JsonObject->TryGetBoolField(TEXT("enable_tessellation"), bEnableTess))
+    {
+        Material->bEnableTessellation = bEnableTess;
+        ChangedProperties.Add(FString::Printf(TEXT("bEnableTessellation=%s"), bEnableTess ? TEXT("true") : TEXT("false")));
+        UE_LOG(LogTemp, Log, TEXT("Set bEnableTessellation to %s"), bEnableTess ? TEXT("true") : TEXT("false"));
+    }
+
+    // Optional: displacement_magnitude — FDisplacementScaling.Magnitude (Nanite displacement height,
+    // read by GetDisplacementScaling().Magnitude; the Voxel MegaMaterial scales per-surface by this).
+    double DispMagnitude;
+    if (JsonObject->TryGetNumberField(TEXT("displacement_magnitude"), DispMagnitude))
+    {
+        Material->DisplacementScaling.Magnitude = static_cast<float>(DispMagnitude);
+        ChangedProperties.Add(FString::Printf(TEXT("DisplacementScaling.Magnitude=%.4f"), static_cast<float>(DispMagnitude)));
+        UE_LOG(LogTemp, Log, TEXT("Set DisplacementScaling.Magnitude to %.4f"), static_cast<float>(DispMagnitude));
+    }
+
+    // Optional: displacement_center — FDisplacementScaling.Center (the [0..1] sample value that maps
+    // to zero displacement; values above push out, below pull in). Engine default 0.5.
+    double DispCenter;
+    if (JsonObject->TryGetNumberField(TEXT("displacement_center"), DispCenter))
+    {
+        Material->DisplacementScaling.Center = static_cast<float>(DispCenter);
+        ChangedProperties.Add(FString::Printf(TEXT("DisplacementScaling.Center=%.4f"), static_cast<float>(DispCenter)));
+        UE_LOG(LogTemp, Log, TEXT("Set DisplacementScaling.Center to %.4f"), static_cast<float>(DispCenter));
+    }
+
     // Optional: material_domain
     FString MaterialDomainStr;
     if (JsonObject->TryGetStringField(TEXT("material_domain"), MaterialDomainStr))
@@ -192,7 +223,7 @@ FString FSetMaterialPropertiesCommand::Execute(const FString& Parameters)
     // Check if any properties were changed
     if (ChangedProperties.Num() == 0)
     {
-        return CreateErrorResponse(TEXT("No valid properties provided to change. Supported: material_domain, blend_mode, shading_model, two_sided, used_with_niagara_sprites, used_with_niagara_ribbons, used_with_niagara_mesh_particles, used_with_particle_sprites, used_with_mesh_particles, used_with_skeletal_mesh, used_with_static_lighting"));
+        return CreateErrorResponse(TEXT("No valid properties provided to change. Supported: material_domain, blend_mode, shading_model, two_sided, enable_tessellation, displacement_magnitude, displacement_center, used_with_niagara_sprites, used_with_niagara_ribbons, used_with_niagara_mesh_particles, used_with_particle_sprites, used_with_mesh_particles, used_with_skeletal_mesh, used_with_static_lighting"));
     }
 
     // Mark package dirty

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Material/MaterialExpressionCore.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Material/MaterialExpressionCore.cpp
@@ -169,6 +169,8 @@ EMaterialProperty FMaterialExpressionService::GetMaterialPropertyFromString(cons
         return MP_Refraction;
     if (PropertyName.Equals(TEXT("SubsurfaceColor"), ESearchCase::IgnoreCase))
         return MP_SubsurfaceColor;
+    if (PropertyName.Equals(TEXT("Displacement"), ESearchCase::IgnoreCase))
+        return MP_Displacement;  // UE 5.7 Nanite tessellation displacement (EditorOnly->Displacement, FScalarMaterialInput)
 
     // Default to emissive for unrecognized properties
     return MP_EmissiveColor;

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Material/MaterialExpressionManagement.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Material/MaterialExpressionManagement.cpp
@@ -120,6 +120,8 @@ bool FMaterialExpressionService::DeleteExpression(
     DisconnectFromOutput(MP_OpacityMask);
     DisconnectFromOutput(MP_WorldPositionOffset);
     DisconnectFromOutput(MP_AmbientOcclusion);
+    DisconnectFromOutput(MP_Displacement);  // UE 5.7 Nanite tessellation — else deleting a node wired
+                                            // to Displacement leaves a dangling input expression ptr
 
     // Remove from expression collection
     EditorData->ExpressionCollection.RemoveExpression(Expression);
@@ -390,6 +392,8 @@ bool FMaterialExpressionService::CompileMaterial(
     CheckMaterialOutput(MP_AmbientOcclusion);
     CheckMaterialOutput(MP_Refraction);
     CheckMaterialOutput(MP_SubsurfaceColor);
+    CheckMaterialOutput(MP_Displacement);  // UE 5.7 Nanite tessellation — a node feeding Displacement
+                                           // is a real sink, not an orphan (else compile_material miscounts)
 
     // Find orphans
     TArray<TSharedPtr<FJsonValue>> OrphanArray;

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Material/MaterialExpressionMetadata.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Services/Material/MaterialExpressionMetadata.cpp
@@ -212,6 +212,7 @@ bool FMaterialExpressionService::GetGraphMetadata(
         AddOutputIfConnected(MP_OpacityMask, TEXT("OpacityMask"));
         AddOutputIfConnected(MP_WorldPositionOffset, TEXT("WorldPositionOffset"));
         AddOutputIfConnected(MP_AmbientOcclusion, TEXT("AmbientOcclusion"));
+        AddOutputIfConnected(MP_Displacement, TEXT("Displacement"));  // UE 5.7 Nanite tessellation
 
         OutMetadata->SetObjectField(TEXT("material_outputs"), OutputsObj);
     }
@@ -260,6 +261,8 @@ bool FMaterialExpressionService::GetGraphMetadata(
             CheckMaterialOutput(MP_AmbientOcclusion);
             CheckMaterialOutput(MP_Refraction);
             CheckMaterialOutput(MP_SubsurfaceColor);
+            CheckMaterialOutput(MP_Displacement);  // UE 5.7 Nanite tessellation — a node feeding
+                                                   // Displacement is a real sink, not an orphan
         }
 
         // Find orphans - expressions not in UsedExpressions
@@ -357,6 +360,7 @@ bool FMaterialExpressionService::GetGraphMetadata(
         TraceFlow(MP_OpacityMask, TEXT("OpacityMask"));
         TraceFlow(MP_WorldPositionOffset, TEXT("WorldPositionOffset"));
         TraceFlow(MP_AmbientOcclusion, TEXT("AmbientOcclusion"));
+        TraceFlow(MP_Displacement, TEXT("Displacement"));  // UE 5.7 Nanite tessellation
 
         OutMetadata->SetObjectField(TEXT("flow"), FlowObj);
     }

--- a/Python/material_mcp_server.py
+++ b/Python/material_mcp_server.py
@@ -797,6 +797,9 @@ async def connect_expression_to_material_output(
             - "AmbientOcclusion": AO value
             - "Refraction": Refraction for translucent materials
             - "SubsurfaceColor": Subsurface scattering color
+            - "Displacement": UE 5.7 Nanite tessellation displacement (scalar). The material
+              must have tessellation enabled for this to take effect — call
+              set_material_properties(enable_tessellation=True) first.
         output_index: Output index on source expression (default 0)
 
     Returns:
@@ -888,6 +891,9 @@ async def set_material_properties(
     blend_mode: str = None,
     shading_model: str = None,
     two_sided: bool = None,
+    enable_tessellation: bool = None,
+    displacement_magnitude: float = None,
+    displacement_center: float = None,
     used_with_niagara_sprites: bool = None,
     used_with_niagara_ribbons: bool = None,
     used_with_niagara_mesh_particles: bool = None,
@@ -908,6 +914,13 @@ async def set_material_properties(
         blend_mode: Blend mode - "Opaque", "Masked", "Translucent", "Additive", "Modulate", "AlphaComposite", "AlphaHoldout"
         shading_model: Shading model - "Unlit", "DefaultLit", "Subsurface", "ClearCoat", "SubsurfaceProfile", "TwoSidedFoliage", "Hair", "Cloth", "Eye", "SingleLayerWater", "ThinTranslucent"
         two_sided: Whether the material renders on both sides
+        enable_tessellation: Enable UE 5.7 Nanite tessellation. REQUIRED for the material's
+            Displacement output to take effect (gates DisplacementScaling editing). Pair with
+            connect_expression_to_material_output(material_property="Displacement").
+        displacement_magnitude: Nanite displacement height (FDisplacementScaling.Magnitude, engine
+            default 4.0). Read per-surface by GetDisplacementScaling().Magnitude.
+        displacement_center: Sample value [0..1] that maps to zero displacement
+            (FDisplacementScaling.Center, engine default 0.5). Above pushes out, below pulls in.
         used_with_niagara_sprites: Enable for Niagara sprite particles
         used_with_niagara_ribbons: Enable for Niagara ribbon particles
         used_with_niagara_mesh_particles: Enable for Niagara mesh particles
@@ -949,6 +962,12 @@ async def set_material_properties(
         params["shading_model"] = shading_model
     if two_sided is not None:
         params["two_sided"] = two_sided
+    if enable_tessellation is not None:
+        params["enable_tessellation"] = enable_tessellation
+    if displacement_magnitude is not None:
+        params["displacement_magnitude"] = displacement_magnitude
+    if displacement_center is not None:
+        params["displacement_center"] = displacement_center
     if used_with_niagara_sprites is not None:
         params["used_with_niagara_sprites"] = used_with_niagara_sprites
     if used_with_niagara_ribbons is not None:


### PR DESCRIPTION
Author Nanite-displacement materials end-to-end from materialMCP (motivating case: the Voxel MegaMaterial reads each surface material's Displacement output
+ GetDisplacementScaling().Magnitude per surface).

- connect_expression_to_material_output: map "Displacement" -> MP_Displacement. GetMaterialPropertyFromString previously fell through to MP_EmissiveColor, silently mis-wiring the source to Emissive.
- set_material_properties: add enable_tessellation (UMaterial::bEnableTessellation), displacement_magnitude / displacement_center (UMaterial::DisplacementScaling).
- Propagate MP_Displacement through every material-output enumeration so the new output stays consistent: graph metadata (material_outputs / orphan / flow), compile_material orphan scan, and delete_material_expression's DisconnectFromOutput (else deleting a Displacement-driver dangles the input).
- Python material_mcp_server + Docs/Material-Tools updated to match.
- Docs/known-issues: note the 7-copy property-list duplication (refactor candidate).

Verified end-to-end against the rebuilt plugin via raw TCP (plugin rule #6): create -> enable tessellation -> connect scalar -> Displacement -> compile (0 errors, 0 orphans) -> material_outputs reports Displacement (not Emissive) -> delete driver clears the input with no dangling ref.