### PR TITLE
fix(project): capture_viewport_screenshot force-renders a fresh frame

### DIFF
--- a/Docs/known-issues.md
+++ b/Docs/known-issues.md
@@ -4,6 +4,24 @@ This file tracks MCP tool limitations discovered during development. When encoun
 
 ## Resolved Issues
 
+### `capture_viewport_screenshot` Returned a Stale Frame When the Editor Was Unfocused (Fixed 2026-06-11)
+- **Affected**: `projectMCP.capture_viewport_screenshot`
+- **Problem**: The capture read the last drawn frame (`GetViewportScreenShot` → `ReadPixels`) without forcing a
+  redraw. With the editor window unfocused — the normal state while an MCP agent drives it — the editor throttles
+  non-realtime viewport redraws, so `Invalidate()`/`RedrawLevelEditingViewports()` (already called by
+  `set_viewport_camera`) only queued a redraw the throttled tick never performed. Consecutive captures returned
+  byte-identical stale PNGs despite successful `set_viewport_camera`/`viewmode` changes in between. `HighResShot`
+  via console rendered the true state, which confirmed the camera state itself was fine.
+- **Fix**: `FViewport::Draw(bShouldPresent=true)` + `FlushRenderingCommands()` synchronously in the capture
+  command, right before reading pixels — bypasses the editor-tick throttle. The Python tool schema is unchanged;
+  the docstring now documents the fresh-frame guarantee.
+- **Verification**: With the editor unfocused: camera A (top-down) → capture, camera B (ground horizon) →
+  capture. Each PNG must differ and show its own camera state (previously consecutive captures were
+  byte-identical). Verified live 2026-06-11 on SimPrototype's Lvl_TopDown.
+- **No automation test**: the repro depends on the window focus/throttle state, which an in-editor automation run
+  cannot control deterministically (a focused session redraws normally and the bug never manifests). Covered by
+  the live MCP verification protocol above.
+
 ### `execute_console_command` Ignored the Active PIE World (Fixed 2026-06-10)
 - **Affected**: `editorMCP.execute_console_command`
 - **Problem**: The C++ command always executed through `GEditor->GetEditorWorldContext()`. During PIE, runtime
@@ -23,6 +41,16 @@ This file tracks MCP tool limitations discovered during development. When encoun
   accordingly.
 
 ## Active Issues
+
+### `viewmode` Console Commands Don't Reach the Editor Viewport
+- **Affected**: `editorMCP.execute_console_command` with `viewmode unlit` / `viewmode wireframe` / etc.
+- **Problem**: The command executes successfully but the level-editor viewport keeps its current view mode —
+  the exec path doesn't route to the `FEditorViewportClient` the way the in-viewport console does. Confirmed
+  2026-06-11 (both via capture_viewport_screenshot after the stale-frame fix AND via `HighResShot`, so it is
+  not a stale-frame symptom — the viewport genuinely never switches).
+- **Workaround**: none via MCP today; change the view mode by hand in the viewport toolbar.
+- **Fix candidate**: a dedicated `set_viewport_viewmode` tool (or special-casing in execute_console_command)
+  calling `FEditorViewportClient::SetViewMode(VMI_*)` on the active perspective viewport.
 
 ### MCP TCP Connection Freezes (Mitigated 2026-05-31)
 - **Affected**: All MCP servers communicating via TCP port 55557

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Project/CaptureViewportScreenshotCommand.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/Project/CaptureViewportScreenshotCommand.cpp
@@ -12,6 +12,7 @@
 #include "IImageWrapper.h"
 #include "IImageWrapperModule.h"
 #include "Modules/ModuleManager.h"
+#include "RenderingThread.h"
 
 bool FCaptureViewportScreenshotCommand::ValidateParams(const FString& Parameters) const
 {
@@ -90,6 +91,16 @@ FString FCaptureViewportScreenshotCommand::Execute(const FString& Parameters)
 		FJsonSerializer::Serialize(ErrorResponse.ToSharedRef(), Writer);
 		return OutputString;
 	}
+
+	// Force-render a fresh frame before reading pixels. When the editor window is unfocused
+	// (the normal state while an MCP agent drives it), the editor throttles non-realtime
+	// viewport redraws — Invalidate()/RedrawLevelEditingViewports() only QUEUE a redraw that
+	// the throttled tick never performs, so ReadPixels would return the LAST drawn frame:
+	// stale relative to any set_viewport_camera / viewmode change since (verified live
+	// 2026-06-11 — consecutive captures came back byte-identical despite camera moves).
+	// FViewport::Draw renders synchronously on the game thread, bypassing the throttle.
+	Viewport->Draw(/*bShouldPresent*/ true);
+	FlushRenderingCommands();
 
 	// Use UE's proper screenshot function - this handles all the render target magic correctly
 	TArray<FColor> Bitmap;

--- a/Python/project_tools/project_tools.py
+++ b/Python/project_tools/project_tools.py
@@ -1706,6 +1706,12 @@ def register_project_tools(mcp: FastMCP):
         Saves a PNG image of the current viewport and returns the file path.
         Useful for AI to visually inspect the current state of the scene.
 
+        The capture force-renders a fresh frame synchronously before reading pixels,
+        so it always reflects the CURRENT camera/viewmode state — even when the editor
+        window is unfocused and its tick is throttled (the normal state while an agent
+        drives the editor; previously this returned a stale frame from before the
+        latest set_viewport_camera / console viewmode change).
+
         Args:
             output_path: Optional full path for the output file. If not provided,
                         saves to MCPGameProject/Saved/Screenshots/MCP/ with timestamp.


### PR DESCRIPTION
The capture read the LAST drawn frame (GetViewportScreenShot -> ReadPixels of the current render-target surface) without forcing a redraw. When the editor window is unfocused - the NORMAL state while an MCP agent drives the editor - the editor throttles non-realtime viewport redraws, so Invalidate()/RedrawLevelEditingViewports() (which set_viewport_camera already called, with a comment claiming it makes the next capture fresh) only QUEUE a redraw the throttled tick never performs. Result: several consecutive captures returned byte-identical stale PNGs despite successful set_viewport_camera / viewmode changes in between (caught live 2026-06-11 during SimPrototype cave-wall visual verification; HighResShot via console rendered the true state, confirming the camera state itself was correct).

Fix: FViewport::Draw(bShouldPresent=true) + FlushRenderingCommands() synchronously in the capture command, right before reading pixels - bypasses the editor-tick throttle entirely, so the capture always reflects the current camera state.

Testing: no automation test - the repro depends on the editor window focus/throttle state, which an in-editor automation run cannot control deterministically (a focused test session redraws normally and the bug never manifests). Verified live over MCP instead, in the unfocused-editor condition the fix targets: camera A (top-down) -> capture, camera B (ground horizon) -> capture; previously consecutive captures were byte-identical, now each shows its own camera state (hashes differ + visually confirmed on SimPrototype Lvl_TopDown).

Found during verification (separate, pre-existing): `viewmode unlit` / `viewmode wireframe` via execute_console_command never reach the editor viewport client at all (confirmed via HighResShot too, so not a staleness symptom) - logged as an Active issue in Docs/known-issues.md with a set_viewport_viewmode fix candidate.

Python docstring updated to document the fresh-frame guarantee.